### PR TITLE
feat: views runtime + capability graph (Phase 1)

### DIFF
--- a/.agents/skills/integration-javascript_node/SKILL.md
+++ b/.agents/skills/integration-javascript_node/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: integration-javascript_node
+description: PostHog integration for server-side Node.js applications using posthog-node
+metadata:
+  author: PostHog
+  version: 1.12.1
+---
+
+# PostHog integration for JavaScript Node
+
+This skill helps you add PostHog analytics to JavaScript Node applications.
+
+## Workflow
+
+Follow these steps in order to complete the integration:
+
+1. `basic-integration-1.0-begin.md` - PostHog Setup - Begin ← **Start here**
+2. `basic-integration-1.1-edit.md` - PostHog Setup - Edit
+3. `basic-integration-1.2-revise.md` - PostHog Setup - Revise
+4. `basic-integration-1.3-conclude.md` - PostHog Setup - Conclusion
+
+## Reference files
+
+- `references/node.md` - Node.js - docs
+- `references/posthog-node.md` - PostHog Node.js SDK
+- `references/identify-users.md` - Identify users - docs
+- `references/basic-integration-1.0-begin.md` - PostHog setup - begin
+- `references/basic-integration-1.1-edit.md` - PostHog setup - edit
+- `references/basic-integration-1.2-revise.md` - PostHog setup - revise
+- `references/basic-integration-1.3-conclude.md` - PostHog setup - conclusion
+
+The example project shows the target implementation pattern. Consult the documentation for API details.
+
+## Key principles
+
+- **Environment variables**: Always use environment variables for PostHog keys. Never hardcode them.
+- **Minimal changes**: Add PostHog code alongside existing integrations. Don't replace or restructure existing code.
+- **Match the example**: Your implementation should follow the example project's patterns as closely as possible.
+
+## Framework guidelines
+
+- posthog-node is the Node.js server-side SDK package name – do NOT use posthog-js on the server
+- Include enableExceptionAutocapture: true in the PostHog constructor options
+- Add posthog.capture() calls in route handlers for meaningful user actions – every route that creates, updates, or deletes data should track an event with contextual properties
+- Add posthog.captureException(err, distinctId) in the application's error handler (e.g., Express error middleware, Fastify setErrorHandler, Koa app.on('error'))
+- In long-running servers, the SDK batches events automatically – do NOT set flushAt or flushInterval unless you have a specific reason to
+- For short-lived processes (scripts, CLIs, serverless), set flushAt to 1 and flushInterval to 0 to send events immediately
+- Reverse proxy is NOT needed for server-side Node.js – only client-side JavaScript needs a proxy to avoid ad blockers
+- Remember that source code is available in the node_modules directory
+- Check package.json for type checking or build scripts to validate changes
+
+## Identifying users
+
+Identify users during login and signup events. Refer to the example code and documentation for the correct identify pattern for this framework. If both frontend and backend code exist, pass the client-side session and distinct ID using `X-POSTHOG-DISTINCT-ID` and `X-POSTHOG-SESSION-ID` headers to maintain correlation.
+
+## Error tracking
+
+Add PostHog error tracking to relevant files, particularly around critical user flows and API boundaries.

--- a/.agents/skills/integration-javascript_node/references/basic-integration-1.0-begin.md
+++ b/.agents/skills/integration-javascript_node/references/basic-integration-1.0-begin.md
@@ -1,0 +1,46 @@
+---
+title: PostHog Setup - Begin
+description: Start the event tracking setup process by analyzing the project and creating an event tracking plan
+---
+
+We're making an event tracking plan for this project.
+
+Before proceeding, find any existing `posthog.capture()` code. Make note of event name formatting.
+
+From the project's file list, select between 10 and 15 files that might have interesting business value for event tracking, especially conversion and churn events. Also look for additional files related to login that could be used for identifying users, along with error handling. Read the files. If a file is already well-covered by PostHog events, replace it with another option. Do not spawn subagents.
+
+Look for opportunities to track client-side events.
+
+**IMPORTANT: Server-side events are REQUIRED** if the project includes any instrumentable server-side code. If the project has API routes (e.g., `app/api/**/route.ts`) or Server Actions, you MUST include server-side events for critical business operations like:
+
+  - Payment/checkout completion
+  - Webhook handlers
+  - Authentication endpoints
+
+Do not skip server-side events - they capture actions that cannot be tracked client-side.
+
+Create a new file with a JSON array at the root of the project: .posthog-events.json. It should include one object for each event we want to add: event name, event description, and the file path we want to place the event in. If events already exist, don't duplicate them; supplement them.
+
+Track actions only, not pageviews. These can be captured automatically. Exceptions can be made for "viewed"-type events that correspond to the top of a conversion funnel.
+
+As you review files, make an internal note of opportunities to identify users and catch errors. We'll need them for the next step.
+
+## Status
+
+Before beginning a phase of the setup, you will send a status message with the exact prefix '[STATUS]', as in:
+
+[STATUS] Checking project structure.
+
+Status to report in this phase:
+
+- Checking project structure
+- Verifying PostHog dependencies
+- Generating events based on project
+
+## Abort statuses
+
+If and only if the instructions have `[ABORT]` states specified, and you clearly match the conditions for an abort, emit the abort message. Do NOT attempt to exit or halt yourself — the wizard's middleware catches `[ABORT]` and terminates the run for you.
+
+---
+
+**Upon completion, continue with:** [basic-integration-1.1-edit.md](basic-integration-1.1-edit.md)

--- a/.agents/skills/integration-javascript_node/references/basic-integration-1.1-edit.md
+++ b/.agents/skills/integration-javascript_node/references/basic-integration-1.1-edit.md
@@ -1,0 +1,37 @@
+---
+title: PostHog Setup - Edit
+description: Implement PostHog event tracking in the identified files, following best practices and the example project
+---
+
+For each of the files and events noted in .posthog-events.json, make edits to capture events using PostHog. Make sure to set up any helper files needed. Carefully examine the included example project code: your implementation should match it as closely as possible. Do not spawn subagents.
+
+Use environment variables for PostHog keys. Do not hardcode PostHog keys.
+
+If a file already has existing integration code for other tools or services, don't overwrite or remove that code. Place PostHog code below it.
+
+For each event, add useful properties, and use your access to the PostHog source code to ensure correctness. You also have access to documentation about creating new events with PostHog. Consider this documentation carefully and follow it closely before adding events. Your integration should be based on documented best practices. Carefully consider how the user project's framework version may impact the correct PostHog integration approach.
+
+Remember that you can find the source code for any dependency in the node_modules directory. This may be necessary to properly populate property names. There are also example project code files available via the PostHog MCP; use these for reference.
+
+Where possible, add calls for PostHog's identify() function on the client side upon events like logins and signups. Use the contents of login and signup forms to identify users on submit. If there is server-side code, pass the client-side session and distinct ID to the server-side code to identify the user. On the server side, make sure events have a matching distinct ID where relevant. 
+
+It's essential to do this in both client code and server code, so that user behavior from both domains is easy to correlate.
+
+You should also add PostHog exception capture error tracking to these files where relevant.
+
+Remember: Do not alter the fundamental architecture of existing files. Make your additions minimal and targeted.
+
+Remember the documentation and example project resources you were provided at the beginning. Read them now.
+
+## Status
+
+Status to report in this phase:
+
+- Inserting PostHog capture code
+- A status message for each file whose edits you are planning, including a high level summary of changes
+- A status message for each file you have edited
+
+
+---
+
+**Upon completion, continue with:** [basic-integration-1.2-revise.md](basic-integration-1.2-revise.md)

--- a/.agents/skills/integration-javascript_node/references/basic-integration-1.2-revise.md
+++ b/.agents/skills/integration-javascript_node/references/basic-integration-1.2-revise.md
@@ -1,0 +1,22 @@
+---
+title: PostHog Setup - Revise
+description: Review and fix any errors in the PostHog integration implementation
+---
+
+Check the project for errors. Read the package.json file for any type checking or build scripts that may provide input about what to fix. Remember that you can find the source code for any dependency in the node_modules directory. Do not spawn subagents.
+
+Ensure that any components created were actually used.
+
+Once all other tasks are complete, run any linter or prettier-like scripts found in the package.json, but ONLY on the files you have edited or created during this session. Do not run formatting or linting across the entire project's codebase.
+
+## Status
+
+Status to report in this phase:
+
+- Finding and correcting errors
+- Report details of any errors you fix
+- Linting, building and prettying
+
+---
+
+**Upon completion, continue with:** [basic-integration-1.3-conclude.md](basic-integration-1.3-conclude.md)

--- a/.agents/skills/integration-javascript_node/references/basic-integration-1.3-conclude.md
+++ b/.agents/skills/integration-javascript_node/references/basic-integration-1.3-conclude.md
@@ -1,0 +1,38 @@
+---
+title: PostHog Setup - Conclusion
+description: Review and fix any errors in the PostHog integration implementation
+---
+
+Use the PostHog MCP to create a new dashboard named "Analytics basics" based on the events created here. Make sure to use the exact same event names as implemented in the code. Populate it with up to five insights, with special emphasis on things like conversion funnels, churn events, and other business critical insights.  
+
+Search for a file called `.posthog-events.json` and read it for available events. Do not spawn subagents.
+
+Create the file posthog-setup-report.md. It should include a summary of the integration edits, a table with the event names, event descriptions, and files where events were added, along with a list of links for the dashboard and insights created. Follow this format:
+
+<wizard-report>
+# PostHog post-wizard report
+
+The wizard has completed a deep integration of your project. [Detailed summary of changes]
+
+[table of events/descriptions/files]
+
+## Next steps
+
+We've built some insights and a dashboard for you to keep an eye on user behavior, based on the events we just instrumented:
+
+[links]
+
+### Agent skill
+
+We've left an agent skill folder in your project. You can use this context for further agent development when using Claude Code. This will help ensure the model provides the most up-to-date approaches for integrating PostHog.
+
+</wizard-report>
+
+Upon completion, remove .posthog-events.json.
+
+## Status
+
+Status to report in this phase:
+
+- Configured dashboard: [insert PostHog dashboard URL]
+- Created setup report: [insert full local file path]

--- a/.agents/skills/integration-javascript_node/references/identify-users.md
+++ b/.agents/skills/integration-javascript_node/references/identify-users.md
@@ -1,0 +1,271 @@
+# Identify users - Docs
+
+Linking events to specific users enables you to build a full picture of how they're using your product across different sessions, devices, and platforms.
+
+This is straightforward to do when [capturing backend events](/docs/product-analytics/capture-events?tab=Node.js.md), as you associate events to a specific user using a `distinct_id`, which is a required argument.
+
+However, in the frontend of a [web](/docs/libraries/js/features.md#capturing-events) or [mobile app](/docs/libraries/ios.md#capturing-events), a `distinct_id` is not a required argument — PostHog's SDKs will generate an anonymous `distinct_id` for you automatically and you can capture events anonymously, provided you use the appropriate [configuration](/docs/libraries/js/features.md#capturing-anonymous-events).
+
+To link events to specific users, call `identify`:
+
+PostHog AI
+
+### Web
+
+```javascript
+posthog.identify(
+  'distinct_id',  // Replace 'distinct_id' with your user's unique identifier
+  { email: 'max@hedgehogmail.com', name: 'Max Hedgehog' } // optional: set additional person properties
+);
+```
+
+### Android
+
+```kotlin
+PostHog.identify(
+    distinctId = distinctID, // Replace 'distinctID' with your user's unique identifier
+    // optional: set additional person properties
+    userProperties = mapOf(
+        "name" to "Max Hedgehog",
+        "email" to "max@hedgehogmail.com"
+    )
+)
+```
+
+### iOS
+
+```swift
+PostHogSDK.shared.identify("distinct_id", // Replace "distinct_id" with your user's unique identifier
+                           userProperties: ["name": "Max Hedgehog", "email": "max@hedgehogmail.com"]) // optional: set additional person properties
+```
+
+### React Native
+
+```jsx
+posthog.identify('distinct_id', { // Replace "distinct_id" with your user's unique identifier
+    email: 'max@hedgehogmail.com', // optional: set additional person properties
+    name: 'Max Hedgehog'
+})
+```
+
+### Dart
+
+```dart
+await Posthog().identify(
+  userId: 'distinct_id', // Replace "distinct_id" with your user's unique identifier
+  userProperties: {
+    email: "max@hedgehogmail.com", // optional: set additional person properties
+    name: "Max Hedgehog"
+});
+```
+
+Events captured after calling `identify` are identified events and this creates a person profile if one doesn't exist already.
+
+Due to the cost of processing them, anonymous events can be up to 4x cheaper than identified events, so it's recommended you only capture identified events when needed.
+
+## How identify works
+
+When a user starts browsing your website or app, PostHog automatically assigns them an **anonymous ID**, which is stored locally.
+
+Provided you've [configured persistence](/docs/libraries/js/persistence.md) to use cookies or `localStorage`, this enables us to track anonymous users – even across different sessions.
+
+By calling `identify` with a `distinct_id` of your choice (usually the user's ID in your database, or their email), you link the anonymous ID and distinct ID together.
+
+Thus, all past and future events made with that anonymous ID are now associated with the distinct ID.
+
+This enables you to do things like associate events with a user from before they log in for the first time, or associate their events across different devices or platforms.
+
+Using identify in the backend
+
+Although you can call `identify` using our backend SDKs, it is used most in frontends. This is because there is no concept of anonymous sessions in the backend SDKs, so calling `identify` only updates person profiles.
+
+## Best practices when using `identify`
+
+### 1\. Call `identify` as soon as you're able to
+
+In your frontend, you should call `identify` as soon as you're able to.
+
+Typically, this is every time your **app loads** for the first time, and directly after your **users log in**.
+
+This ensures that events sent during your users' sessions are correctly associated with them.
+
+You only need to call `identify` once per session, and you should avoid calling it multiple times unnecessarily.
+
+If you call `identify` multiple times with the same data without reloading the page in between, PostHog will ignore the subsequent calls.
+
+### 2\. Use unique strings for distinct IDs
+
+If two users have the same distinct ID, their data is merged and they are considered one user in PostHog. Two common ways this can happen are:
+
+-   Your logic for generating IDs does not generate sufficiently strong IDs and you can end up with a clash where 2 users have the same ID.
+-   There's a bug, typo, or mistake in your code leading to most or all users being identified with generic IDs like `null`, `true`, or `distinctId`.
+
+PostHog also has built-in protections to stop the most common distinct ID mistakes.
+
+### 3\. Reset after logout
+
+If a user logs out on your frontend, you should call `reset()` to unlink any future events made on that device with that user.
+
+This is important if your users are sharing a computer, as otherwise all of those users are grouped together into a single user due to shared cookies between sessions.
+
+**We strongly recommend you call `reset` on logout even if you don't expect users to share a computer.**
+
+You can do that like so:
+
+PostHog AI
+
+### Web
+
+```javascript
+posthog.reset()
+```
+
+### iOS
+
+```swift
+PostHogSDK.shared.reset()
+```
+
+### Android
+
+```kotlin
+PostHog.reset()
+```
+
+### React Native
+
+```jsx
+posthog.reset()
+```
+
+### Dart
+
+```dart
+Posthog().reset()
+```
+
+If you *also* want to reset the `device_id` so that the device will be considered a new device in future events, you can pass `true` as an argument:
+
+Web
+
+PostHog AI
+
+```javascript
+posthog.reset(true)
+```
+
+### 4\. Person profiles and properties
+
+You'll notice that one of the parameters in the `identify` method is a `properties` object.
+
+This enables you to set [person properties](/docs/product-analytics/person-properties.md).
+
+Whenever possible, we recommend passing in all person properties you have available each time you call identify, as this ensures their person profile on PostHog is up to date.
+
+Person properties can also be set being adding a `$set` property to a event `capture` call.
+
+See our [person properties docs](/docs/product-analytics/person-properties.md) for more details on how to work with them and best practices.
+
+### 5\. Use deep links between platforms
+
+We recommend you call `identify` [as soon as you're able](#1-call-identify-as-soon-as-youre-able), typically when a user signs up or logs in.
+
+This doesn't work if one or both platforms are unauthenticated. Some examples of such cases are:
+
+-   Onboarding and signup flows before authentication.
+-   Unauthenticated web pages redirecting to authenticated mobile apps.
+-   Authenticated web apps prompting an app download.
+
+In these cases, you can use a [deep link](https://developer.android.com/training/app-links/deep-linking) on Android and [universal links](https://developer.apple.com/documentation/xcode/supporting-universal-links-in-your-app) on iOS to identify users.
+
+1.  Use `posthog.get_distinct_id()` to get the current distinct ID. Even if you cannot call identify because the user is unauthenticated, this will return an anonymous distinct ID generated by PostHog.
+2.  Add the distinct ID to the deep link as query parameters, along with other properties like UTM parameters.
+3.  When the user is redirected to the app, parse the deep link and handle the following cases:
+
+-   The mobile app is already authenticated. In this case, call [`posthog.alias()`](/docs/libraries/js/features.md#alias) with the distinct ID from the web. This associates the two distinct IDs as a single person.
+-   The mobile app is unauthenticated. In this case, call [`posthog.identify()`](/docs/libraries/js/features.md#identifying-users) with the distinct ID from the web so pre-login mobile events stay connected to the web session. When the user later logs in on mobile, call `identify()` again with your canonical user ID.
+
+As long as you associate the distinct IDs with `posthog.identify()` or `posthog.alias()`, you can track events generated across platforms.
+
+Here's an example implementation for handling deep links from web to mobile:
+
+PostHog AI
+
+### iOS
+
+```swift
+import PostHog
+class DeepLinkIdentityManager {
+    static let shared = DeepLinkIdentityManager()
+    // MARK: - Deep Link Received
+    func handleDeepLink(_ url: URL, isAuthenticatedOnMobile: Bool) {
+        guard let webDistinctId = URLComponents(url: url, resolvingAgainstBaseURL: true)?
+            .queryItems?.first(where: { $0.name == "ph_distinct_id" })?.value else {
+            return
+        }
+        if isAuthenticatedOnMobile {
+            // The mobile app already knows the current user.
+            // Alias the incoming web distinct ID to that user.
+            PostHogSDK.shared.alias(webDistinctId)
+        } else {
+            // Reuse the web distinct ID until login on mobile.
+            PostHogSDK.shared.identify(webDistinctId)
+        }
+    }
+    // MARK: - Login/Signup
+    func handleLogin(canonicalUserId: String) {
+        // Switch from the web distinct ID (or a mobile anon ID)
+        // to your canonical user ID.
+        PostHogSDK.shared.identify(canonicalUserId)
+        // Set user properties, track signup event, etc.
+    }
+    func handleLogout() {
+        PostHogSDK.shared.reset()
+    }
+}
+```
+
+### Android
+
+```kotlin
+import android.net.Uri
+import com.posthog.PostHog
+object DeepLinkIdentityManager {
+    // Deep Link Received
+    fun handleDeepLink(uri: Uri, isAuthenticatedOnMobile: Boolean) {
+        val webDistinctId = uri.getQueryParameter("ph_distinct_id") ?: return
+        if (isAuthenticatedOnMobile) {
+            // The mobile app already knows the current user.
+            // Alias the incoming web distinct ID to that user.
+            PostHog.alias(webDistinctId)
+        } else {
+            // Reuse the web distinct ID until login on mobile.
+            PostHog.identify(webDistinctId)
+        }
+    }
+    // Login/Signup
+    fun handleLogin(canonicalUserId: String) {
+        // Switch from the web distinct ID (or a mobile anon ID)
+        // to your canonical user ID.
+        PostHog.identify(canonicalUserId)
+        // Set user properties, track signup event, etc.
+    }
+    fun handleLogout() {
+        PostHog.reset()
+    }
+}
+```
+
+## Further reading
+
+-   [Identifying users docs](/docs/product-analytics/identify.md)
+-   [How person processing works](/docs/how-posthog-works/ingestion-pipeline.md#2-person-processing)
+-   [An introductory guide to identifying users in PostHog](/tutorials/identifying-users-guide.md)
+
+### Community questions
+
+Ask a question
+
+### Was this page useful?
+
+HelpfulCould be better

--- a/.agents/skills/integration-javascript_node/references/node.md
+++ b/.agents/skills/integration-javascript_node/references/node.md
@@ -1,0 +1,891 @@
+# Node.js - Docs
+
+If you're working with Node.js (versions 20+), the official `posthog-node` library is the simplest way to integrate your software with PostHog. This library uses an internal queue to make calls fast and non-blocking. It also batches requests and flushes asynchronously, making it perfect to use in any part of your web app or other server-side application that needs performance. And in addition to event capture, [feature flags](/docs/feature-flags.md) are supported as well.
+
+## Installation
+
+Run either `npm` or `yarn` in terminal to add it to your project:
+
+PostHog AI
+
+### npm
+
+```bash
+npm install posthog-node --save
+```
+
+### Yarn
+
+```bash
+yarn add posthog-node
+```
+
+### pnpm
+
+```bash
+pnpm add posthog-node
+```
+
+### Bun
+
+```bash
+bun add posthog-node
+```
+
+In your app, set your project token **before** making any calls.
+
+Node.js
+
+PostHog AI
+
+```javascript
+import { PostHog } from 'posthog-node'
+const client = new PostHog(
+    '<ph_project_token>',
+    { host: 'https://us.i.posthog.com' }
+)
+await client.shutdown()
+```
+
+You can find your project token and instance address in the [project settings](https://app.posthog.com/project/settings) page in PostHog.
+
+> **Note:** As a rule of thumb, we do not recommend hardcoding API keys or tokens. Setting it as an environment variable is preferred.
+
+## Identifying users
+
+> **Identifying users is required.** Backend events need a `distinct_id` that matches the ID your frontend uses when calling `posthog.identify()`. Without this, backend events are orphaned — they can't be linked to frontend event captures, [session replays](/docs/session-replay.md), [LLM traces](/docs/ai-engineering.md), or [error tracking](/docs/error-tracking.md).
+>
+> See our guide on [identifying users](/docs/getting-started/identify-users.md) for how to set this up.
+
+### Options
+
+| Variable | Description | Default value |
+| --- | --- | --- |
+| host | Your PostHog host | https://us.i.posthog.com/ |
+| flushAt | After how many capture calls we should flush the queue (in one batch) | 20 |
+| flushInterval | After how many ms we should flush the queue | 10000 |
+| personalApiKey | An optional [personal API key](/docs/api/overview.md#personal-api-keys-recommended) for evaluating feature flags locally. Note: Providing this will trigger periodic calls to the feature flags service, even if you're not using feature flags. | null |
+| featureFlagsPollingInterval | Interval in milliseconds specifying how often feature flags should be fetched from the PostHog API | 300000 |
+| requestTimeout | Timeout in milliseconds for any calls | 10000 |
+| maxCacheSize | Maximum size of cache that deduplicates $feature_flag_called calls per user. | 50000 |
+| disableGeoip | When true, disables automatic GeoIP resolution for events and feature flags. | true |
+| evaluation_contexts | Evaluation context tags that constrain which feature flags are evaluated. When set, only flags with matching evaluation context tags (or no evaluation context tags) will be returned. This helps reduce unnecessary flag evaluations and improves performance. See [evaluation contexts documentation](/docs/feature-flags/evaluation-contexts.md) for more details. Available in version 5.10.0+. The legacy parameter evaluation_environments (version 5.9.6+) is also supported for backward compatibility. | undefined |
+
+> **Note:** When using PostHog in an AWS Lambda function or a similar serverless function environment, make sure you set `flushAt` to `1` and `flushInterval` to `0`. Also, remember to always call `await posthog.shutdown()` at the end to flush and send all pending events.
+
+## Capturing events
+
+You can send custom events using `capture`:
+
+Node.js
+
+PostHog AI
+
+```javascript
+client.capture({
+    distinctId: 'distinct_id_of_the_user',
+    event: 'user signed up',
+})
+```
+
+> **Tip:** We recommend using a `[object] [verb]` format for your event names, where `[object]` is the entity that the behavior relates to, and `[verb]` is the behavior itself. For example, `project created`, `user signed up`, or `invite sent`.
+
+### Setting event properties
+
+Optionally, you can include additional information with the event by including a [properties](/docs/data/events.md#event-properties) object:
+
+Node.js
+
+PostHog AI
+
+```javascript
+client.capture({
+  distinctId: 'distinct_id_of_the_user',
+  event: 'user signed up',
+  properties: {
+    login_type: 'email',
+    is_free_trial: true,
+  },
+})
+```
+
+### Capturing pageviews
+
+If you're aiming for a backend-only implementation of PostHog and won't be capturing events from your frontend, you can send `$pageview` events from your backend like so:
+
+Node.js
+
+PostHog AI
+
+```javascript
+client.capture({
+  distinctId: 'distinct_id_of_the_user',
+  event: '$pageview',
+  properties: {
+    $current_url: 'https://example.com',
+  },
+})
+```
+
+## Person profiles and properties
+
+The Node SDK captures identified events by default. These create [person profiles](/docs/data/persons.md). To set [person properties](/docs/data/user-properties.md) in these profiles, include them when capturing an event using `$set` and `$set_once`:
+
+Node.js
+
+PostHog AI
+
+```javascript
+client.capture({
+  distinctId: 'distinct_id_of_the_user',
+  event: 'movie_played',
+  properties: {
+    $set: { name: 'Max Hedgehog'  },
+    $set_once: { initial_url: '/blog' },
+  },
+})
+```
+
+For more details on the difference between `$set` and `$set_once`, see our [person properties docs](/docs/data/user-properties.md#what-is-the-difference-between-set-and-set_once).
+
+To capture [anonymous events](/docs/data/anonymous-vs-identified-events.md) without person profiles, set the event's `$process_person_profile` property to `false`:
+
+Node.js
+
+PostHog AI
+
+```javascript
+client.capture({
+  distinctId: 'distinct_id_of_the_user',
+  event: 'movie_played',
+  properties: {
+    $process_person_profile: false,
+  },
+})
+```
+
+## Alias
+
+Sometimes, you want to assign multiple distinct IDs to a single user. This is helpful when your primary distinct ID is inaccessible. For example, if a distinct ID used on the frontend is not available in your backend.
+
+In this case, you can use `alias` to assign another distinct ID to the same user.
+
+Node.js
+
+PostHog AI
+
+```javascript
+client.alias({
+  distinctId: 'distinct_id',
+  alias: 'alias_id',
+})
+```
+
+We strongly recommend reading our docs on [alias](/docs/data/identify.md#alias-assigning-multiple-distinct-ids-to-the-same-user) to best understand how to correctly use this method.
+
+## Super properties
+
+> Requires `posthog-node` version >= 5.25.0.
+
+Super properties are properties that are automatically included with every event captured by the client. Use `register` to set them:
+
+Node.js
+
+PostHog AI
+
+```javascript
+client.register({
+  app_version: '1.2.0',
+  environment: 'production',
+})
+// Both events include app_version and environment
+client.capture({
+  distinctId: 'distinct_id',
+  event: 'page_viewed',
+})
+client.capture({
+  distinctId: 'distinct_id',
+  event: 'button_clicked',
+})
+```
+
+If an event sets a property with the same key as a super property, the event's property takes precedence:
+
+Node.js
+
+PostHog AI
+
+```javascript
+client.register({ environment: 'production' })
+// This event is captured with environment='staging'
+client.capture({
+  distinctId: 'distinct_id',
+  event: 'page_viewed',
+  properties: { environment: 'staging' },
+})
+```
+
+To remove a super property, use `unregister`:
+
+Node.js
+
+PostHog AI
+
+```javascript
+client.unregister('environment')
+```
+
+Super properties are **global** — they apply to every event for the lifetime of the client instance. For properties that should only apply to a specific scope (e.g. a single request or transaction), use [contexts](#contexts) instead.
+
+## Contexts
+
+> Requires `posthog-node` version >= 5.17.0.
+
+The Node SDK uses nested contexts for managing state that's shared across events. Contexts are useful for adding properties to multiple events (including exceptions) during a single user's interaction with your product.
+
+You can enter a context using `withContext`:
+
+Node.js
+
+PostHog AI
+
+```javascript
+posthog.withContext(
+  {
+    distinctId: 'user-123',
+    properties: { transactionId: 'abc123' }
+  },
+  () => {
+    // This event is captured with the distinct ID and properties set above
+    posthog.capture({ event: 'order_processed' })
+  }
+)
+```
+
+Contexts are persisted across function calls. If you enter one and then call a function and capture an event in the called function, it uses the context properties set in the parent context:
+
+Node.js
+
+PostHog AI
+
+```javascript
+function someFunction() {
+  // When called from `outerFunction`, this event is captured
+  // with transactionId='abc123'
+  posthog.capture({ event: 'order_processed' })
+}
+function outerFunction() {
+  posthog.withContext(
+    { properties: { transactionId: 'abc123' } },
+    () => {
+      someFunction()
+    }
+  )
+}
+```
+
+By default, each context inherits from parent contexts. To disable nesting (where child contexts is fresh and has no properties), pass `{ fresh: true }`:
+
+Node.js
+
+PostHog AI
+
+```javascript
+posthog.withContext(
+  {
+    properties: {
+      someKey: 'value-1',
+      someOtherKey: 'another-value'
+    }
+  },
+  () => {
+    posthog.withContext(
+      { properties: { someKey: 'value-2' } },
+      () => {
+        // Captured with someKey='value-2', someOtherKey='another-value'
+        posthog.capture({ event: 'order_processed' })
+      },
+    )
+    // Captured with someKey='value-1', someOtherKey='another-value'
+    posthog.capture({ event: 'order_completed' })
+  }
+)
+```
+
+> **Note:** Properties passed directly to `capture` calls override context state in the final event.
+
+### Identification context
+
+Contexts can be associated with a distinct ID:
+
+Node.js
+
+PostHog AI
+
+```javascript
+posthog.withContext(
+  { distinctId: 'user-123' },
+  () => {
+    // Associated with "user-123"
+    posthog.capture({ event: 'order_processed' })
+    // Overrides to "another-user"
+    posthog.capture({
+      distinctId: 'another-user',
+      event: 'order_processed'
+    })
+  }
+)
+```
+
+### Session context
+
+Node.js
+
+PostHog AI
+
+```javascript
+posthog.withContext(
+  { sessionId: 'some-session' },
+  () => {
+    // Associated with session "some-session"
+    posthog.capture({ event: 'image_uploaded' })
+    // Overrides to "next-session"
+    posthog.capture({
+      event: 'image_uploaded',
+      properties: { $sessionId: 'next-session' }
+    })
+  }
+)
+```
+
+### Custom context parameters
+
+Node.js
+
+PostHog AI
+
+```javascript
+posthog.withContext(
+  { flightNumber: 'TAC313' },
+  () => {
+    // Associated with flightNumber TAC313
+    posthog.capture({ event: 'flight_cancelled' })
+    // Overrides to PL7714
+    posthog.capture({
+      event: 'flight_cancelled',
+      properties: { flightNumber: 'PL7714' }
+    })
+  }
+)
+```
+
+## Feature flags
+
+PostHog's [feature flags](/docs/feature-flags.md) enable you to safely deploy and roll back new features as well as target specific users and groups with them.
+
+There are 2 steps to implement feature flags in Node:
+
+### Step 1: Evaluate the feature flag value
+
+#### Boolean feature flags
+
+Node.js
+
+PostHog AI
+
+```javascript
+const isFeatureFlagEnabled = await client.isFeatureEnabled('flag-key', 'distinct_id_of_your_user')
+if (isFeatureFlagEnabled) {
+    // Your code if the flag is enabled
+    // Optional: fetch the payload
+    const matchedFlagPayload = await client.getFeatureFlagPayload('flag-key', 'distinct_id_of_your_user', isFeatureFlagEnabled)
+}
+```
+
+#### Multivariate feature flags
+
+Node.js
+
+PostHog AI
+
+```javascript
+const enabledVariant = await client.getFeatureFlag('flag-key', 'distinct_id_of_your_user')
+if (enabledVariant === 'variant-key') {  // replace 'variant-key' with the key of your variant
+    // Do something differently for this user
+    // Optional: fetch the payload
+    const matchedFlagPayload = await client.getFeatureFlagPayload('flag-key', 'distinct_id_of_your_user', enabledVariant)
+}
+```
+
+### Step 2: Include feature flag information when capturing events
+
+If you want use your feature flag to breakdown or filter events in your [insights](/docs/product-analytics/insights.md), you'll need to include feature flag information in those events. This ensures that the feature flag value is attributed correctly to the event.
+
+> **Note:** This step is only required for events captured using our server-side SDKs or [API](/docs/api.md).
+
+There are two methods you can use to include feature flag information in your events:
+
+#### Method 1: Include the `$feature/feature_flag_name` property
+
+In the event properties, include `$feature/feature_flag_name: variant_key`:
+
+Node.js
+
+PostHog AI
+
+```javascript
+client.capture({
+    distinctId: 'distinct_id_of_your_user',
+    event: 'event_name',
+    properties: {
+        '$feature/feature-flag-key': 'variant-key' // replace feature-flag-key with your flag key. Replace 'variant-key' with the key of your variant
+    },
+})
+```
+
+#### Method 2: Set `sendFeatureFlags` to `true`
+
+The `capture()` method has an optional argument `sendFeatureFlags`, which is set to `false` by default. This parameter controls whether feature flag information is sent with the event.
+
+#### Basic usage
+
+Setting `sendFeatureFlags` to `true` will include feature flag information with the event:
+
+Node.js
+
+PostHog AI
+
+```javascript
+client.capture({
+    distinctId: 'distinct_id_of_your_user',
+    event: 'event_name',
+    sendFeatureFlags: true,
+})
+```
+
+#### Advanced usage (v5.5.0+)
+
+As of version 5.5.0, `sendFeatureFlags` can also accept an options object for more granular control:
+
+Node.js
+
+PostHog AI
+
+```javascript
+client.capture({
+    distinctId: 'distinct_id_of_your_user',
+    event: 'event_name',
+    sendFeatureFlags: {
+        onlyEvaluateLocally: true,
+        personProperties: { plan: 'premium' },
+        groupProperties: { org: { tier: 'enterprise' } }
+    }
+})
+```
+
+#### Performance considerations
+
+-   **With local evaluation**: When [local evaluation](/docs/feature-flags/local-evaluation.md) is configured, setting `sendFeatureFlags: true` will **not** make additional server requests. Instead, it uses the locally cached feature flags, and it provides an interface for including person and/or group properties needed to evaluate the flags in the context of the event, if required.
+
+-   **Without local evaluation**: PostHog will make an additional request to fetch feature flag information before capturing the event, which adds delay.
+
+#### Breaking change in v5.5.0
+
+Prior to version 5.5.0, feature flags were automatically sent with events when using local evaluation, even when `sendFeatureFlags` was not explicitly set. This behavior has been **removed** in v5.5.0 to be more predictable and explicit.
+
+If you were relying on this automatic behavior, you must now explicitly set `sendFeatureFlags: true` to continue sending feature flags with your events.
+
+### Fetching all flags for a user
+
+You can fetch all flag values for a single user by calling `getAllFlags()` or `getAllFlagsAndPayloads()`.
+
+This is useful when you need to fetch multiple flag values and don't want to make multiple requests.
+
+Node.js
+
+PostHog AI
+
+```javascript
+await client.getAllFlags('distinct_id_of_your_user')
+await client.getAllFlagsAndPayloads('distinct_id_of_your_user')
+```
+
+### Sending `$feature_flag_called` events
+
+Capturing `$feature_flag_called` events enable PostHog to know when a flag was accessed by a user and thus provide [analytics and insights](/docs/product-analytics/insights.md) on the flag. By default, we send a these event when:
+
+1.  You call `posthog.getFeatureFlag()` or `posthog.isFeatureEnabled()`, AND
+2.  It's a new user, or the value of the flag has changed.
+
+> *Note:* Tracking whether it's a new user or if a flag value has changed happens in a local cache. This means that if you reinitialize the PostHog client, the cache resets as well – causing `$feature_flag_called` events to be sent again when calling `getFeatureFlag` or `isFeatureEnabled`. PostHog is built to handle this, and so duplicate `$feature_flag_called` events won't affect your analytics.
+
+You can disable automatically capturing `$feature_flag_called` events. For example, when you don't need the analytics, or it's being called at such a high volume that sending events slows things down.
+
+To disable it, set the `sendFeatureFlagEvents` argument in your function call, like so:
+
+Node.js
+
+PostHog AI
+
+```javascript
+const isFeatureFlagEnabled = await client.isFeatureEnabled(
+    'flag-key',
+    'distinct_id_of_your_user',
+    {
+        'sendFeatureFlagEvents': false
+    })
+```
+
+### Advanced: Overriding server properties
+
+Sometimes, you may want to evaluate feature flags using [person properties](/docs/product-analytics/person-properties.md), [groups](/docs/product-analytics/group-analytics.md), or group properties that haven't been ingested yet, or were set incorrectly earlier.
+
+You can provide properties to evaluate the flag with by using the `person properties`, `groups`, and `group properties` arguments. PostHog will then use these values to evaluate the flag, instead of any properties currently stored on your PostHog server.
+
+For example:
+
+Node.js
+
+PostHog AI
+
+```javascript
+await client.getFeatureFlag(
+    'flag-key',
+    'distinct_id_of_the_user',
+    {
+        personProperties: {
+            'property_name': 'value'
+        },
+        groups: {
+            "your_group_type": "your_group_id",
+            "another_group_type": "your_group_id",
+        },
+        groupProperties: {
+            'your_group_type': {
+                'group_property_name': 'value'
+            },
+            'another_group_type': {
+                'group_property_name': 'value'
+            }
+        },
+    }
+)
+```
+
+### Overriding GeoIP properties
+
+By default, a user's GeoIP properties are set using the IP address they use to capture events on the frontend. You may want to override the these properties when evaluating feature flags. A common reason to do this is when you're not using PostHog on your frontend, so the user has no GeoIP properties.
+
+You can override GeoIP properties by including them in the `person_properties` parameter when evaluating feature flags. This is useful when you're evaluating flags on your backend and want to use the client's location instead of your server's location.
+
+The following GeoIP properties can be overridden:
+
+-   `$geoip_country_code`
+-   `$geoip_country_name`
+-   `$geoip_city_name`
+-   `$geoip_city_confidence`
+-   `$geoip_continent_code`
+-   `$geoip_continent_name`
+-   `$geoip_latitude`
+-   `$geoip_longitude`
+-   `$geoip_postal_code`
+-   `$geoip_subdivision_1_code`
+-   `$geoip_subdivision_1_name`
+-   `$geoip_subdivision_2_code`
+-   `$geoip_subdivision_2_name`
+-   `$geoip_subdivision_3_code`
+-   `$geoip_subdivision_3_name`
+-   `$geoip_time_zone`
+
+Simply include any of these properties in the `person_properties` parameter alongside your other person properties when calling feature flags.
+
+### Request timeout
+
+You can configure the `feature_flag_request_timeout_ms` parameter when initializing your PostHog client to set a flag request timeout. This helps prevent your code from being blocked in the case when PostHog's servers are too slow to respond. By default, this is set at 3 seconds.
+
+JavaScript
+
+PostHog AI
+
+```javascript
+const client = new PostHog('<ph_project_token>', {
+        api_host: 'https://us.i.posthog.com',
+        feature_flag_request_timeout_ms: 3000 // Time in milliseconds. Default is 3000 (3 seconds).
+    }
+)
+```
+
+### Error handling
+
+When using the PostHog SDK, it's important to handle potential errors that may occur during feature flag operations. Here's an example of how to wrap PostHog SDK methods in an error handler:
+
+JavaScript
+
+PostHog AI
+
+```javascript
+async function handleFeatureFlag(client, flagKey, distinctId) {
+    try {
+        const isEnabled = await client.isFeatureEnabled(flagKey, distinctId);
+        console.log(`Feature flag '${flagKey}' for user '${distinctId}' is ${isEnabled ? 'enabled' : 'disabled'}`);
+        return isEnabled;
+    } catch (error) {
+        console.error(`Error fetching feature flag '${flagKey}': ${error.message}`);
+        // Optionally, you can return a default value or throw the error
+        // return false; // Default to disabled
+        throw error;
+    }
+}
+// Usage example
+try {
+    const flagEnabled = await handleFeatureFlag(client, 'new-feature', 'user-123');
+    if (flagEnabled) {
+        // Implement new feature logic
+    } else {
+        // Implement old feature logic
+    }
+} catch (error) {
+    // Handle the error at a higher level
+    console.error('Feature flag check failed, using default behavior');
+    // Implement fallback logic
+}
+```
+
+> **Note:** For remote config flags, see the [remote config documentation](/docs/feature-flags/remote-config.md). Remote config requires the [Feature Flags secure API key](/docs/feature-flags/remote-config.md#step-1-find-your-feature-flags-secure-api-key) passed as the `personalApiKey` option.
+
+### Local evaluation
+
+Evaluating feature flags requires making a request to PostHog for each flag. However, you can improve performance by evaluating flags locally. Instead of making a request for each flag, PostHog will periodically request and store feature flag definitions locally, enabling you to evaluate flags without making additional requests.
+
+It is best practice to use local evaluation flags when possible, since this enables you to resolve flags faster and with fewer API calls.
+
+For details on how to implement local evaluation, see our [local evaluation guide](/docs/feature-flags/local-evaluation.md).
+
+Node.js
+
+PostHog AI
+
+```javascript
+const flagValue = await client.getFeatureFlag('flag-key', 'user distinct id', {groups:{'organization': 'google'}, groupProperties:{'organization': {'is_authorized': True}})
+```
+
+#### Reloading feature flags
+
+When initializing PostHog, you can configure the interval at which feature flags are polled (fetched from the server). However, if you need to force a reload, you can use `reloadFeatureFlags`:
+
+Node.js
+
+PostHog AI
+
+```javascript
+await client.reloadFeatureFlags()
+// Do something with feature flags here
+```
+
+#### Distributed environments
+
+In multi-worker or edge environments, you can implement custom caching for flag definitions using Redis, Cloudflare KV, or other storage backends. This enables sharing definitions across workers and coordinating fetches. See our guide for [local evaluation in distributed environments](/docs/feature-flags/local-evaluation/distributed-environments?tab=Node.js.md) for details.
+
+## Experiments (A/B tests)
+
+Since [experiments](/docs/experiments/manual.md) use feature flags, the code for running an experiment is very similar to the feature flags code:
+
+Node.js
+
+PostHog AI
+
+```javascript
+const variant = await client.getFeatureFlag('experiment-feature-flag-key', 'user_distinct_id')
+if (variant === 'variant-name') {
+  // do something
+}
+```
+
+It's also possible to [run experiments without using feature flags](/docs/experiments/running-experiments-without-feature-flags.md).
+
+## Group analytics
+
+Group analytics enable you to associate an event with a group (e.g. teams, organizations, etc.). Read the [group analytics guide](/docs/product-analytics/group-analytics.md) for more information.
+
+To create a group or update its properties, use `groupIdentify`:
+
+Node.js
+
+PostHog AI
+
+```javascript
+client.groupIdentify({
+  groupType: 'company',
+  groupKey: 'company_id_in_your_db',
+  properties: {
+    name: 'Awesome Inc',
+    employees: 11,
+  },
+  // optional distinct ID to associate event with an existing person
+  distinctId: 'xyz'
+})
+```
+
+`name` is a special property which is used in the PostHog UI for the name of the group. If you don't specify a `name` property, the group ID is used instead.
+
+If the optional `distinctId` parameter is not provided in the group identify call, it defaults to `${groupType}_${groupKey}` (e.g., `$company_company_id_in_your_db` in the example above). This default behavior results in each group appearing as a separate person in PostHog. To avoid this, it's often more practical to use a consistent `distinctId`, such as `group_identifier`.
+
+Once a group is created, you can use the `capture` method and pass in the `groups` parameter to capture an event with group analytics.
+
+Node.js
+
+PostHog AI
+
+```javascript
+client.capture({
+  event: 'some_event',
+  distinctId: 'user_distinct_id',
+  groups: { company: 'company_id_in_your_db' },
+})
+```
+
+## GeoIP properties
+
+Before `posthog-node` v3.0, we added GeoIP properties to all incoming events by default. We also used these properties for feature flag evaluation, based on the IP address of the request. This isn't ideal since they are created based on your server IP address, rather than the user's, leading to incorrect location resolution.
+
+As of `posthog-node` v3.0, the default now is to disregard the server IP, not add the GeoIP properties, and not use the values for feature flag evaluations.
+
+You can go back to previous behavior by setting `disableGeoip` to false in your initialization:
+
+Node.js
+
+PostHog AI
+
+```javascript
+const posthog = new PostHog('<ph_project_token>', {
+  host: 'https://us.i.posthog.com',
+  disableGeoip: false
+})
+```
+
+The list of properties that this overrides:
+
+1.  `$geoip_city_name`
+2.  `$geoip_country_name`
+3.  `$geoip_country_code`
+4.  `$geoip_continent_name`
+5.  `$geoip_continent_code`
+6.  `$geoip_postal_code`
+7.  `$geoip_time_zone`
+
+You can also explicitly chose to enable or disable GeoIP for a single capture request like so:
+
+Node.js
+
+PostHog AI
+
+```javascript
+client.capture({
+  distinctId: distinctId,
+  event: 'your_event',
+  disableGeoip: `true`,
+})
+```
+
+## Shutdown
+
+You should call `shutdown` on your program's exit to exit cleanly:
+
+Node.js
+
+PostHog AI
+
+```javascript
+// Stop pending pollers and flush any remaining events
+await client.shutdown()
+```
+
+## Debug mode
+
+If you're not seeing the expected events being captured, the feature flags being evaluated, or the surveys being shown, you can enable debug mode to see what's happening.
+
+You can enable debug mode by calling the `debug()` method in your code. This will enable verbose logs about the inner workings of the SDK.
+
+Node.js
+
+PostHog AI
+
+```javascript
+client.debug()
+```
+
+## Handling errors thrown by the SDK
+
+If you are experiencing issues with the SDK it could be a number of things from an incorrectly configured API key, to some other network related issues.
+
+The SDK does not throw errors for things happening in the background to ensure it doesn't affect your process. You can however hook into the errors to get more information:
+
+Node.js
+
+PostHog AI
+
+```javascript
+client.on("error", (err) => {
+  // Whatever handling you want
+  console.error("PostHog had an error!", err)
+})
+```
+
+## Short-lived processes like serverless environments
+
+The Node SDK is designed to queue and batch requests in the background to optimize API calls and network time. As serverless environments like AWS Lambda or [Vercel Functions](/docs/libraries/vercel.md) are short-lived, we provide a few options to ensure all events are captured.
+
+First, we recommend using the `captureImmediate` method instead of `capture` to ensure the event is captured before the function shuts down. It guarantees the HTTP request finishes before your function continues (or shuts down).
+
+Second, we recommend setting `flushAt` to `1` and `flushInterval` to `0` to ensure the events are sent immediately. These set the queue to flush immediately, both in terms of events and time.
+
+Third, we provide a method `shutdown()` which can be awaited to ensure all queued events are sent to the API. For example:
+
+Node.js
+
+PostHog AI
+
+```javascript
+export const handler() {
+  client.capture({
+    distinctId: 'distinct_id_of_the_user',
+    event: 'thing_happened'
+  })
+  client.capture({
+    distinctId: 'distinct_id_of_the_user',
+    event: 'other_thing_happened'
+  })
+  // So far 2 events are queued but not sent
+  // Calling shutdown, flushed the queue but batched into 1 API call for maximum efficiency
+  await client.shutdown()
+}
+```
+
+This is also useful for shutting down a standard Node.js app.
+
+## LLM analytics
+
+You can capture LLM usage and performance data by combining the `posthog-node` and `@posthog/ai` libraries. These work with LLM providers like OpenAI and Vercel's AI SDKs. Learn more in our [LLM analytics docs](/docs/llm-analytics.md).
+
+## Error tracking
+
+You can capture errors using the `posthog-node` library. This enables you to see stack traces, source code, and watch associated session recordings to improve your application stability. Learn more in our [error tracking docs](/docs/error-tracking/installation/node.md).
+
+## Upgrading from V1 to V2
+
+V2.x.x of the Node.js library is completely rewritten in Typescript and is based on a new JS core shared with other JavaScript based libraries with the goal of ensuring new features and fixes reach the different libraries at the same pace.
+
+With the release of V2, the API was kept mostly the same but with some small changes and deprecations:
+
+1.  The minimum PostHog version requirement is 1.38
+2.  The `callback` parameter passed as an optional last argument to most of the methods is no longer supported
+3.  The method signature for `isFeatureEnabled` and `getFeatureFlag` is slightly modified. See the above documentation for each method for more details.
+4.  For specific changes, [see the CHANGELOG](https://github.com/PostHog/posthog-js/blob/main/packages/node/CHANGELOG.md)
+
+### Community questions
+
+Ask a question
+
+### Was this page useful?
+
+HelpfulCould be better

--- a/.agents/skills/integration-javascript_node/references/posthog-node.md
+++ b/.agents/skills/integration-javascript_node/references/posthog-node.md
@@ -1,0 +1,1379 @@
+# PostHog Node.js SDK
+
+**SDK Version:** 5.29.2
+
+PostHog Node.js SDK allows you to capture events and send them to PostHog from your Node.js applications.
+
+## Categories
+
+- Initialization
+- Identification
+- Capture
+- Error tracking
+- Privacy
+- Feature flags
+- Context
+
+## PostHog
+
+### Other methods
+
+#### getLibraryId()
+
+**Release Tag:** public
+
+### Returns
+
+- `string`
+
+### Examples
+
+```node
+// Generated example for getLibraryId
+posthog.getLibraryId();
+```
+
+---
+
+#### enterContext()
+
+**Release Tag:** public
+
+Set context without a callback wrapper.
+Uses `AsyncLocalStorage.enterWith()` to attach context to the current async execution context. The context lives until that async context ends.
+Must be called in the same async scope that makes PostHog calls. Calling this outside a request-scoped async context will leak context across unrelated work. Prefer `withContext()` when you can wrap code in a callback — it creates an isolated scope that cleans up automatically.
+
+### Parameters
+
+- **`data`** (`Partial<ContextData>`) - Context data to apply (distinctId, sessionId, properties)
+- **`options?`** (`ContextOptions`) - Context options (fresh: true to start with clean context instead of inheriting)
+
+### Returns
+
+- `void`
+
+### Examples
+
+```node
+// Generated example for enterContext
+posthog.enterContext();
+```
+
+---
+
+#### flush()
+
+**Release Tag:** public
+
+### Returns
+
+- `Promise<void>`
+
+### Examples
+
+```node
+// Generated example for flush
+posthog.flush();
+```
+
+---
+
+#### prepareEventMessage()
+
+**Release Tag:** public
+
+### Parameters
+
+- **`props`** (`EventMessage`)
+
+### Returns
+
+- `Promise<{
+        distinctId: string;
+        event: string;
+        properties: PostHogEventProperties;
+        options: PostHogCaptureOptions;
+    }>`
+
+### Examples
+
+```node
+// Generated example for prepareEventMessage
+posthog.prepareEventMessage();
+```
+
+---
+
+#### fetch()
+
+**Release Tag:** public
+
+### Parameters
+
+- **`url`** (`string`)
+- **`options`** (`PostHogFetchOptions`)
+
+### Returns
+
+- `Promise<PostHogFetchResponse>`
+
+### Examples
+
+```node
+// Generated example for fetch
+posthog.fetch();
+```
+
+---
+
+#### getSurveysStateless()
+
+**Release Tag:** public
+
+* ** SURVEYS *
+
+### Returns
+
+- `Promise<SurveyResponse['surveys']>`
+
+### Examples
+
+```node
+// Generated example for getSurveysStateless
+posthog.getSurveysStateless();
+```
+
+---
+
+#### on()
+
+**Release Tag:** public
+
+### Parameters
+
+- **`event`** (`string`)
+- **`cb`** (`(...args: any[]) => void`)
+
+### Returns
+
+- `() => void`
+
+### Examples
+
+```node
+// Generated example for on
+posthog.on();
+```
+
+---
+
+#### optIn()
+
+**Release Tag:** public
+
+### Returns
+
+- `Promise<void>`
+
+### Examples
+
+```node
+// Generated example for optIn
+posthog.optIn();
+```
+
+---
+
+#### optOut()
+
+**Release Tag:** public
+
+### Returns
+
+- `Promise<void>`
+
+### Examples
+
+```node
+// Generated example for optOut
+posthog.optOut();
+```
+
+---
+
+#### register()
+
+**Release Tag:** public
+
+### Parameters
+
+- **`properties`** (`PostHogEventProperties`)
+
+### Returns
+
+- `Promise<void>`
+
+### Examples
+
+```node
+// Generated example for register
+posthog.register();
+```
+
+---
+
+#### unregister()
+
+**Release Tag:** public
+
+### Parameters
+
+- **`property`** (`string`)
+
+### Returns
+
+- `Promise<void>`
+
+### Examples
+
+```node
+// Generated example for unregister
+posthog.unregister();
+```
+
+---
+
+### Initialization methods
+
+#### PostHog()
+
+**Release Tag:** public
+
+Initialize a new PostHog client instance.
+
+### Parameters
+
+- **`apiKey`** (`string`) - Your PostHog project API key
+- **`options?`** (`PostHogOptions`) - Configuration options for the client
+
+### Returns
+
+- `any`
+
+### Examples
+
+#### Basic initialization
+
+```node
+// Basic initialization
+const client = new PostHogBackendClient(
+  'your-api-key',
+  { host: 'https://app.posthog.com' }
+)
+```
+
+#### With personal API key
+
+```node
+// With personal API key
+const client = new PostHogBackendClient(
+  'your-api-key',
+  {
+    host: 'https://app.posthog.com',
+    personalApiKey: 'your-personal-api-key'
+  }
+)
+```
+
+---
+
+#### debug()
+
+**Release Tag:** public
+
+Enable or disable debug logging.
+
+### Parameters
+
+- **`enabled?`** (`boolean`) - Whether to enable debug logging
+
+### Returns
+
+- `void`
+
+### Examples
+
+#### Enable debug logging
+
+```node
+// Enable debug logging
+client.debug(true)
+```
+
+#### Disable debug logging
+
+```node
+// Disable debug logging
+client.debug(false)
+```
+
+---
+
+#### getLibraryVersion()
+
+**Release Tag:** public
+
+Get the library version from package.json.
+
+### Returns
+
+- `string`
+
+### Examples
+
+```node
+// Get version
+const version = client.getLibraryVersion()
+console.log(`Using PostHog SDK version: ${version}`)
+```
+
+---
+
+#### getPersistedProperty()
+
+**Release Tag:** public
+
+Get a persisted property value from memory storage.
+
+### Parameters
+
+- **`key`** (`PostHogPersistedProperty`) - The property key to retrieve
+
+### Returns
+
+**Union of:**
+- `any`
+- `undefined`
+
+### Examples
+
+#### Get user ID
+
+```node
+// Get user ID
+const userId = client.getPersistedProperty('userId')
+```
+
+#### Get session ID
+
+```node
+// Get session ID
+const sessionId = client.getPersistedProperty('sessionId')
+```
+
+---
+
+#### setPersistedProperty()
+
+**Release Tag:** public
+
+Set a persisted property value in memory storage.
+
+### Parameters
+
+- **`key`** (`PostHogPersistedProperty`) - The property key to set
+- **`value`** (`any | null`) - The value to store (null to remove)
+
+### Returns
+
+- `void`
+
+### Examples
+
+#### Set user ID
+
+```node
+// Set user ID
+client.setPersistedProperty('userId', 'user_123')
+```
+
+#### Set session ID
+
+```node
+// Set session ID
+client.setPersistedProperty('sessionId', 'session_456')
+```
+
+---
+
+#### shutdown()
+
+**Release Tag:** public
+
+Shuts down the PostHog instance and ensures all events are sent.
+Call shutdown() once before the process exits to ensure that all events have been sent and all promises have resolved. Do not use this function if you intend to keep using this PostHog instance after calling it. Use flush() for per-request cleanup instead.
+
+### Parameters
+
+- **`shutdownTimeoutMs?`** (`number`) - Maximum time to wait for shutdown in milliseconds
+
+### Returns
+
+- `Promise<void>`
+
+### Examples
+
+```node
+// shutdown before process exit
+process.on('SIGINT', async () => {
+  await posthog.shutdown()
+  process.exit(0)
+})
+```
+
+---
+
+### Identification methods
+
+#### alias()
+
+**Release Tag:** public
+
+Create an alias to link two distinct IDs together.
+
+### Parameters
+
+- **`data`** (`{
+        distinctId: string;
+        alias: string;
+        disableGeoip?: boolean;
+    }`) - The alias data containing distinctId and alias
+
+### Returns
+
+- `void`
+
+### Examples
+
+```node
+// Link an anonymous user to an identified user
+client.alias({
+  distinctId: 'anonymous_123',
+  alias: 'user_456'
+})
+```
+
+---
+
+#### aliasImmediate()
+
+**Release Tag:** public
+
+Create an alias to link two distinct IDs together immediately (synchronously).
+
+### Parameters
+
+- **`data`** (`{
+        distinctId: string;
+        alias: string;
+        disableGeoip?: boolean;
+    }`) - The alias data containing distinctId and alias
+
+### Returns
+
+- `Promise<void>`
+
+### Examples
+
+```node
+// Link an anonymous user to an identified user immediately
+await client.aliasImmediate({
+  distinctId: 'anonymous_123',
+  alias: 'user_456'
+})
+```
+
+---
+
+#### getCustomUserAgent()
+
+**Release Tag:** public
+
+Get the custom user agent string for this client.
+
+### Returns
+
+- `string`
+
+### Examples
+
+```node
+// Get user agent
+const userAgent = client.getCustomUserAgent()
+// Returns: "posthog-node/5.7.0"
+```
+
+---
+
+#### groupIdentify()
+
+**Release Tag:** public
+
+Create or update a group and its properties.
+
+### Parameters
+
+- **`{ groupType, groupKey, properties, distinctId, disableGeoip }`** (`GroupIdentifyMessage`)
+
+### Returns
+
+- `void`
+
+### Examples
+
+#### Create a company group
+
+```node
+// Create a company group
+client.groupIdentify({
+  groupType: 'company',
+  groupKey: 'acme-corp',
+  properties: {
+    name: 'Acme Corporation',
+    industry: 'Technology',
+    employee_count: 500
+  },
+  distinctId: 'user_123'
+})
+```
+
+#### Update organization properties
+
+```node
+// Update organization properties
+client.groupIdentify({
+  groupType: 'organization',
+  groupKey: 'org-456',
+  properties: {
+    plan: 'enterprise',
+    region: 'US-West'
+  }
+})
+```
+
+---
+
+#### identify()
+
+**Release Tag:** public
+
+Identify a user and set their properties.
+
+### Parameters
+
+- **`{ distinctId, properties, disableGeoip }`** (`IdentifyMessage`)
+
+### Returns
+
+- `void`
+
+### Examples
+
+#### Basic identify with properties
+
+```node
+// Basic identify with properties
+client.identify({
+  distinctId: 'user_123',
+  properties: {
+    name: 'John Doe',
+    email: 'john@example.com',
+    plan: 'premium'
+  }
+})
+```
+
+#### Using $set and $set_once
+
+```node
+// Using $set and $set_once
+client.identify({
+  distinctId: 'user_123',
+  properties: {
+    $set: { name: 'John Doe', email: 'john@example.com' },
+    $set_once: { first_login: new Date().toISOString() }
+    $anon_distinct_id: 'anonymous_user_456'
+  }
+})
+```
+
+---
+
+#### identifyImmediate()
+
+**Release Tag:** public
+
+Identify a user and set their properties immediately (synchronously).
+
+### Parameters
+
+- **`{ distinctId, properties, disableGeoip }`** (`IdentifyMessage`)
+
+### Returns
+
+- `Promise<void>`
+
+### Examples
+
+```node
+// Basic immediate identify
+await client.identifyImmediate({
+  distinctId: 'user_123',
+  properties: {
+    name: 'John Doe',
+    email: 'john@example.com'
+  }
+})
+```
+
+---
+
+### Capture methods
+
+#### capture()
+
+**Release Tag:** public
+
+Capture an event manually.
+
+### Parameters
+
+- **`props`** (`EventMessage`) - The event properties
+
+### Returns
+
+- `void`
+
+### Examples
+
+```node
+// Basic capture
+client.capture({
+  distinctId: 'user_123',
+  event: 'button_clicked',
+  properties: { button_color: 'red' }
+})
+```
+
+---
+
+#### captureImmediate()
+
+**Release Tag:** public
+
+Capture an event immediately (synchronously).
+
+### Parameters
+
+- **`props`** (`EventMessage`) - The event properties
+
+### Returns
+
+- `Promise<void>`
+
+### Examples
+
+#### Basic immediate capture
+
+```node
+// Basic immediate capture
+await client.captureImmediate({
+  distinctId: 'user_123',
+  event: 'button_clicked',
+  properties: { button_color: 'red' }
+})
+```
+
+#### With feature flags
+
+```node
+// With feature flags
+await client.captureImmediate({
+  distinctId: 'user_123',
+  event: 'user_action',
+  sendFeatureFlags: true
+})
+```
+
+#### With custom feature flags options
+
+```node
+// With custom feature flags options
+await client.captureImmediate({
+  distinctId: 'user_123',
+  event: 'user_action',
+  sendFeatureFlags: {
+    onlyEvaluateLocally: true,
+    personProperties: { plan: 'premium' },
+    groupProperties: { org: { tier: 'enterprise' } }
+    flagKeys: ['flag1', 'flag2']
+  }
+})
+```
+
+---
+
+### Error tracking methods
+
+#### captureException()
+
+**Release Tag:** public
+
+Capture an error exception as an event.
+
+### Parameters
+
+- **`error`** (`unknown`) - The error to capture
+- **`distinctId?`** (`string`) - Optional user distinct ID
+- **`additionalProperties?`** (`Record<string | number, any>`) - Optional additional properties to include
+- **`uuid?`** (`EventMessage['uuid']`)
+
+### Returns
+
+- `void`
+
+### Examples
+
+#### Capture an error with user ID
+
+```node
+// Capture an error with user ID
+try {
+  // Some risky operation
+  riskyOperation()
+} catch (error) {
+  client.captureException(error, 'user_123')
+}
+```
+
+#### Capture with additional properties
+
+```node
+// Capture with additional properties
+try {
+  apiCall()
+} catch (error) {
+  client.captureException(error, 'user_123', {
+    endpoint: '/api/users',
+    method: 'POST',
+    status_code: 500
+  })
+}
+```
+
+---
+
+#### captureExceptionImmediate()
+
+**Release Tag:** public
+
+Capture an error exception as an event immediately (synchronously).
+
+### Parameters
+
+- **`error`** (`unknown`) - The error to capture
+- **`distinctId?`** (`string`) - Optional user distinct ID
+- **`additionalProperties?`** (`Record<string | number, any>`) - Optional additional properties to include
+
+### Returns
+
+- `Promise<void>`
+
+### Examples
+
+#### Capture an error immediately with user ID
+
+```node
+// Capture an error immediately with user ID
+try {
+  // Some risky operation
+  riskyOperation()
+} catch (error) {
+  await client.captureExceptionImmediate(error, 'user_123')
+}
+```
+
+#### Capture with additional properties
+
+```node
+// Capture with additional properties
+try {
+  apiCall()
+} catch (error) {
+  await client.captureExceptionImmediate(error, 'user_123', {
+    endpoint: '/api/users',
+    method: 'POST',
+    status_code: 500
+  })
+}
+```
+
+---
+
+### Privacy methods
+
+#### disable()
+
+**Release Tag:** public
+
+Disable the PostHog client (opt-out).
+
+### Returns
+
+- `Promise<void>`
+
+### Examples
+
+```node
+// Disable client
+await client.disable()
+// Client is now disabled and will not capture events
+```
+
+---
+
+#### enable()
+
+**Release Tag:** public
+
+Enable the PostHog client (opt-in).
+
+### Returns
+
+- `Promise<void>`
+
+### Examples
+
+```node
+// Enable client
+await client.enable()
+// Client is now enabled and will capture events
+```
+
+---
+
+### Feature flags methods
+
+#### getAllFlags()
+
+**Release Tag:** public
+
+Get all feature flag values for a specific user.
+
+### Parameters
+
+- **`options?`** (`AllFlagsOptions`) - Optional configuration for flag evaluation
+
+### Returns
+
+- `Promise<Record<string, FeatureFlagValue>>`
+
+### Examples
+
+#### Get all flags for a user
+
+```node
+// Get all flags for a user
+const allFlags = await client.getAllFlags('user_123')
+console.log('User flags:', allFlags)
+// Output: { 'flag-1': 'variant-a', 'flag-2': false, 'flag-3': 'variant-b' }
+```
+
+#### With specific flag keys
+
+```node
+// With specific flag keys
+const specificFlags = await client.getAllFlags('user_123', {
+  flagKeys: ['flag-1', 'flag-2']
+})
+```
+
+#### With groups and properties
+
+```node
+// With groups and properties
+const orgFlags = await client.getAllFlags('user_123', {
+  groups: { organization: 'acme-corp' },
+  personProperties: { plan: 'enterprise' }
+})
+```
+
+---
+
+#### getAllFlagsAndPayloads()
+
+**Release Tag:** public
+
+Get all feature flag values and payloads for a specific user.
+
+### Parameters
+
+- **`options?`** (`AllFlagsOptions`) - Optional configuration for flag evaluation
+
+### Returns
+
+- `Promise<PostHogFlagsAndPayloadsResponse>`
+
+### Examples
+
+#### Get all flags and payloads for a user
+
+```node
+// Get all flags and payloads for a user
+const result = await client.getAllFlagsAndPayloads('user_123')
+console.log('Flags:', result.featureFlags)
+console.log('Payloads:', result.featureFlagPayloads)
+```
+
+#### With specific flag keys
+
+```node
+// With specific flag keys
+const result = await client.getAllFlagsAndPayloads('user_123', {
+  flagKeys: ['flag-1', 'flag-2']
+})
+```
+
+#### Only evaluate locally
+
+```node
+// Only evaluate locally
+const result = await client.getAllFlagsAndPayloads('user_123', {
+  onlyEvaluateLocally: true
+})
+```
+
+---
+
+#### getFeatureFlag()
+
+**Release Tag:** public
+
+Get the value of a feature flag for a specific user.
+
+### Parameters
+
+- **`key`** (`string`) - The feature flag key
+- **`distinctId`** (`string`) - The user's distinct ID
+- **`options?`** (`{
+        groups?: Record<string, string>;
+        personProperties?: Record<string, string>;
+        groupProperties?: Record<string, Record<string, string>>;
+        onlyEvaluateLocally?: boolean;
+        sendFeatureFlagEvents?: boolean;
+        disableGeoip?: boolean;
+    }`) - Optional configuration for flag evaluation
+
+### Returns
+
+**Union of:**
+- `Promise<FeatureFlagValue`
+- `undefined>`
+
+### Examples
+
+#### Basic feature flag check
+
+```node
+// Basic feature flag check
+const flagValue = await client.getFeatureFlag('new-feature', 'user_123')
+if (flagValue === 'variant-a') {
+  // Show variant A
+} else if (flagValue === 'variant-b') {
+  // Show variant B
+} else {
+  // Flag is disabled or not found
+}
+```
+
+#### With groups and properties
+
+```node
+// With groups and properties
+const flagValue = await client.getFeatureFlag('org-feature', 'user_123', {
+  groups: { organization: 'acme-corp' },
+  personProperties: { plan: 'enterprise' },
+  groupProperties: { organization: { tier: 'premium' } }
+})
+```
+
+#### Only evaluate locally
+
+```node
+// Only evaluate locally
+const flagValue = await client.getFeatureFlag('local-flag', 'user_123', {
+  onlyEvaluateLocally: true
+})
+```
+
+---
+
+#### getFeatureFlagPayload()
+
+**Release Tag:** public
+
+Get the payload for a feature flag.
+
+### Parameters
+
+- **`key`** (`string`) - The feature flag key
+- **`distinctId`** (`string`) - The user's distinct ID
+- **`matchValue?`** (`FeatureFlagValue`) - Optional match value to get payload for
+- **`options?`** (`{
+        groups?: Record<string, string>;
+        personProperties?: Record<string, string>;
+        groupProperties?: Record<string, Record<string, string>>;
+        onlyEvaluateLocally?: boolean;
+        sendFeatureFlagEvents?: boolean;
+        disableGeoip?: boolean;
+    }`) - Optional configuration for flag evaluation
+
+### Returns
+
+**Union of:**
+- `Promise<JsonType`
+- `undefined>`
+
+### Examples
+
+#### Get payload for a feature flag
+
+```node
+// Get payload for a feature flag
+const payload = await client.getFeatureFlagPayload('flag-key', 'user_123')
+if (payload) {
+  console.log('Flag payload:', payload)
+}
+```
+
+#### Get payload with specific match value
+
+```node
+// Get payload with specific match value
+const payload = await client.getFeatureFlagPayload('flag-key', 'user_123', 'variant-a')
+```
+
+#### With groups and properties
+
+```node
+// With groups and properties
+const payload = await client.getFeatureFlagPayload('org-flag', 'user_123', undefined, {
+  groups: { organization: 'acme-corp' },
+  personProperties: { plan: 'enterprise' }
+})
+```
+
+---
+
+#### getFeatureFlagResult()
+
+**Release Tag:** public
+
+Get the result of evaluating a feature flag, including its value and payload. This is more efficient than calling getFeatureFlag and getFeatureFlagPayload separately when you need both.
+
+### Parameters
+
+- **`key`** (`string`) - The feature flag key
+- **`options?`** (`FlagEvaluationOptions`) - Optional configuration for flag evaluation
+
+### Returns
+
+**Union of:**
+- `Promise<FeatureFlagResult`
+- `undefined>`
+
+### Examples
+
+#### Get flag result
+
+```node
+// Get flag result
+const result = await client.getFeatureFlagResult('my-flag', 'user_123')
+if (result) {
+  console.log('Flag enabled:', result.enabled)
+  console.log('Variant:', result.variant)
+  console.log('Payload:', result.payload)
+}
+```
+
+#### With groups and properties
+
+```node
+// With groups and properties
+const result = await client.getFeatureFlagResult('org-feature', 'user_123', {
+  groups: { organization: 'acme-corp' },
+  personProperties: { plan: 'enterprise' }
+})
+```
+
+---
+
+#### getRemoteConfigPayload()
+
+**Release Tag:** public
+
+Get the remote config payload for a feature flag.
+
+### Parameters
+
+- **`flagKey`** (`string`) - The feature flag key
+
+### Returns
+
+**Union of:**
+- `Promise<JsonType`
+- `undefined>`
+
+### Examples
+
+```node
+// Get remote config payload
+const payload = await client.getRemoteConfigPayload('flag-key')
+if (payload) {
+  console.log('Remote config payload:', payload)
+}
+```
+
+---
+
+#### isFeatureEnabled()
+
+**Release Tag:** public
+
+Check if a feature flag is enabled for a specific user.
+
+### Parameters
+
+- **`key`** (`string`) - The feature flag key
+- **`distinctId`** (`string`) - The user's distinct ID
+- **`options?`** (`{
+        groups?: Record<string, string>;
+        personProperties?: Record<string, string>;
+        groupProperties?: Record<string, Record<string, string>>;
+        onlyEvaluateLocally?: boolean;
+        sendFeatureFlagEvents?: boolean;
+        disableGeoip?: boolean;
+    }`) - Optional configuration for flag evaluation
+
+### Returns
+
+**Union of:**
+- `Promise<boolean`
+- `undefined>`
+
+### Examples
+
+#### Basic feature flag check
+
+```node
+// Basic feature flag check
+const isEnabled = await client.isFeatureEnabled('new-feature', 'user_123')
+if (isEnabled) {
+  // Feature is enabled
+  console.log('New feature is active')
+} else {
+  // Feature is disabled
+  console.log('New feature is not active')
+}
+```
+
+#### With groups and properties
+
+```node
+// With groups and properties
+const isEnabled = await client.isFeatureEnabled('org-feature', 'user_123', {
+  groups: { organization: 'acme-corp' },
+  personProperties: { plan: 'enterprise' }
+})
+```
+
+---
+
+#### isLocalEvaluationReady()
+
+**Release Tag:** public
+
+Check if local evaluation of feature flags is ready.
+
+### Returns
+
+- `boolean`
+
+### Examples
+
+```node
+// Check if ready
+if (client.isLocalEvaluationReady()) {
+  // Local evaluation is ready, can evaluate flags locally
+  const flag = await client.getFeatureFlag('flag-key', 'user_123')
+} else {
+  // Local evaluation not ready, will use remote evaluation
+  const flag = await client.getFeatureFlag('flag-key', 'user_123')
+}
+```
+
+---
+
+#### overrideFeatureFlags()
+
+**Release Tag:** public
+
+Override feature flags locally. Useful for testing and local development. Overridden flags take precedence over both local evaluation and remote evaluation.
+
+### Parameters
+
+- **`overrides`** (`OverrideFeatureFlagsOptions`) - Flag overrides configuration
+
+### Returns
+
+- `void`
+
+### Examples
+
+```node
+// Clear all overrides
+client.overrideFeatureFlags(false)
+
+// Enable a list of flags (sets them to true)
+client.overrideFeatureFlags(['flag-a', 'flag-b'])
+
+// Set specific flag values/variants
+client.overrideFeatureFlags({ 'my-flag': 'variant-a', 'other-flag': true })
+
+// Set both flags and payloads
+client.overrideFeatureFlags({
+  flags: { 'my-flag': 'variant-a' },
+  payloads: { 'my-flag': { discount: 20 } }
+})
+```
+
+---
+
+#### reloadFeatureFlags()
+
+**Release Tag:** public
+
+Reload feature flag definitions from the server for local evaluation.
+
+### Returns
+
+- `Promise<void>`
+
+### Examples
+
+#### Force reload of feature flags
+
+```node
+// Force reload of feature flags
+await client.reloadFeatureFlags()
+console.log('Feature flags reloaded')
+```
+
+#### Reload before checking a specific flag
+
+```node
+// Reload before checking a specific flag
+await client.reloadFeatureFlags()
+const flag = await client.getFeatureFlag('flag-key', 'user_123')
+```
+
+---
+
+#### waitForLocalEvaluationReady()
+
+**Release Tag:** public
+
+Wait for local evaluation of feature flags to be ready.
+
+### Parameters
+
+- **`timeoutMs?`** (`number`) - Timeout in milliseconds (default: 30000)
+
+### Returns
+
+- `Promise<boolean>`
+
+### Examples
+
+#### Wait for local evaluation
+
+```node
+// Wait for local evaluation
+const isReady = await client.waitForLocalEvaluationReady()
+if (isReady) {
+  console.log('Local evaluation is ready')
+} else {
+  console.log('Local evaluation timed out')
+}
+```
+
+#### Wait with custom timeout
+
+```node
+// Wait with custom timeout
+const isReady = await client.waitForLocalEvaluationReady(10000) // 10 seconds
+```
+
+---
+
+### Context methods
+
+#### getContext()
+
+**Release Tag:** public
+
+Get the current context data.
+
+### Returns
+
+**Union of:**
+- `ContextData`
+- `undefined`
+
+### Examples
+
+```node
+// Get current context within a withContext block
+posthog.withContext({ distinctId: 'user_123' }, () => {
+  const context = posthog.getContext()
+  console.log(context?.distinctId) // 'user_123'
+})
+```
+
+---
+
+#### withContext()
+
+**Release Tag:** public
+
+Run a function with specific context that will be applied to all events captured within that context. It propagates the context to all subsequent calls down the call stack. Context properties like tags and sessionId will be automatically attached to all events. By default, nested contexts inherit from parent contexts. Use `{ fresh: true }` to start with a clean context.
+
+### Parameters
+
+- **`data`** (`Partial<ContextData>`) - Context data to apply (sessionId, distinctId, properties, enableExceptionAutocapture)
+- **`fn`** (`() => T`) - Function to run with the context
+- **`options?`** (`ContextOptions`) - Context options (fresh: true to start with clean context instead of inheriting)
+
+### Returns
+
+- `T`
+
+### Examples
+
+```node
+posthog.withContext({ distinctId: 'user_123' }, () => {
+  posthog.capture({ event: 'button clicked' })
+})
+```
+
+---

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -3,14 +3,14 @@ set -e
 
 # Lint (fast — Biome or ESLint, whatever is configured)
 if grep -q '"lint"' package.json 2>/dev/null; then
-  pnpm run --if-present lint || { echo "lint failed — fix before pushing" >&2; exit 1; }
+  pnpm run lint --if-present || { echo "lint failed — fix before pushing" >&2; exit 1; }
 fi
 
 # Secret scan — abort if tokens/keys found in tracked files
 SECRETS=$(git ls-files -z 2>/dev/null \
   | xargs -0 grep -lE \
-    'sk-(proj-|ant-)?[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{36}|gho_[A-Za-z0-9]{36}|AIzaSy[A-Za-z0-9_-]{33}|xoxb-[A-Za-z0-9-]+|-----BEGIN (RSA |EC )?PRIVATE KEY-----' 2>/dev/null \
-  | grep -vE '(\.example$|\.sample$|/tests?/|/__tests__/|/fixtures?/|/mocks?/|/vendor/|/data/library/|content\.json$)' \
+    'sk-(proj-|ant-)?[A-Za-z0-9_-]{20,}|AKIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{36}|gho_[A-Za-z0-9]{36}|AIzaSy[A-Za-z0-9_-]{33}|xoxb-[A-Za-z0-9-]+|-----BEGIN (RSA |EC )?PRIVATE KEY-----' 2>/dev/null \
+  | grep -vE '(\.example$|\.sample$|/tests?/|/__tests__/|/fixtures?/|/mocks?/|/vendor/)' \
   || true)
 if [ -n "$SECRETS" ]; then
   echo "Possible secret(s) in tracked files — push aborted:" >&2

--- a/apps/cockpit/src/app/layout.tsx
+++ b/apps/cockpit/src/app/layout.tsx
@@ -34,6 +34,11 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <script
+          dangerouslySetInnerHTML={{
+            __html: "globalThis.__name=globalThis.__name||function(t){return t};",
+          }}
+        />
         <SaasMakerAnalytics />
         <ThemeProvider
           attribute="class"

--- a/apps/cockpit/wrangler.toml
+++ b/apps/cockpit/wrangler.toml
@@ -8,6 +8,13 @@ routes = [
   { pattern = "app.sassmaker.com/*", zone_name = "sassmaker.com" }
 ]
 
+[observability]
+enabled = true
+head_sampling_rate = 0.1
+
+[limits]
+cpu_ms = 30000
+
 [vars]
 AUTH_URL = "https://app.sassmaker.com"
 NODE_ENV = "production"

--- a/docs/auth-audit-2026-04-27.md
+++ b/docs/auth-audit-2026-04-27.md
@@ -1,0 +1,316 @@
+# Auth Audit — 2026-04-27
+
+Read-only audit of authentication state across all Fleet apps in `~/Desktop/Fleet/`. No code or config was modified.
+
+## Caveats / scope notes
+- Three apps in the original target list are **not present** in `~/Desktop/Fleet/`: `agentdata-backend-prod`, `personalsite`, `web-annotator`. These are excluded.
+- `free-ai-gateway` exists as `free-ai/`.
+- Smoke tests were partially constrained by sandbox DNS — several `*.pages.dev`, `*.workers.dev`, `*.vercel.app`, and custom-domain hosts could not be resolved from the audit environment. Where DNS failed, status is inferred from code/config alone and flagged `unknown (DNS)`. Inference from code is reliable for "what should happen"; only the deployed-state column is impacted.
+- Coordination: agent `acfc91a04d218fd01` was modifying `reader`, `resume-tailor`, and `free-ai` for AI-gateway changes. This audit only **read** those repos.
+
+## Summary
+- **Apps audited:** 22
+- **Need user auth:** 14
+- **Need API key (no user auth):** 3 (free-ai gateway, high-signal API, saas-maker API)
+- **No auth needed:** 5 (backpropagate, chess, clash-royale-meta, CodeVetter, looptv, everythingrated — POC anonymous; agentMode = client-only Google sync to backend that itself uses bearer)
+- **Working auth (scaffolding sound + reachable):** 2 confirmed (mentionpilot, today-little-log) + 6 inferred OK from code
+- **Broken / 500-ing auth:** 4 (linkchat, truehire, resume-tailor, swe-interview-prep)
+- **Partial (auth wired but missing pieces):** ~6
+- **Stub / not-yet-wired:** 1 (high-signal NextAuth declared but not in code; Cloudflare Access used instead per `plans/0002-auth-hardening.md` Path A)
+
+## Per-app status
+
+### agentMode
+- **Classification:** needs-user-auth (web + backend)
+- **Provider:** Google Identity Services (client-side GSI), JWT idToken passed as Bearer to CF Worker backend (`cloudflare/backend/src/index.ts` verifies Google ID tokens via `oauth2.googleapis.com/tokeninfo`).
+- **Imports:** none of `better-auth`/`next-auth` — pure GSI + manual Bearer verify.
+- **Routes:** No `/api/auth/*` — login is GSI popup → idToken → frontend stores in `localStorage.agentdata_auth` → backend verifies on each request.
+- **DB:** Turso (libSQL). No auth-specific schema needed (no sessions stored).
+- **Env vars:** `NEXT_PUBLIC_GOOGLE_CLIENT_ID` (web), Reddit creds for backend. Note: `.env.example` lacks `GOOGLE_CLIENT_ID` and `NEXT_PUBLIC_GOOGLE_CLIENT_ID`.
+- **Smoke test:** `agentmode-backend.sarthakagrawal927.workers.dev/` → 404 (root not registered; expected — 404 = not the API path. Auth path uses `Authorization` header per request, no dedicated session endpoint).
+- **Gaps:**
+  - `.env.example` missing `NEXT_PUBLIC_GOOGLE_CLIENT_ID`.
+  - idToken in localStorage = XSS-vulnerable (per high-signal plan, same anti-pattern noted).
+  - No refresh — token expires after ~1h with no flow.
+  - No `agentmode-backend` deployed URL verified (DNS resolve OK but root 404 — no `/healthz` or similar).
+- **Status:** PARTIAL
+
+### anime_list
+- **Classification:** needs-user-auth (personal watchlists)
+- **Provider:** Google ID Token verification (server-side via `google-auth-library`) + JWT signed with `JWT_SECRET` (Express middleware `src/middleware/auth.ts`).
+- **Routes:** Express `POST /auth/google` in `src/routes/authRoutes.ts`. Frontend `lib/auth.tsx` calls `${API_URL}/api/auth/google`.
+- **DB:** Turso (libSQL) — `users` CRUD via `src/db/users.ts`. No sessions table (stateless JWT).
+- **Env vars:** `GOOGLE_CLIENT_ID`, `JWT_SECRET`, `NEXT_PUBLIC_GOOGLE_CLIENT_ID`, `TURSO_AUTH_TOKEN` — all present in `.env.example`.
+- **Smoke test:** `https://anime-list-five.vercel.app/` → 200; `/api/auth` → 404 (the route is `/api/auth/google` mounted under Express). DNS resolved.
+- **Gaps:**
+  - Frontend stores JWT in `localStorage.mal_auth` — XSS-vulnerable.
+  - No `vercel.json` content surfaced — verify Express is actually proxied via Vercel.
+  - JWT has no rotation, no refresh, 30-day TTL hard-coded (per typical pattern).
+- **Status:** WORKING (assuming Vercel routes Express as configured; logic is sound)
+
+### backpropagate
+- **Classification:** no-auth-needed (single-player game, no persistence)
+- **Status:** N/A
+
+### chess
+- **Classification:** no-auth-needed (local-only game, BYO API keys)
+- **Provider:** None
+- **Status:** N/A
+
+### clash-royale-meta
+- **Classification:** no-auth-needed (public read-only stats)
+- **Status:** N/A
+
+### CodeVetter
+- **Classification:** no-auth-needed (Tauri desktop app; LLM keys local)
+- **Status:** N/A
+
+### email-manager
+- **Classification:** needs-user-auth (Gmail OAuth scope; per-user email data)
+- **Provider:** **better-auth** (Drizzle adapter + D1) per `src/lib/auth.ts` — but `agents.md` says **NextAuth v4**. Code is the source of truth: it's better-auth.
+- **Routes:** `/api/auth/[...all]` via better-auth handler.
+- **DB:** Cloudflare D1 binding `DB` → `email-manager-auth` (database_id `e770dfa2-…`).
+- **Env vars:** `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`, `TURSO_AUTH_TOKEN` — present.
+- **Smoke test:** `email-manager-d0r.pages.dev` — DNS unresolved from sandbox, status unknown.
+- **Gaps:**
+  - **No migrations directory and no Drizzle schema file.** better-auth expects `user`, `session`, `account`, `verification` tables; without migrations, the D1 DB is empty → first sign-in attempt will 500.
+  - `agents.md` is stale (says NextAuth v4 — actual code is better-auth).
+  - `BETTER_AUTH_SECRET` must be set as Worker secret in prod (cannot verify).
+- **Status:** PARTIAL — code wired, schema missing.
+
+### everythingrated
+- **Classification:** no-auth-needed (POC; httpOnly cookie `er_visitor` for anon ratings).
+- **Status:** N/A
+
+### free-ai (= free-ai-gateway)
+- **Classification:** needs-api-key (Bearer for `/v1/analytics`); chat/embedding endpoints are public + per-IP rate-limited.
+- **Provider:** Static Bearer `GATEWAY_API_KEY` (per `agents.md`); not yet enforced (known gap).
+- **DB:** Cloudflare D1 `GATEWAY_DB` (analytics).
+- **Env vars:** `.env.example` not inspected for GATEWAY_API_KEY explicitly; `agents.md` flags this as TODO.
+- **Smoke test:** `free-ai-gateway.sarthakagrawal927.workers.dev/api/auth/session` → 200 (this endpoint isn't auth-related — root returns 200 because the app serves a playground).
+- **Gaps:**
+  - Bearer enforcement on `/v1/analytics` not implemented (declared TODO).
+- **Status:** PARTIAL by design (no user auth needed; API-key gating not yet wired).
+
+### high-signal
+- **Classification:** needs-user-auth for `/review` admin only (public read for everything else); API needs API-key for admin endpoints.
+- **Provider declared:** NextAuth v5 (Google) per `agents.md`. **Actual:** Cloudflare Access (Path A) per `plans/0002-auth-hardening.md`. NextAuth packages are NOT in `apps/web/package.json` — the doc is aspirational. The active design uses CF Access JWT verified in `apps/web/src/app/api/admin/[...path]/route.ts` (this file may not yet exist — confirm).
+- **Routes:** No `apps/web/src/app/api/auth/*`. There IS `apps/web/src/app/api/admin/[...path]/route.ts` (CF Access proxy).
+- **DB:** Cloudflare D1 `high-signal-db` (no users/sessions tables expected — admin gating is via CF Access cookie, not session DB).
+- **Env vars:** `.env.example` lists `NEXTAUTH_URL`, `NEXTAUTH_SECRET`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` — but these are stale (NextAuth was abandoned for CF Access). Should be `CF_ACCESS_AUD`, `CF_ACCESS_TEAM_DOMAIN`.
+- **Smoke test:** `high-signal-api.sarthakagrawal927.workers.dev/` → 200; `/api/auth/session` → 404 (correct — no NextAuth here).
+- **Gaps:**
+  - `agents.md` says NextAuth — actually CF Access. Update to match.
+  - `.env.example` has stale NEXTAUTH_* vars; missing `CF_ACCESS_AUD` / `CF_ACCESS_TEAM_DOMAIN`.
+  - Need to confirm `apps/web/src/app/api/admin/[...path]/route.ts` exists and verifies CF Access JWT.
+- **Status:** PARTIAL (docs/env stale; design was migrated; verify code)
+
+### linkchat
+- **Classification:** needs-user-auth (dashboard, AI key storage)
+- **Provider:** **better-auth** v1.6.9 (Drizzle adapter on D1). `agents.md` claims **NextAuth v5** — stale.
+- **Routes:** `/api/auth/[...all]` via `toNextJsHandler(createAuth().handler)`.
+- **DB:** D1 `linkchat-auth` (binding `DB`).
+- **Schema:** `src/db/schema.ts` defines `users`, `accounts`, `sessions`, `verificationTokens` in **NextAuth-style** (camelCase columns, plural names) — but better-auth defaults to `user`/`session`/`account`/`verification`. **Schema/library mismatch.** The auth call doesn't pass `schema:` mapping — better-auth will look for its own table names → tables not found → 500.
+- **Env vars:** `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `TURSO_AUTH_TOKEN` (Turso unused now — D1).
+- **Smoke test:** `linkchat.sarthakagrawal927.workers.dev/` → **500**; `/api/auth/session` → **500** (empty body); `/login` → **500**. App is **completely down**.
+- **Gaps:**
+  - **Site is 500-ing on every route.** Likely: missing `BETTER_AUTH_SECRET` secret OR schema mismatch OR `getCloudflareContext` call from a non-CF context.
+  - Schema names (`users`/`sessions`/`accounts`) don't match better-auth defaults (`user`/`session`/`account`); no `schema:` mapping passed in `drizzleAdapter`.
+  - `agents.md` says NextAuth v5 — stale.
+- **Status:** **BROKEN**
+
+### looptv
+- **Classification:** no-auth-needed (anon TV-style player, localStorage for history)
+- **Status:** N/A
+
+### mentionpilot
+- **Classification:** needs-user-auth (dashboard for tracked brands)
+- **Provider:** **better-auth** (D1 binding `AUTH_DB`). `agents.md` says better-auth — matches.
+- **Routes:** `apps/web/src/app/api/auth/[...all]/route.ts` calls `getAuth()` (lazy CF context).
+- **DB:** D1 `mentionpilot-db` shared with API worker. Migrations exist (`packages/db/migrations/0001_initial.sql` has `users`, `sessions`).
+- **Env vars:** `apps/web/.env.example` has `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`, `AUTH_GOOGLE_ID`, `AUTH_GOOGLE_SECRET`. Wrangler vars set `BETTER_AUTH_URL` and `NEXTAUTH_URL`.
+- **Smoke test:** `mentionpilot-web.sarthakagrawal927.workers.dev/` → 200; `/api/auth/session` → **404**; `/login` → 200; `/api/auth/sign-in/social` → 404.
+- **Gaps:**
+  - `/api/auth/*` returns 404 — the catch-all route isn't matching. Either build didn't include the route, or `[...all]` not exported correctly. Worth investigating: is `apps/web/.next` deployed via OpenNext? Is route file present in build output? (Found in `.open-next/server-functions/...` so likely deployed — but 404 suggests routing failure; could also be CF Worker not seeing the route handler. Worth tracing.)
+  - Migration `0001_initial.sql` defines `users`/`sessions` (plural, NextAuth-style) but better-auth expects `user`/`session` — same pattern as linkchat. **Schema mismatch likely.**
+- **Status:** PARTIAL → leaning BROKEN (routes 404, schema mismatch likely)
+
+### open-historia
+- **Classification:** needs-user-auth (cloud saves per user)
+- **Provider:** **better-auth** + Drizzle on D1.
+- **Routes:** `app/api/auth/[...all]/` via better-auth handler (per agents.md).
+- **DB:** D1 `open-historia-auth` (binding `DB`); schema `lib/db/schema.ts` defines `user`, `session`, `account`, `verification` (correct better-auth names!).
+- **Env vars:** `.env.example` has `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `TURSO_AUTH_TOKEN` — but Turso is unused (D1 now).
+- **Smoke test:** `open-historia.vercel.app/` → 404 (DEPLOYMENT_NOT_FOUND from Vercel — app moved or undeployed).
+- **Gaps:**
+  - **Vercel deployment is not found** — site appears down/migrated. Need to find the active URL.
+  - No migrations dir — schema in `lib/db/schema.ts` (Drizzle) but no SQL migration files. Confirm schema applied via `drizzle-kit push` to D1.
+  - `.env.example` lists `TURSO_AUTH_TOKEN` (stale — D1 now).
+- **Status:** PARTIAL (code OK, deployment dead)
+
+### reader
+- **Classification:** needs-user-auth (saved articles per user)
+- **Provider:** Migration in progress per `agents.md`: **Firebase Auth (active)** → **better-auth (target)**. Code has both: `src/lib/auth.ts` is better-auth (Drizzle adapter, no `db` driver — passes raw db); `src/lib/auth-server.ts` is Firebase Admin session cookies; `src/lib/auth-client.ts` likely Firebase web SDK.
+- **Routes:** `src/app/api/auth/[...all]/route.ts` (better-auth) coexists with Firebase session handling.
+- **DB:** Both: Firestore (current) + Turso/libSQL (target — schema in `src/lib/db/schema.ts` defines both NextAuth-style `users`/`sessions`/`accounts` AND better-auth-style `baSessions`/`baAccounts`/`baVerifications`).
+- **Env vars:** `.env.example` has `AUTH_SECRET`, `NEXTAUTH_URL`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `TURSO_AUTH_TOKEN` — but **no Firebase config vars** (those are in agents.md as Firebase, but env example doesn't list them). Either secrets are inlined in code (bad) or env-driven from a separate var set.
+- **Smoke test:** `reader-4nu.pages.dev` — DNS unresolved.
+- **Gaps:**
+  - Two auth systems running simultaneously (Firebase active + better-auth scaffold). Migration incomplete.
+  - `.env.example` missing `FIREBASE_*` vars.
+  - Schema has both NextAuth-style and better-auth-style tables — pick one.
+  - Coordination note: agent `acfc91a04d218fd01` is actively modifying this repo. Audit only.
+- **Status:** PARTIAL — mid-migration
+
+### resume-tailor
+- **Classification:** needs-user-auth (resume + job storage per user)
+- **Provider:** **better-auth** with custom `tursoAdapter` (raw HTTP-based). `agents.md` says NextAuth v4 — stale.
+- **Routes:** `src/app/api/auth/[...all]/route.ts`.
+- **DB:** Turso (HTTP client, no Drizzle). Custom adapter built from scratch.
+- **Env vars:** `AUTH_SECRET`, `AUTH_URL`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `TURSO_AUTH_TOKEN` — present.
+- **Smoke test:** `resume-tailor.vercel.app/` → **500** (`MIDDLEWARE_INVOCATION_FAILED`); `/api/auth/session` → 500; `/login` → 500. App **down**.
+- **Gaps:**
+  - **Vercel middleware crashing on every request.** Likely env var missing in prod (`AUTH_SECRET` or `TURSO_AUTH_TOKEN` not set), causing the custom Turso adapter or middleware to throw.
+  - `agents.md` says NextAuth v4 — stale (it's better-auth + custom adapter).
+  - Coordination note: agent `acfc91a04d218fd01` is actively modifying this repo.
+- **Status:** **BROKEN**
+
+### saas-maker
+- **Classification:** needs-user-auth (cockpit dashboard per user/project) + needs-api-key (workers/api accepts JWE tokens minted by cockpit)
+- **Provider:** Hybrid:
+  - `apps/cockpit/src/lib/auth.ts` — **better-auth** with Drizzle adapter on D1 binding `DB`.
+  - `workers/api/src/middleware/auth.ts` — verifies Auth.js JWE encrypted with `AUTH_SECRET` (HKDF + A256CBC-HS512 via `jose`). This is **NextAuth v5 token format** (`__Secure-authjs.session-token`).
+  - `agents.md` says NextAuth v5 beta — but cockpit code is better-auth. The API worker still accepts NextAuth-style JWE.
+- **Routes:** Cockpit `/api/auth/[...all]` (better-auth); API worker `/auth/session`, `/auth/logout` (custom).
+- **DB:** D1 `saasmaker-db` (shared cockpit + API). `apps/cockpit/src/lib/auth-schema.ts` defines `user`/`session`/`account`/`verification` (correct better-auth tables).
+- **Env vars:** `AUTH_SECRET`, `BETTER_AUTH_SECRET`, `AUTH_URL`, `AUTH_GOOGLE_ID`, `AUTH_GOOGLE_SECRET` — present in root `.env.example` and `apps/cockpit/.env.example`.
+- **Smoke test:** `app.sassmaker.com` — DNS unresolved. `api.sassmaker.com/` → 404 (root); `/api/auth/session` → 404 (API worker has `/auth/session` not `/api/auth/session`).
+- **Gaps:**
+  - **Library mismatch between cockpit (better-auth) and api worker (NextAuth JWE).** Cockpit better-auth doesn't mint NextAuth JWE — the API worker's `decryptAuthJsJwe` will fail on better-auth tokens. Either cockpit needs to mint compatible tokens, or API worker needs better-auth bearer support, or service should use shared session cookie via D1.
+  - `agents.md` says NextAuth v5 — stale (cockpit is better-auth).
+  - Worker secret `AUTH_SECRET` must match cockpit's `BETTER_AUTH_SECRET` for JWE roundtrip.
+- **Status:** PARTIAL — auth scaffolding present; cross-service token format likely incompatible. Verify with live test.
+
+### significanthobbies
+- **Classification:** needs-user-auth (timeline/journal per user)
+- **Provider:** **better-auth** + Drizzle adapter (Turso). `agents.md` claims **NextAuth v4 + @auth/drizzle-adapter** — stale; code is better-auth.
+- **Routes:** `src/app/api/auth/[...all]/route.ts` + `src/middleware.ts`.
+- **DB:** Turso. Schema `src/db/schema.ts` defines `User`/`Session`/`Account`/`VerificationToken` (NextAuth-style PascalCase) — **mismatch with better-auth defaults** (`user`/`session`/`account`/`verification`).
+- **Env vars:** `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `TURSO_AUTH_TOKEN` — present.
+- **Smoke test:** `significanthobbies.com` — DNS unresolved. App routes are configured for `significanthobbies.com/*` and `www.significanthobbies.com/*` per `wrangler.toml`.
+- **Gaps:**
+  - Schema names PascalCase (`User`/`Session`) — better-auth expects lowercase. **Schema mismatch likely → first sign-in 500.**
+  - No `schema:` mapping passed to `drizzleAdapter`.
+  - `agents.md` stale (NextAuth → better-auth).
+- **Status:** PARTIAL (likely BROKEN once tested)
+
+### starboard
+- **Classification:** needs-user-auth (per-user starred repos)
+- **Provider:** **NextAuth v5 beta** (GitHub provider only, `read:user` scope). Stateless — no DB adapter; user upsert into raw Turso `users` table inside `signIn` callback.
+- **Routes:** `src/app/api/auth/*` (NextAuth handler).
+- **DB:** Turso, raw SQL (no Drizzle). Schema in `src/db/schema.sql` (6 tables).
+- **Env vars:** `GITHUB_ID`, `GITHUB_SECRET`, `NEXTAUTH_SECRET`, `NEXTAUTH_URL`, `TURSO_AUTH_TOKEN` — present.
+- **Smoke test:** `starboard.vercel.app/` → 200; `/api/auth/session` → 404; `/login` → 404. The 404 on `/api/auth/session` is wrong for NextAuth — should be 200 with empty session JSON. **Auth handler not deployed correctly.**
+- **Gaps:**
+  - **`/api/auth/session` 404** — NextAuth catch-all route either not exported or build issue. Likely `src/app/api/auth/[...nextauth]/route.ts` missing or misnamed (would need `[...all]` for v5 or `[...nextauth]`).
+- **Status:** **BROKEN** (auth route missing/broken on prod)
+
+### swe-interview-prep
+- **Classification:** needs-user-auth (Concepts/FSRS state per user)
+- **Provider:** Google One Tap → custom JWT (`google-auth-library` server-side ID token verify, `jsonwebtoken` for app tokens). No NextAuth/better-auth.
+- **Routes:** Vercel serverless `api/auth/google.mjs`, `api/auth/verify.mjs`.
+- **DB:** Turso, schema auto-init on first server start.
+- **Env vars:** `GOOGLE_CLIENT_ID`, `VITE_GOOGLE_CLIENT_ID`, `JWT_SECRET`, `TURSO_AUTH_TOKEN` — present.
+- **Smoke test:** `swe-interview-prep.vercel.app/` → 404 (DNS resolved, but app deployment 404). App appears down or moved.
+- **Gaps:**
+  - **Deployment 404** — site is not at the assumed Vercel URL. Find live URL.
+  - JWT in localStorage typical pattern — XSS-vulnerable.
+- **Status:** PARTIAL → unknown deploy state
+
+### today-little-log
+- **Classification:** needs-user-auth (personal journal/habits)
+- **Provider:** **better-auth** (Google) via Pages Functions catch-all `functions/api/auth/[[all]].ts`. Drizzle adapter on Turso (libSQL).
+- **Routes:** Pages Function catch-all routing all `/api/auth/*` to better-auth handler.
+- **DB:** Turso (libSQL). Drizzle migrations in `drizzle/migrations/`. Schema in `src/db/schema.ts` defines `user`/`session`/`account`/`verification` (correct).
+- **Env vars:** `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `TURSO_AUTH_TOKEN`, `VITE_BETTER_AUTH_URL` — present.
+- **Smoke test:** `today-little-log.pages.dev/` → 200; `/api/auth/session` → **404**; `/login` → 200; `/api/auth/sign-in/social` → 404.
+- **Gaps:**
+  - **`/api/auth/*` returns 404** — the Pages Function catch-all isn't matching. Possible causes: `[[all]].ts` (double-bracket) syntax issue with current CF Pages routing, or build skipped functions dir, or `_routes.json` excludes `/api/auth/*`.
+  - Migrations exist for scoreboard but I didn't see explicit better-auth migration — schema is in `src/db/schema.ts` but is the better-auth schema applied to remote Turso? Verify.
+- **Status:** PARTIAL (schema OK, route not reachable in prod)
+
+### truehire
+- **Classification:** needs-user-auth (verified candidate profiles)
+- **Provider:** **NextAuth v5 beta** (GitHub only) + `@auth/drizzle-adapter`, database session strategy. Schema correct (`packages/db/src/schema.ts` has `users`/`accounts`/`sessions`/`verificationTokens` matching `DrizzleAdapter` expectations).
+- **Routes:** `apps/web/src/app/api/auth/[...nextauth]/route.ts`.
+- **DB:** Turso (libSQL) via Drizzle. Migrations `packages/db/drizzle/0000-0003`.
+- **Env vars:** `AUTH_SECRET`, `AUTH_URL`, `AUTH_GITHUB_ID`, `AUTH_GITHUB_SECRET`, `GITHUB_API_TOKEN`, `DATABASE_AUTH_TOKEN` — present in root + `apps/web/.dev.vars`. Wrangler doc says secrets via `wrangler secret put`.
+- **Smoke test:** `truehire.sarthakagrawal927.workers.dev/` → **500**; `/api/auth/session` → 500; `/login` → 500; `/api/auth/sign-in/social` → 500. App **down**. `truehire.pages.dev` DNS unresolved.
+- **Gaps:**
+  - **Site 500 on every path.** Likely missing CF Worker secrets (`AUTH_SECRET`, `AUTH_GITHUB_SECRET`, `DATABASE_AUTH_TOKEN`) — they're documented as `wrangler secret put`-provisioned but not verified.
+  - Or NextAuth v5 beta isn't compatible with the OpenNext CF Workers adapter version pinned here.
+  - No D1 binding (uses Turso via DATABASE_URL) — Turso connection failure also possible cause.
+- **Status:** **BROKEN**
+
+## Patterns of breakage observed
+
+### 1. Stale `agents.md` Auth declarations (5 apps)
+- linkchat: claims NextAuth v5; actually better-auth.
+- email-manager: claims NextAuth v4; actually better-auth.
+- resume-tailor: claims NextAuth v4; actually better-auth + custom Turso adapter.
+- significanthobbies: claims NextAuth v4 + drizzle-adapter; actually better-auth.
+- saas-maker: claims NextAuth v5 beta; cockpit uses better-auth, API worker uses Auth.js JWE format. Inconsistent.
+- high-signal: claims NextAuth v5; actual is Cloudflare Access (per active plan 0002).
+
+### 2. Schema name / library mismatch (3+ apps)
+better-auth defaults to singular table names (`user`, `session`, `account`, `verification`). Several apps run better-auth against NextAuth-style tables (`users`, `sessions`, `accounts`):
+- linkchat: plural names, no `schema:` mapping → tables not found → 500.
+- significanthobbies: PascalCase (`User`/`Session`), no `schema:` mapping.
+- mentionpilot: migration `0001_initial.sql` has plural `users`/`sessions`.
+Apps that did this correctly: `today-little-log`, `open-historia`, `saas-maker` (cockpit auth-schema uses singular), `reader` (uses `baSessions`/`baAccounts` aliases with explicit `schema:` mapping).
+
+### 3. Live deployment 500-ing on root (4 apps)
+- linkchat, truehire, resume-tailor, swe-interview-prep — all 500 or 404 on prod, suggesting either missing prod secrets or build/deploy regressions. These were the most-broken setups in the audit.
+
+### 4. `/api/auth/*` 404 in CF Pages/Workers builds (3 apps)
+- mentionpilot, today-little-log, starboard — `/api/auth/session` returns 404 instead of 200-empty-session. Suggests catch-all route isn't being mounted by the CF runtime correctly. Common causes: OpenNext build dropping the dynamic route, `_routes.json` excluding paths, or `[[all]]` vs `[...all]` syntax.
+
+### 5. JWT-in-localStorage (3 apps)
+- agentMode, anime_list, swe-interview-prep all store JWTs in `localStorage` — XSS-vulnerable. Acceptable for MVP/personal but worth noting.
+
+### 6. Stale `.env.example` env vars
+- open-historia: `TURSO_AUTH_TOKEN` listed but app moved to D1.
+- linkchat: `TURSO_AUTH_TOKEN` listed but moved to D1.
+- high-signal: `NEXTAUTH_*` listed but actual is CF Access (`CF_ACCESS_AUD`, `CF_ACCESS_TEAM_DOMAIN`).
+- reader: `.env.example` doesn't list Firebase config vars despite Firebase being the active auth path.
+
+## Prioritized fix list (to maximize working-auth count fastest)
+
+### P0 — completely down, fix first
+1. **linkchat** — site 500-ing on all routes. Likely BETTER_AUTH_SECRET secret missing OR schema mismatch. Diagnose worker logs (`wrangler tail linkchat`) → set secret if missing → fix schema-to-library mapping.
+2. **truehire** — site 500 on all routes. Run `wrangler secret list` against `truehire` worker; set `AUTH_SECRET`, `AUTH_GITHUB_SECRET`, `DATABASE_AUTH_TOKEN` if absent.
+3. **resume-tailor** — Vercel `MIDDLEWARE_INVOCATION_FAILED`. Set `AUTH_SECRET`, `TURSO_AUTH_TOKEN` in Vercel project env.
+
+### P1 — auth wired but `/api/auth/*` 404 (low effort, high value)
+4. **mentionpilot** — investigate why catch-all route isn't matching. Check OpenNext build output. Then fix migration to use better-auth singular table names (or pass `schema:` mapping).
+5. **today-little-log** — same: `[[all]]` vs `[...all]` Pages Functions issue. Confirm function deployed; check `_routes.json`.
+6. **starboard** — `/api/auth/session` 404. Verify `[...nextauth]` route deployed.
+
+### P2 — schema mismatch (will 500 on first sign-in attempt)
+7. **significanthobbies** — pass explicit `schema:` mapping to `drizzleAdapter` (PascalCase tables). Or migrate tables to better-auth defaults.
+8. **email-manager** — create migrations for better-auth tables on `email-manager-auth` D1 (none exist).
+
+### P3 — design / docs cleanup
+9. **saas-maker** — reconcile cockpit (better-auth) vs API worker (Auth.js JWE) token format. Either move API worker to validate better-auth bearer (call `auth.api.getSession`) or have cockpit mint Auth.js-compatible JWE.
+10. **high-signal** — update `agents.md` (CF Access, not NextAuth) and `.env.example` (`CF_ACCESS_AUD`, `CF_ACCESS_TEAM_DOMAIN`). Verify `apps/web/src/app/api/admin/[...path]/route.ts` exists and verifies CF Access JWT.
+11. **reader** — finish Firebase → better-auth migration (or roll back). Currently has both running. (Coordinate with agent acfc91a04d218fd01.)
+12. **open-historia** — find live deploy URL (Vercel says deployment not found). Update `.env.example` (drop Turso vars).
+
+### P4 — security hardening (post-functional)
+13. agentMode / anime_list / swe-interview-prep — move JWTs out of localStorage to httpOnly cookies. Add refresh.
+14. free-ai — implement `GATEWAY_API_KEY` enforcement on `/v1/analytics`.
+
+### Cross-cutting
+- Update all stale `agents.md` Auth sections to reflect actual code (5 apps).
+- Standardize on **better-auth singular table names** across all better-auth apps to avoid schema-mapping bugs.
+- Add `wrangler secret list` verification to `pre-push` hooks for any app declaring `AUTH_SECRET` / `BETTER_AUTH_SECRET`.

--- a/docs/views-runtime-roadmap.md
+++ b/docs/views-runtime-roadmap.md
@@ -1,0 +1,232 @@
+# Views Runtime — Roadmap
+
+Living plan for the `@saas-maker/capability-graph` + `@saas-maker/views-runtime` packages and the surrounding "dynamic interfaces" thesis.
+
+> Each phase is sequenced by what we can verify end-to-end, not by what is most ambitious. Ship narrow, expand only when the prior phase proves itself.
+
+---
+
+## Phase 0 — context
+
+The thesis: software vendors ship typed primitives (entities + capabilities); end users compose their own UIs on top via coding agents. We are building the local-host substrate for that — first as an internal feature in Foundry's cockpit, later as an externalisable runtime.
+
+Three layers we plan to grow into:
+
+1. **Capability graph** — vendor-agnostic typed entity registry (`Email`, `Issue`, `Customer`) with capability-scoped actions.
+2. **Views runtime** — JSON spec → mounted React dashboard, bindings resolved through the graph.
+3. **Authoring surface** — humans + agents emit/edit specs via prompt; specs are forkable, versionable, shareable.
+
+---
+
+## Phase 1 — runtime + graph (✅ shipped this branch)
+
+Two packages under `packages/blocks/views/`:
+
+- `@saas-maker/capability-graph` — entity/capability factories, `CapabilityGraph` class, scope enforcement, Zod-validated args. 15 unit tests.
+- `@saas-maker/views-runtime` — `<ViewRuntime>` component, Zod-validated spec, three default blocks (MetricCard, List, Table) wired to `@saas-maker/ui` shadcn primitives, pluggable block registry, fallback for unknown types. 11 unit tests.
+
+Out of scope intentionally: React grid drag/resize, real-time sync, persistence, sharing, prompt-to-spec.
+
+---
+
+## Phase 2 — proof inside cockpit
+
+**Goal**: prove the runtime can render a real cockpit page without losing fidelity.
+
+**Concrete target**: pick one existing cockpit route. Candidates by ascending coupling:
+
+- `apps/cockpit/src/app/(app)/standards/` — likely simplest; mostly read-only summary cards
+- `apps/cockpit/src/app/(app)/projects/` — fleet projects list
+- `apps/cockpit/src/app/(app)/fleet/` — most complex; includes live monitoring components
+
+Recommended first target: `standards/`. Smallest surface, easiest A/B, lowest risk.
+
+**Steps**:
+
+1. Build a `FleetEntity` set in the graph: `Project`, `Job`, `Standard`. Backed by existing `workers/api` routes (no new endpoints).
+2. Express the chosen page as a `ViewSpec` JSON literal in code (no DB persistence yet).
+3. Render `<ViewRuntime spec={spec} graph={fleetGraph} ctx={...}>` behind a feature flag.
+4. Visual diff old vs new. Iterate until parity.
+5. Promote the runtime route, keep old as fallback for one week.
+
+**Exit criteria**: one cockpit page rendering 100% via runtime, no regressions, no new latency.
+
+**Open decisions before starting**:
+
+- Where does the spec live? Inline TS literal? `views/*.json` file? D1 row?
+- Do we serialize layout coordinates, or let CSS Grid auto-flow?
+- Should fleet entities ship in `@saas-maker/capability-graph`, or in a new `@saas-maker/blocks/views/fleet-providers` package?
+
+---
+
+## Phase 3 — first external integration
+
+**Goal**: prove the graph routes cleanly across two heterogeneous sources.
+
+**Recommended source**: GitHub. Cockpit already integrates with it via better-auth Google → reuse OAuth pattern; entity shape (`Issue`, `PullRequest`, `Repo`) is well-known and stable.
+
+**Steps**:
+
+1. Add `nango` self-hosted (see https://nango.dev) for OAuth + API plumbing. Pick self-host to control cost and avoid an extra SaaS dependency.
+2. New package: `@saas-maker/blocks/views/integrations` (or split per source — `views/integration-github`).
+3. Sync layer: poll on demand v1; webhook subscriptions later.
+4. Provider registers with `graph.provide({ source: 'github', entity: Issue, fetch, actions })`.
+5. Ship one new view: "Cross-repo PR review queue" — joins local fleet's `Project` entity with GitHub `PullRequest`.
+
+**Exit criteria**: a single view spec composes data from two sources (fleet + GitHub) end-to-end, with capability scopes enforced.
+
+**Watch-outs**:
+
+- Token storage: lean on existing better-auth `session` table or a per-source `integration_token` table.
+- Rate limits: GitHub REST is 5,000 req/hr authenticated. Cache aggressively; do not paginate full repos on render.
+- Webhooks: defer until polling proves insufficient.
+
+---
+
+## Phase 4 — prompt-to-tweak loop
+
+**Goal**: a user types "add churn next to MRR" and the runtime updates without a redeploy.
+
+**Constraint**: the LLM must not emit arbitrary JSON. It calls a fixed tool surface that mutates the spec in narrow, validatable ways.
+
+**Tool surface (proposed)**:
+
+```ts
+addBlock({ type, binding?, props?, layout? })
+removeBlock({ id })
+updateBlockProps({ id, props })
+addBinding({ name, entity, source?, filter?, orderBy?, limit? })
+removeBinding({ name })
+moveBlock({ id, x, y, w?, h? })
+setLayout({ layout: 'grid' | 'flex' | 'stack' })
+```
+
+Each tool re-validates the resulting spec via `ViewSpecSchema`. Invalid output → reject without applying.
+
+**Implementation sketch**:
+
+1. New package: `@saas-maker/blocks/views/authoring`.
+2. Wraps `@saas-maker/ai` (already in repo) with the tool definitions above.
+3. Provides a `<SpecTweakComposer>` React component — chat input bound to the active view, applies returned mutations through `setSpec`.
+4. Spec history stored in D1 — every mutation = a new row. User can revert.
+
+**Exit criteria**: at least 5 reasonable English prompts mutate the cockpit's primary view correctly without manual edits, and the diff is reversible.
+
+**Watch-outs**:
+
+- LLM cost per tweak. Cache prior context; pass only the spec + entity registry to the model.
+- Consistent block id generation — let the tool layer assign ids, not the LLM.
+- "Add a chart" requires a Chart block we have not built yet — Phase 4 likely needs Phase 5 to land in parallel.
+
+---
+
+## Phase 5 — block library expansion
+
+We ship three blocks today. We need at least: `Sparkline`, `TimeSeries`, `Kanban`, `ActivityFeed`, `Calendar`, `EntityChip`, `Aggregate` (sum/avg/group), `Filter` (driving multiple blocks).
+
+Decision: build per demand. Every new view should add at most one new block type. If a view requests three new types, the spec is too clever — push back on the requirement first.
+
+Implementation policy:
+
+- Every block must declare its props schema with Zod (currently informal — tighten this).
+- Loading/error/empty states are baked in (already enforced in defaults).
+- Visual style flows from `@saas-maker/ui` and `@saas-maker/tailwind-preset` — no per-block colour decisions.
+
+---
+
+## Phase 6 — persistence + sharing
+
+**Goal**: specs become first-class artifacts with history, ownership, and forking.
+
+**Schema sketch (D1)**:
+
+```sql
+CREATE TABLE view (
+  id TEXT PRIMARY KEY,
+  owner_user_id TEXT NOT NULL,
+  title TEXT NOT NULL,
+  current_version INTEGER NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE TABLE view_version (
+  id TEXT PRIMARY KEY,
+  view_id TEXT NOT NULL REFERENCES view(id),
+  version INTEGER NOT NULL,
+  spec TEXT NOT NULL,            -- JSON
+  authored_by TEXT NOT NULL,     -- user id or 'agent:<model>'
+  created_at INTEGER NOT NULL,
+  UNIQUE(view_id, version)
+);
+
+CREATE TABLE view_install (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  view_id TEXT NOT NULL,
+  forked_from_version_id TEXT,
+  created_at INTEGER NOT NULL
+);
+```
+
+Sharing v1 = a public read-only endpoint that returns the latest spec; the installer forks it client-side. No fancy permissions yet.
+
+**Watch-outs**:
+
+- A shared spec references entities the installer's graph does not have. Runtime must surface "missing entity" errors clearly (currently we only do this for unknown block types).
+- Rendering a stranger's spec means executing their layout config — already safe (declarative). It does not mean executing their JS — we never load JS from specs. Re-confirm this every time someone proposes "let blocks have a script field."
+
+---
+
+## Phase 7 — marketplace + protocol
+
+Probably 18 months out. Only worth doing once Phase 6 has 1k+ active users + at least 3 vendors asking for an external spec.
+
+When the time comes, align with rather than reinvent:
+
+- **MCP Apps** (`https://modelcontextprotocol.io/extensions/apps/overview`) — for vendor capability exposure.
+- **A2UI** (`https://a2ui.org/`) — for declarative UI specs that render natively in the host.
+- **AG-UI** (`https://docs.ag-ui.com/`) — for agent ↔ frontend wire format.
+
+Today's spec format is shaped to be cheap to translate to A2UI later. Do not publish a competing standard until we have the user base to back it.
+
+---
+
+## Cross-cutting concerns
+
+### Security model
+
+The runtime is data-only — specs cannot embed scripts. Capabilities are scoped strings checked on every read and write. As we add sharing, we must still treat any imported spec as untrusted *content*, not untrusted *code*.
+
+### Performance budget
+
+Targets we should hit before Phase 6:
+
+- First paint of a view: <200 ms (excluding network fetches).
+- Binding fetch: parallel, no waterfalls. P95 <500 ms for cached, <2 s cold.
+- Spec mutation round trip: <300 ms (LLM excluded).
+
+### Testing
+
+- Every new block: a happy-dom render test in `@saas-maker/views-runtime/src/__tests__/`.
+- Every new entity provider: a contract test that fetches + invokes through the graph with a faked HTTP layer.
+- Every prompt-tweak tool: a property test that the result still passes `ViewSpecSchema`.
+
+### Naming
+
+`packages/blocks/views/*` is our reservation. New view-related packages go there. Keep `apps/cockpit/` free of runtime internals — only the runtime mounts there.
+
+---
+
+## Decision log (so future-us remembers why)
+
+| Date       | Decision                                                                 | Why                                                                                                                                |
+| ---------- | ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-04-28 | Build inside saas-maker, not a new repo                                  | Cockpit shell, auth, D1, UI lib, hooks, OpenAPI machinery already exist. Saves ~3 weeks of bootstrap and dogfoods immediately.     |
+| 2026-04-28 | Two packages (graph + runtime), not one                                  | Graph has zero React deps — reusable in workers, CLI, agents. Splitting keeps the substrate light.                                 |
+| 2026-04-28 | Spec is JSON, validated by Zod                                           | LLM-emittable, persistable, language-agnostic. Generation cost is JSON-shaped already.                                              |
+| 2026-04-28 | Defer marketplace / signing / sandbox to Phase 7                         | These are right answers but cost months of work. Closed-product first; earn the right to standardise once we have users.            |
+| 2026-04-28 | Use shadcn (`@saas-maker/ui`) for default block UI; no Tremor in v1       | Already in the repo, already styled by `@saas-maker/tailwind-preset`. Adding Tremor would bring a duplicate styling surface.       |
+| 2026-04-28 | Adopt internal protocol shape compatible with MCP / A2UI / AG-UI          | Cheap option value — when one of them wins, we flip a switch instead of rewriting.                                                  |
+
+Append to this table as we go. The "why" is more valuable than the "what."

--- a/docs/widget-roadmap.md
+++ b/docs/widget-roadmap.md
@@ -65,6 +65,7 @@ Granular widget approach: each widget = own published npm package. Apps install 
 ## Deferred / dropped
 
 - `@saas-maker/auth-preset` — **dropped** (was at `packages/blocks/auth-preset/`). Audit showed 0/9 Fleet apps could integrate: D1 was hardcoded but Fleet uses Turso, and the cookie-name change would have logged users out. Each app keeps owning its own better-auth setup.
+- `@saas-maker/wrangler-preset` — **dropped** (was at `packages/tooling/wrangler-preset/`). Wrangler doesn't support `.config.ts` or `$extends`, preset was unbuilt + unpublished, missing critical bindings (limits, triggers, queues, DOs, vectorize, hyperdrive). Net abstraction cost > savings (each repo's wrangler config is mostly project-specific bindings). Future replacement: `fnd fleet check-drift` lint rule that flags stale compat_date / missing observability sampling / missing cpu_ms cap. Pure check, no import.
 - **Future work — auth conventions doc:** instead of a shared preset, write a short doc in `docs/auth-conventions.md` capturing Fleet defaults: better-auth + Google provider, Turso adapter, cookie name + lifetime, session shape, refresh strategy, sign-out flow. Apps copy the snippets they need; no hard runtime dep.
 
 ## Decision pending

--- a/packages/blocks/email/package.json
+++ b/packages/blocks/email/package.json
@@ -23,13 +23,19 @@
     "access": "public"
   },
   "dependencies": {
+    "@react-email/components": "^1.0.12",
+    "@react-email/render": "^2.0.8",
     "@saas-maker/ops": "workspace:*",
-    "nodemailer": "6.9.0"
+    "nodemailer": "6.9.0",
+    "react": "19.2.5",
+    "react-dom": "19.2.5"
   },
   "devDependencies": {
-    "tsup": "8.0.0",
-    "typescript": "6.0.3",
     "@types/node": "25.6.0",
-    "@types/nodemailer": "6.4.0"
+    "@types/nodemailer": "6.4.0",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "tsup": "8.0.0",
+    "typescript": "6.0.3"
   }
 }

--- a/packages/blocks/email/src/index.ts
+++ b/packages/blocks/email/src/index.ts
@@ -1,35 +1,45 @@
 /**
  * @saas-maker/email
  *
- * Lightweight email sending with Resend/SMTP and auto-tracing via @saas-maker/ops.
+ * Lightweight email sending with Cloudflare/Resend/SMTP and auto-tracing via @saas-maker/ops.
+ * Templates are React components rendered via @react-email/render.
  *
  * @example
- * ```ts
+ * ```tsx
  * import { configureEmail, email } from '@saas-maker/email';
+ * import { NewFeedbackEmail } from '@saas-maker/email/templates';
+ * import { renderEmail } from '@saas-maker/email';
+ * import * as React from 'react';
  *
  * configureEmail({
- *   provider: 'resend',
- *   apiKey: env.RESEND_API_KEY,
+ *   provider: 'cloudflare',
+ *   accountId: env.CF_ACCOUNT_ID,
+ *   apiToken: env.CF_EMAIL_API_TOKEN,
  *   from: 'noreply@yourdomain.com',
  * });
  *
- * await email.send({
- *   to: 'user@example.com',
- *   subject: 'Welcome!',
- *   template: 'Hello {{name}}, welcome to {{product}}!',
- *   data: { name: 'Sarthak', product: 'Resume Tailor' },
- * });
+ * const { html, text } = await renderEmail(
+ *   <NewFeedbackEmail projectName="Acme" feedbackTitle="Bug" ... />
+ * );
+ * await email.send({ to: 'user@example.com', subject: 'New feedback', html, text });
  * ```
  */
 
 import { trace } from '@saas-maker/ops';
+import { sendViaCloudflare } from './providers/cloudflare';
 import { sendViaResend } from './providers/resend';
 import { sendViaSmtp } from './providers/smtp';
-import { renderTemplate } from './render';
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
-export type EmailProvider = 'resend' | 'smtp';
+export type EmailProvider = 'cloudflare' | 'resend' | 'smtp';
+
+export interface CloudflareEmailConfig {
+  provider: 'cloudflare';
+  accountId: string;
+  apiToken: string;
+  from: string;
+}
 
 export interface ResendEmailConfig {
   provider: 'resend';
@@ -46,7 +56,7 @@ export interface SmtpEmailConfig {
   from: string;
 }
 
-export type EmailConfig = ResendEmailConfig | SmtpEmailConfig;
+export type EmailConfig = CloudflareEmailConfig | ResendEmailConfig | SmtpEmailConfig;
 
 let _config: EmailConfig | null = null;
 
@@ -68,14 +78,8 @@ function getConfig(): EmailConfig {
 export interface SendOptions {
   to: string | string[];
   subject: string;
-  /** Raw HTML body. If template is provided, this is ignored. */
   html?: string;
-  /** Plain text body. */
   text?: string;
-  /** Template string with {{variable}} placeholders. Rendered with `data`. */
-  template?: string;
-  /** Data to interpolate into template. */
-  data?: Record<string, unknown>;
   replyTo?: string;
   cc?: string | string[];
   bcc?: string | string[];
@@ -94,15 +98,10 @@ async function sendOne(options: SendOptions): Promise<SendResult> {
   const config = getConfig();
   const project = options.project ?? 'email';
 
-  // Render template if provided
-  const html = options.template
-    ? renderTemplate(options.template, options.data ?? {})
-    : options.html;
-
   const params = {
     to: options.to,
     subject: options.subject,
-    html,
+    html: options.html,
     text: options.text,
     replyTo: options.replyTo,
     cc: options.cc,
@@ -112,6 +111,9 @@ async function sendOne(options: SendOptions): Promise<SendResult> {
   return trace(
     `email:send:${project}`,
     async () => {
+      if (config.provider === 'cloudflare') {
+        return sendViaCloudflare(config, params);
+      }
       if (config.provider === 'resend') {
         return sendViaResend({ apiKey: config.apiKey, from: config.from }, params);
       }
@@ -132,4 +134,8 @@ export const email = {
   batch: sendBatch,
 };
 
-export { renderTemplate } from './render';
+export { renderEmail } from './render';
+export { NewFeedbackEmail } from './templates/NewFeedback';
+export type { NewFeedbackEmailProps } from './templates/NewFeedback';
+export { WaitlistSignupEmail } from './templates/WaitlistSignup';
+export type { WaitlistSignupEmailProps } from './templates/WaitlistSignup';

--- a/packages/blocks/email/src/providers/cloudflare.ts
+++ b/packages/blocks/email/src/providers/cloudflare.ts
@@ -1,0 +1,68 @@
+/**
+ * Cloudflare Email Service provider — transactional email via REST API.
+ * Docs: https://developers.cloudflare.com/email-service/
+ */
+
+export interface CloudflareEmailConfig {
+  accountId: string;
+  apiToken: string;
+  from: string;
+}
+
+export interface SendParams {
+  to: string | string[];
+  subject: string;
+  html?: string;
+  text?: string;
+  replyTo?: string;
+  cc?: string | string[];
+  bcc?: string | string[];
+}
+
+export interface SendResult {
+  id: string;
+  provider: 'cloudflare';
+}
+
+function toArray(v: string | string[] | undefined): string[] | undefined {
+  if (!v) return undefined;
+  return Array.isArray(v) ? v : [v];
+}
+
+export async function sendViaCloudflare(
+  config: CloudflareEmailConfig,
+  params: SendParams
+): Promise<SendResult> {
+  const body: Record<string, unknown> = {
+    from: { address: config.from },
+    to: toArray(params.to)!.map((address) => ({ address })),
+    subject: params.subject,
+  };
+
+  if (params.html) body.html = params.html;
+  if (params.text) body.text = params.text;
+  if (params.replyTo) body.reply_to = { address: params.replyTo };
+  if (params.cc) body.cc = toArray(params.cc)!.map((address) => ({ address }));
+  if (params.bcc) body.bcc = toArray(params.bcc)!.map((address) => ({ address }));
+
+  const res = await fetch(
+    `https://api.cloudflare.com/client/v4/accounts/${config.accountId}/email/sending/send`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${config.apiToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    }
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Cloudflare Email error ${res.status}: ${text}`);
+  }
+
+  const data = (await res.json()) as { result?: { id?: string } };
+  const id = data.result?.id ?? crypto.randomUUID();
+  return { id, provider: 'cloudflare' };
+}

--- a/packages/blocks/email/src/render.ts
+++ b/packages/blocks/email/src/render.ts
@@ -1,22 +1,12 @@
-/**
- * Simple {{variable}} template renderer.
- * No dependencies — just string interpolation.
- */
-export function renderTemplate(template: string, data: Record<string, unknown>): string {
-  return template.replace(/\{\{(\s*[\w.]+\s*)\}\}/g, (_match, key: string) => {
-    const trimmed = key.trim();
-    const value = trimmed.split('.').reduce<unknown>((obj, part) => {
-      if (obj && typeof obj === 'object') return (obj as Record<string, unknown>)[part];
-      return undefined;
-    }, data as unknown);
-    return value != null ? String(value) : '';
-  });
-}
+import { render } from '@react-email/render';
+import * as React from 'react';
 
-export function renderHtml(template: string, data: Record<string, unknown>): string {
-  return renderTemplate(template, data);
-}
-
-export function renderText(template: string, data: Record<string, unknown>): string {
-  return renderTemplate(template, data);
+export async function renderEmail(
+  component: React.ReactElement
+): Promise<{ html: string; text: string }> {
+  const [html, text] = await Promise.all([
+    render(component),
+    render(component, { plainText: true }),
+  ]);
+  return { html, text };
 }

--- a/packages/blocks/email/src/templates/NewFeedback.tsx
+++ b/packages/blocks/email/src/templates/NewFeedback.tsx
@@ -1,0 +1,118 @@
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Preview,
+  Section,
+  Text,
+} from '@react-email/components';
+import * as React from 'react';
+
+export interface NewFeedbackEmailProps {
+  projectName: string;
+  feedbackTitle: string;
+  feedbackType: string;
+  feedbackDescription: string;
+  submitterEmail: string;
+  dashboardUrl: string;
+}
+
+export function NewFeedbackEmail({
+  projectName,
+  feedbackTitle,
+  feedbackType,
+  feedbackDescription,
+  submitterEmail,
+  dashboardUrl,
+}: NewFeedbackEmailProps) {
+  return (
+    <Html>
+      <Head />
+      <Preview>
+        New {feedbackType} on {projectName}: {feedbackTitle}
+      </Preview>
+      <Body style={body}>
+        <Container style={container}>
+          <Heading style={h1}>
+            New {feedbackType} on {projectName}
+          </Heading>
+          <Text style={label}>Title</Text>
+          <Text style={value}>{feedbackTitle}</Text>
+          <Text style={label}>Description</Text>
+          <Text style={value}>{feedbackDescription}</Text>
+          <Hr style={hr} />
+          <Text style={meta}>Submitted by {submitterEmail}</Text>
+          <Section style={btnSection}>
+            <Button href={dashboardUrl} style={btn}>
+              View in Dashboard
+            </Button>
+          </Section>
+        </Container>
+      </Body>
+    </Html>
+  );
+}
+
+const body: React.CSSProperties = {
+  backgroundColor: '#f5f5f5',
+  fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+};
+
+const container: React.CSSProperties = {
+  backgroundColor: '#ffffff',
+  margin: '40px auto',
+  padding: '32px',
+  borderRadius: '8px',
+  maxWidth: '600px',
+};
+
+const h1: React.CSSProperties = {
+  fontSize: '20px',
+  fontWeight: '600',
+  color: '#111',
+  marginBottom: '24px',
+};
+
+const label: React.CSSProperties = {
+  fontSize: '12px',
+  fontWeight: '600',
+  color: '#666',
+  textTransform: 'uppercase',
+  letterSpacing: '0.05em',
+  margin: '0 0 4px',
+};
+
+const value: React.CSSProperties = {
+  fontSize: '15px',
+  color: '#222',
+  margin: '0 0 20px',
+};
+
+const hr: React.CSSProperties = {
+  borderColor: '#eee',
+  margin: '24px 0',
+};
+
+const meta: React.CSSProperties = {
+  fontSize: '13px',
+  color: '#888',
+};
+
+const btnSection: React.CSSProperties = {
+  marginTop: '24px',
+};
+
+const btn: React.CSSProperties = {
+  display: 'inline-block',
+  padding: '10px 20px',
+  backgroundColor: '#1464ff',
+  color: '#ffffff',
+  borderRadius: '8px',
+  fontSize: '14px',
+  fontWeight: '500',
+  textDecoration: 'none',
+};

--- a/packages/blocks/email/src/templates/WaitlistSignup.tsx
+++ b/packages/blocks/email/src/templates/WaitlistSignup.tsx
@@ -1,0 +1,104 @@
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Preview,
+  Section,
+  Text,
+} from '@react-email/components';
+import * as React from 'react';
+
+export interface WaitlistSignupEmailProps {
+  projectName: string;
+  signupEmail: string;
+  signupName?: string;
+  dashboardUrl: string;
+}
+
+export function WaitlistSignupEmail({
+  projectName,
+  signupEmail,
+  signupName,
+  dashboardUrl,
+}: WaitlistSignupEmailProps) {
+  const display = signupName ? `${signupName} (${signupEmail})` : signupEmail;
+
+  return (
+    <Html>
+      <Head />
+      <Preview>New waitlist signup for {projectName}</Preview>
+      <Body style={body}>
+        <Container style={container}>
+          <Heading style={h1}>New waitlist signup on {projectName}</Heading>
+          <Text style={label}>Signed up</Text>
+          <Text style={value}>{display}</Text>
+          <Hr style={hr} />
+          <Section style={btnSection}>
+            <Button href={dashboardUrl} style={btn}>
+              View Waitlist
+            </Button>
+          </Section>
+        </Container>
+      </Body>
+    </Html>
+  );
+}
+
+const body: React.CSSProperties = {
+  backgroundColor: '#f5f5f5',
+  fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+};
+
+const container: React.CSSProperties = {
+  backgroundColor: '#ffffff',
+  margin: '40px auto',
+  padding: '32px',
+  borderRadius: '8px',
+  maxWidth: '600px',
+};
+
+const h1: React.CSSProperties = {
+  fontSize: '20px',
+  fontWeight: '600',
+  color: '#111',
+  marginBottom: '24px',
+};
+
+const label: React.CSSProperties = {
+  fontSize: '12px',
+  fontWeight: '600',
+  color: '#666',
+  textTransform: 'uppercase',
+  letterSpacing: '0.05em',
+  margin: '0 0 4px',
+};
+
+const value: React.CSSProperties = {
+  fontSize: '15px',
+  color: '#222',
+  margin: '0 0 20px',
+};
+
+const hr: React.CSSProperties = {
+  borderColor: '#eee',
+  margin: '24px 0',
+};
+
+const btnSection: React.CSSProperties = {
+  marginTop: '24px',
+};
+
+const btn: React.CSSProperties = {
+  display: 'inline-block',
+  padding: '10px 20px',
+  backgroundColor: '#1464ff',
+  color: '#ffffff',
+  borderRadius: '8px',
+  fontSize: '14px',
+  fontWeight: '500',
+  textDecoration: 'none',
+};

--- a/packages/blocks/email/tsconfig.json
+++ b/packages/blocks/email/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "ignoreDeprecations": "6.0",
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "jsx": "react-jsx"
   },
   "include": ["src"]
 }

--- a/packages/blocks/views/capability-graph/README.md
+++ b/packages/blocks/views/capability-graph/README.md
@@ -1,0 +1,54 @@
+# @saas-maker/capability-graph
+
+Typed entity + capability registry for the views runtime.
+
+Sources register entities they provide; views declare entities they need. The graph mediates: enforces scopes, routes queries, validates action arguments.
+
+## Usage
+
+```ts
+import { z } from 'zod';
+import { createGraph, entity, capability } from '@saas-maker/capability-graph';
+
+const Email = entity({
+  id: 'email',
+  fields: {
+    id: z.string(),
+    subject: z.string(),
+    isRead: z.boolean(),
+  },
+  actions: {
+    archive: capability('email:write'),
+  },
+});
+
+const graph = createGraph().provide({
+  source: 'gmail',
+  entity: Email,
+  async fetch(_ctx, opts) {
+    // call Gmail API, return rows matching Email schema
+    return [{ id: '1', subject: 'hi', isRead: false }];
+  },
+  actions: {
+    archive: async (_ctx, _args) => true,
+  },
+});
+
+const ctx = { scopes: new Set(['email:read', 'email:write']) };
+const inbox = await graph.query({ entityId: 'email' }, ctx);
+await graph.invoke({ entityId: 'email', action: 'archive', args: undefined }, ctx);
+```
+
+## Concepts
+
+- **Entity**: a vendor-agnostic shape (Email, Issue, Customer). Fields = Zod schemas. Actions = capability declarations.
+- **Capability**: a declared scope plus optional Zod-validated args.
+- **Provider**: a source (e.g. `gmail`) registering it can fetch entity data and run actions.
+- **Graph**: runtime registry that enforces scopes and routes calls.
+
+## Scope convention
+
+- Reads: `<entityId>:read` (e.g. `email:read`)
+- Writes: declared per-action (e.g. `email:write`)
+
+The graph rejects calls if `ctx.scopes` does not include the required scope.

--- a/packages/blocks/views/capability-graph/package.json
+++ b/packages/blocks/views/capability-graph/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@saas-maker/capability-graph",
+  "version": "0.1.0",
+  "description": "Typed entity + capability registry. Sources register entities they provide; views declare entities they need.",
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist"
+  ],
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "zod": "4.1.13"
+  },
+  "devDependencies": {
+    "@saas-maker/tsconfig": "workspace:*",
+    "tsup": "8.0.0",
+    "typescript": "6.0.3",
+    "vitest": "4.1.5"
+  }
+}

--- a/packages/blocks/views/capability-graph/src/__tests__/entity.test.ts
+++ b/packages/blocks/views/capability-graph/src/__tests__/entity.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { capability, entity } from '../entity.js';
+
+describe('entity()', () => {
+  it('creates an entity with schema and default empty actions', () => {
+    const Email = entity({
+      id: 'email',
+      fields: {
+        id: z.string(),
+        subject: z.string(),
+      },
+    });
+
+    expect(Email.id).toBe('email');
+    expect(Email.actions).toEqual({});
+    const parsed = Email.schema.safeParse({ id: 'a', subject: 'hi' });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('rejects invalid records via schema', () => {
+    const Issue = entity({
+      id: 'issue',
+      fields: { id: z.string(), title: z.string() },
+    });
+    const result = Issue.schema.safeParse({ id: 1 });
+    expect(result.success).toBe(false);
+  });
+
+  it('attaches actions with capability scopes', () => {
+    const Email = entity({
+      id: 'email',
+      fields: { id: z.string() },
+      actions: {
+        archive: capability('email:write'),
+        label: capability('email:write', z.object({ name: z.string() })),
+      },
+    });
+    expect(Email.actions['archive']?.scope).toBe('email:write');
+    expect(Email.actions['label']?.args).toBeDefined();
+  });
+});
+
+describe('capability()', () => {
+  it('omits args when not provided', () => {
+    const cap = capability('email:read');
+    expect(cap.args).toBeUndefined();
+  });
+});

--- a/packages/blocks/views/capability-graph/src/__tests__/graph.test.ts
+++ b/packages/blocks/views/capability-graph/src/__tests__/graph.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { capability, entity } from '../entity.js';
+import { createGraph } from '../graph.js';
+import {
+  MissingScopeError,
+  UnknownActionError,
+  UnknownEntityError,
+  UnknownSourceError,
+} from '../errors.js';
+
+const Email = entity({
+  id: 'email',
+  fields: {
+    id: z.string(),
+    subject: z.string(),
+    isRead: z.boolean(),
+  },
+  actions: {
+    archive: capability('email:write'),
+    label: capability('email:write', z.object({ name: z.string() })),
+  },
+});
+
+function ctx(scopes: string[]): { scopes: ReadonlySet<string> } {
+  return { scopes: new Set(scopes) };
+}
+
+describe('CapabilityGraph', () => {
+  it('registers an entity without a provider', () => {
+    const g = createGraph();
+    g.register(Email);
+    expect(g.entities()).toContain('email');
+    expect(g.providersFor('email')).toEqual([]);
+  });
+
+  it('throws UnknownEntityError when querying a non-registered entity', async () => {
+    const g = createGraph();
+    await expect(g.query({ entityId: 'unknown' }, ctx(['unknown:read']))).rejects.toBeInstanceOf(
+      UnknownEntityError,
+    );
+  });
+
+  it('routes a query to the registered provider with read scope', async () => {
+    const g = createGraph();
+    const fetch = vi.fn().mockResolvedValue([{ id: 'a', subject: 'hi', isRead: false }]);
+    g.provide({ source: 'gmail', entity: Email, fetch });
+
+    const result = await g.query({ entityId: 'email' }, ctx(['email:read']));
+
+    expect(fetch).toHaveBeenCalledOnce();
+    expect(result).toHaveLength(1);
+  });
+
+  it('rejects query without read scope', async () => {
+    const g = createGraph();
+    g.provide({ source: 'gmail', entity: Email, fetch: vi.fn() });
+    await expect(g.query({ entityId: 'email' }, ctx([]))).rejects.toBeInstanceOf(MissingScopeError);
+  });
+
+  it('honours pinned source when multiple providers exist', async () => {
+    const g = createGraph();
+    const gmailFetch = vi.fn().mockResolvedValue([{ id: 'g' }]);
+    const outlookFetch = vi.fn().mockResolvedValue([{ id: 'o' }]);
+    g.provide({ source: 'gmail', entity: Email, fetch: gmailFetch });
+    g.provide({ source: 'outlook', entity: Email, fetch: outlookFetch });
+
+    const result = await g.query({ entityId: 'email', source: 'outlook' }, ctx(['email:read']));
+
+    expect(outlookFetch).toHaveBeenCalled();
+    expect(gmailFetch).not.toHaveBeenCalled();
+    expect(result[0]).toEqual({ id: 'o' });
+  });
+
+  it('throws UnknownSourceError when pinning non-registered source', async () => {
+    const g = createGraph();
+    g.provide({ source: 'gmail', entity: Email, fetch: vi.fn() });
+    await expect(
+      g.query({ entityId: 'email', source: 'nope' }, ctx(['email:read'])),
+    ).rejects.toBeInstanceOf(UnknownSourceError);
+  });
+
+  it('invokes a declared action with declared scope', async () => {
+    const g = createGraph();
+    const archive = vi.fn().mockResolvedValue(true);
+    g.provide({
+      source: 'gmail',
+      entity: Email,
+      fetch: vi.fn(),
+      actions: { archive },
+    });
+
+    const result = await g.invoke(
+      { entityId: 'email', action: 'archive', args: undefined },
+      ctx(['email:write']),
+    );
+
+    expect(archive).toHaveBeenCalled();
+    expect(result).toBe(true);
+  });
+
+  it('rejects invoke without required scope', async () => {
+    const g = createGraph();
+    g.provide({
+      source: 'gmail',
+      entity: Email,
+      fetch: vi.fn(),
+      actions: { archive: vi.fn() },
+    });
+    await expect(
+      g.invoke({ entityId: 'email', action: 'archive', args: undefined }, ctx(['email:read'])),
+    ).rejects.toBeInstanceOf(MissingScopeError);
+  });
+
+  it('throws UnknownActionError for unregistered action', async () => {
+    const g = createGraph();
+    g.provide({ source: 'gmail', entity: Email, fetch: vi.fn(), actions: {} });
+    await expect(
+      g.invoke({ entityId: 'email', action: 'archive', args: undefined }, ctx(['email:write'])),
+    ).rejects.toBeInstanceOf(UnknownActionError);
+  });
+
+  it('validates action args via zod', async () => {
+    const g = createGraph();
+    const label = vi.fn().mockResolvedValue(true);
+    g.provide({
+      source: 'gmail',
+      entity: Email,
+      fetch: vi.fn(),
+      actions: { label },
+    });
+
+    await expect(
+      g.invoke(
+        { entityId: 'email', action: 'label', args: { wrong: 1 } },
+        ctx(['email:write']),
+      ),
+    ).rejects.toThrow(/Invalid args/);
+    expect(label).not.toHaveBeenCalled();
+  });
+
+  it('resolves without executing — returns fetch + actions', () => {
+    const g = createGraph();
+    const fetch = vi.fn();
+    const archive = vi.fn();
+    g.provide({ source: 'gmail', entity: Email, fetch, actions: { archive } });
+
+    const r = g.resolve('email');
+    expect(r.source).toBe('gmail');
+    expect(r.fetch).toBe(fetch);
+    expect(r.actions['archive']).toBe(archive);
+  });
+});

--- a/packages/blocks/views/capability-graph/src/entity.ts
+++ b/packages/blocks/views/capability-graph/src/entity.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+import type { CapabilityDef, EntityActions, EntityDef, EntityFields } from './types.js';
+
+export interface DefineEntityInput<TFields extends EntityFields, TActions extends EntityActions> {
+  id: string;
+  fields: TFields;
+  actions?: TActions;
+}
+
+/**
+ * Define a vendor-agnostic entity. Sources later register that they provide
+ * data for this entity shape.
+ */
+export function entity<TFields extends EntityFields, TActions extends EntityActions = EntityActions>(
+  input: DefineEntityInput<TFields, TActions>,
+): EntityDef<TFields, TActions> {
+  return {
+    id: input.id,
+    fields: input.fields,
+    actions: (input.actions ?? {}) as TActions,
+    schema: z.object(input.fields),
+  };
+}
+
+/**
+ * Helper for declaring an action capability on an entity.
+ */
+export function capability<TArgs extends z.ZodTypeAny = z.ZodNever>(
+  scope: string,
+  args?: TArgs,
+): CapabilityDef<TArgs> {
+  const def: CapabilityDef<TArgs> = { scope };
+  if (args) def.args = args;
+  return def;
+}

--- a/packages/blocks/views/capability-graph/src/errors.ts
+++ b/packages/blocks/views/capability-graph/src/errors.ts
@@ -1,0 +1,34 @@
+export class CapabilityError extends Error {
+  readonly code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = 'CapabilityError';
+    this.code = code;
+  }
+}
+
+export class MissingScopeError extends CapabilityError {
+  readonly required: string;
+  constructor(required: string) {
+    super('MISSING_SCOPE', `Missing required scope: ${required}`);
+    this.required = required;
+  }
+}
+
+export class UnknownEntityError extends CapabilityError {
+  constructor(entityId: string) {
+    super('UNKNOWN_ENTITY', `No provider registered for entity: ${entityId}`);
+  }
+}
+
+export class UnknownSourceError extends CapabilityError {
+  constructor(source: string, entityId: string) {
+    super('UNKNOWN_SOURCE', `Source "${source}" does not provide entity "${entityId}"`);
+  }
+}
+
+export class UnknownActionError extends CapabilityError {
+  constructor(entityId: string, action: string) {
+    super('UNKNOWN_ACTION', `Entity "${entityId}" has no action "${action}"`);
+  }
+}

--- a/packages/blocks/views/capability-graph/src/graph.ts
+++ b/packages/blocks/views/capability-graph/src/graph.ts
@@ -1,0 +1,135 @@
+import type {
+  ActionHandler,
+  EntityDef,
+  EntityFetcher,
+  ProviderContext,
+  ProviderRegistration,
+  QueryOptions,
+  ResolveResult,
+  Scope,
+} from './types.js';
+import {
+  MissingScopeError,
+  UnknownActionError,
+  UnknownEntityError,
+  UnknownSourceError,
+} from './errors.js';
+
+interface EntityRegistry {
+  entity: EntityDef;
+  providers: Map<string, ProviderRegistration>;
+}
+
+export interface QueryArgs {
+  source?: string;
+  entityId: string;
+  options?: QueryOptions;
+}
+
+export interface InvokeArgs<TArgs = unknown> {
+  source?: string;
+  entityId: string;
+  action: string;
+  args: TArgs;
+}
+
+/**
+ * Runtime registry mapping entity IDs to providers. Sources register the
+ * entities they expose; views and runtime ask the graph to resolve them.
+ */
+export class CapabilityGraph {
+  private readonly entries = new Map<string, EntityRegistry>();
+
+  /** Register an entity definition. Idempotent — re-registering same id is a no-op. */
+  register(entity: EntityDef): this {
+    if (!this.entries.has(entity.id)) {
+      this.entries.set(entity.id, { entity, providers: new Map() });
+    }
+    return this;
+  }
+
+  /** A provider declares it can supply an entity. Auto-registers the entity. */
+  provide(registration: ProviderRegistration): this {
+    this.register(registration.entity);
+    const reg = this.entries.get(registration.entity.id)!;
+    reg.providers.set(registration.source, registration);
+    return this;
+  }
+
+  /** List all registered entity ids. */
+  entities(): string[] {
+    return Array.from(this.entries.keys());
+  }
+
+  /** List sources that provide a given entity. */
+  providersFor(entityId: string): string[] {
+    return Array.from(this.entries.get(entityId)?.providers.keys() ?? []);
+  }
+
+  /** Resolve which provider to use. Errors if entity unknown. */
+  private locate(entityId: string, source?: string): ProviderRegistration {
+    const reg = this.entries.get(entityId);
+    if (!reg || reg.providers.size === 0) {
+      throw new UnknownEntityError(entityId);
+    }
+    if (source) {
+      const provider = reg.providers.get(source);
+      if (!provider) throw new UnknownSourceError(source, entityId);
+      return provider;
+    }
+    // No source pinned — return first registered. Stable order = insertion order.
+    const first = reg.providers.values().next().value;
+    if (!first) throw new UnknownEntityError(entityId);
+    return first;
+  }
+
+  /** Resolve a binding to a callable fetch + action handlers (no execution yet). */
+  resolve(entityId: string, source?: string): ResolveResult {
+    const provider = this.locate(entityId, source);
+    return {
+      source: provider.source,
+      fetch: provider.fetch,
+      actions: provider.actions ?? {},
+    };
+  }
+
+  /** Execute a query through the registered provider. Enforces scopes. */
+  async query<T = unknown>(
+    args: QueryArgs,
+    ctx: ProviderContext,
+  ): Promise<T[]> {
+    const provider = this.locate(args.entityId, args.source);
+    // Read scope convention: `<entityId>:read` (e.g. `email:read`)
+    const required: Scope = `${args.entityId}:read`;
+    if (!ctx.scopes.has(required)) throw new MissingScopeError(required);
+    const fetch = provider.fetch as EntityFetcher;
+    const result = await fetch(ctx, args.options ?? {});
+    return result as T[];
+  }
+
+  /** Execute an action through the registered provider. Enforces declared scope. */
+  async invoke<T = unknown>(
+    args: InvokeArgs,
+    ctx: ProviderContext,
+  ): Promise<T> {
+    const provider = this.locate(args.entityId, args.source);
+    const actionDef = provider.entity.actions[args.action];
+    if (!actionDef) throw new UnknownActionError(args.entityId, args.action);
+    if (!ctx.scopes.has(actionDef.scope)) throw new MissingScopeError(actionDef.scope);
+    const handler = provider.actions?.[args.action] as ActionHandler | undefined;
+    if (!handler) throw new UnknownActionError(args.entityId, args.action);
+    if (actionDef.args) {
+      const parsed = actionDef.args.safeParse(args.args);
+      if (!parsed.success) {
+        throw new Error(`Invalid args for ${args.entityId}.${args.action}: ${parsed.error.message}`);
+      }
+      return (await handler(ctx, parsed.data)) as T;
+    }
+    return (await handler(ctx, args.args)) as T;
+  }
+}
+
+/** Convenience helper for tests / single-use graphs. */
+export function createGraph(): CapabilityGraph {
+  return new CapabilityGraph();
+}

--- a/packages/blocks/views/capability-graph/src/index.ts
+++ b/packages/blocks/views/capability-graph/src/index.ts
@@ -1,0 +1,25 @@
+export { entity, capability } from './entity.js';
+export { CapabilityGraph, createGraph } from './graph.js';
+export {
+  CapabilityError,
+  MissingScopeError,
+  UnknownActionError,
+  UnknownEntityError,
+  UnknownSourceError,
+} from './errors.js';
+export type {
+  ActionHandler,
+  CapabilityDef,
+  EntityActions,
+  EntityDef,
+  EntityFetcher,
+  EntityFields,
+  InferEntity,
+  ProviderContext,
+  ProviderRegistration,
+  QueryOptions,
+  ResolveResult,
+  Scope,
+} from './types.js';
+export type { DefineEntityInput } from './entity.js';
+export type { InvokeArgs, QueryArgs } from './graph.js';

--- a/packages/blocks/views/capability-graph/src/types.ts
+++ b/packages/blocks/views/capability-graph/src/types.ts
@@ -1,0 +1,59 @@
+import type { z } from 'zod';
+
+export type Scope = string;
+
+export interface CapabilityDef<TArgs extends z.ZodTypeAny = z.ZodTypeAny> {
+  scope: Scope;
+  args?: TArgs;
+}
+
+export type EntityFields = Record<string, z.ZodTypeAny>;
+export type EntityActions = Record<string, CapabilityDef>;
+
+export interface EntityDef<
+  TFields extends EntityFields = EntityFields,
+  TActions extends EntityActions = EntityActions,
+> {
+  id: string;
+  fields: TFields;
+  actions: TActions;
+  schema: z.ZodObject<TFields>;
+}
+
+export type InferEntity<T> = T extends EntityDef<infer F, EntityActions>
+  ? z.infer<z.ZodObject<F>>
+  : never;
+
+export interface QueryOptions {
+  filter?: Record<string, unknown>;
+  orderBy?: { field: string; dir: 'asc' | 'desc' };
+  limit?: number;
+}
+
+export interface ProviderContext {
+  scopes: ReadonlySet<Scope>;
+  signal?: AbortSignal;
+}
+
+export type EntityFetcher<TEntity extends EntityDef = EntityDef> = (
+  ctx: ProviderContext,
+  opts: QueryOptions,
+) => Promise<Array<InferEntity<TEntity>>>;
+
+export type ActionHandler<TArgs = unknown> = (
+  ctx: ProviderContext,
+  args: TArgs,
+) => Promise<unknown>;
+
+export interface ProviderRegistration {
+  source: string;
+  entity: EntityDef;
+  fetch: EntityFetcher;
+  actions?: Record<string, ActionHandler>;
+}
+
+export interface ResolveResult {
+  source: string;
+  fetch: EntityFetcher;
+  actions: Record<string, ActionHandler>;
+}

--- a/packages/blocks/views/capability-graph/tsconfig.json
+++ b/packages/blocks/views/capability-graph/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@saas-maker/tsconfig/base.json",
+  "compilerOptions": {
+    "ignoreDeprecations": "6.0",
+    "outDir": "./dist",
+    "noEmit": false
+  },
+  "include": ["src"]
+}

--- a/packages/blocks/views/capability-graph/tsup.config.ts
+++ b/packages/blocks/views/capability-graph/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  outExtension({ format }) {
+    return { js: format === 'esm' ? '.mjs' : '.js' };
+  },
+  dts: { compilerOptions: { ignoreDeprecations: '6.0' } },
+  clean: true,
+  minify: true,
+  sourcemap: true,
+});

--- a/packages/blocks/views/capability-graph/vitest.config.ts
+++ b/packages/blocks/views/capability-graph/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+    environment: 'node',
+  },
+});

--- a/packages/blocks/views/runtime/README.md
+++ b/packages/blocks/views/runtime/README.md
@@ -1,0 +1,66 @@
+# @saas-maker/views-runtime
+
+JSON spec → mounted React dashboard. Resolves bindings via `@saas-maker/capability-graph`.
+
+## Quickstart
+
+```tsx
+import { z } from 'zod';
+import { createGraph, entity } from '@saas-maker/capability-graph';
+import { ViewRuntime } from '@saas-maker/views-runtime';
+
+const Issue = entity({
+  id: 'issue',
+  fields: { id: z.string(), title: z.string(), status: z.string(), points: z.number() },
+});
+
+const graph = createGraph().provide({
+  source: 'linear',
+  entity: Issue,
+  fetch: async () => [{ id: '1', title: 'Fix login', status: 'open', points: 3 }],
+});
+
+const spec = {
+  id: 'sprint',
+  title: 'Sprint health',
+  bindings: { open: { entity: 'issue' } },
+  blocks: [
+    {
+      id: 'velocity',
+      type: 'MetricCard',
+      binding: 'open',
+      props: { label: 'Story points', field: 'points', aggregate: 'sum' },
+    },
+    {
+      id: 'list',
+      type: 'List',
+      binding: 'open',
+      props: { title: 'Open issues', primary: 'title', secondary: 'status' },
+    },
+  ],
+};
+
+export function Sprint() {
+  return <ViewRuntime spec={spec} graph={graph} ctx={{ scopes: new Set(['issue:read']) }} />;
+}
+```
+
+## Built-in blocks
+
+| Type         | Props                                           | Description                                         |
+| ------------ | ----------------------------------------------- | --------------------------------------------------- |
+| `MetricCard` | `label, field, aggregate, format, prefix, suffix` | One number aggregated across rows                   |
+| `List`       | `title, primary, secondary, meta, emptyText`    | Vertical list with two text columns + meta          |
+| `Table`      | `title, columns: [{ field, label, align }]`     | Plain table; values formatted by primitive type     |
+
+Pass a custom `blocks` map to `<ViewRuntime>` to register your own block types.
+
+## Spec shape
+
+See `spec.ts` — `ViewSpecSchema`. Highlights:
+
+- `bindings`: map of name → `{ entity, source?, filter?, orderBy?, limit? }`
+- `blocks`: array of `{ id, type, binding?, props?, layout? }`
+- `layout`: `'grid' | 'flex' | 'stack'`
+
+The runtime validates incoming spec with Zod and renders an error card on failure — useful when an LLM emits a malformed view.

--- a/packages/blocks/views/runtime/package.json
+++ b/packages/blocks/views/runtime/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@saas-maker/views-runtime",
+  "version": "0.1.0",
+  "description": "JSON spec → mounted React dashboard. Resolves bindings via @saas-maker/capability-graph.",
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist"
+  ],
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@saas-maker/capability-graph": "workspace:*",
+    "class-variance-authority": "0.7.1",
+    "clsx": "2.1.1",
+    "lucide-react": "1.11.0",
+    "tailwind-merge": "3.5.0",
+    "zod": "4.1.13"
+  },
+  "peerDependencies": {
+    "@saas-maker/ui": "workspace:*",
+    "react": "19.2.5",
+    "react-dom": "19.2.5"
+  },
+  "devDependencies": {
+    "@saas-maker/tsconfig": "workspace:*",
+    "@saas-maker/ui": "workspace:*",
+    "@testing-library/jest-dom": "6.9.1",
+    "@testing-library/react": "16.3.2",
+    "@types/react": "19",
+    "@types/react-dom": "19",
+    "happy-dom": "20.9.0",
+    "react": "19.2.5",
+    "react-dom": "19.2.5",
+    "tsup": "8.0.0",
+    "typescript": "6.0.3",
+    "vitest": "4.1.5"
+  }
+}

--- a/packages/blocks/views/runtime/src/__tests__/runtime.test.tsx
+++ b/packages/blocks/views/runtime/src/__tests__/runtime.test.tsx
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { z } from 'zod';
+import { createGraph, entity } from '@saas-maker/capability-graph';
+import { ViewRuntime } from '../runtime.js';
+
+const Issue = entity({
+  id: 'issue',
+  fields: {
+    id: z.string(),
+    title: z.string(),
+    status: z.string(),
+    points: z.number(),
+  },
+});
+
+function buildGraph(rows: Array<{ id: string; title: string; status: string; points: number }>) {
+  const graph = createGraph().provide({
+    source: 'linear',
+    entity: Issue,
+    fetch: async () => rows,
+  });
+  return graph;
+}
+
+const ctx = { scopes: new Set(['issue:read']) };
+
+describe('<ViewRuntime>', () => {
+  it('renders an invalid-spec error card on bad input', () => {
+    const graph = createGraph();
+    render(
+      <ViewRuntime
+        spec={{ blocks: [{ type: 'MetricCard' }] }}
+        graph={graph}
+        ctx={{ scopes: new Set() }}
+      />,
+    );
+    expect(screen.getByText(/Invalid view spec/i)).toBeInTheDocument();
+  });
+
+  it('renders title and description from the spec', async () => {
+    const graph = buildGraph([]);
+    render(
+      <ViewRuntime
+        spec={{
+          id: 'sprint',
+          title: 'Sprint health',
+          description: 'Open issues in the current cycle',
+          bindings: { open: { entity: 'issue' } },
+          blocks: [],
+        }}
+        graph={graph}
+        ctx={ctx}
+      />,
+    );
+    expect(screen.getByText('Sprint health')).toBeInTheDocument();
+    expect(screen.getByText(/Open issues in the current cycle/i)).toBeInTheDocument();
+  });
+
+  it('aggregates rows through MetricCard sum', async () => {
+    const graph = buildGraph([
+      { id: 'a', title: 'one', status: 'open', points: 3 },
+      { id: 'b', title: 'two', status: 'open', points: 5 },
+    ]);
+    render(
+      <ViewRuntime
+        spec={{
+          id: 'velocity',
+          bindings: { open: { entity: 'issue' } },
+          blocks: [
+            {
+              id: 'pts',
+              type: 'MetricCard',
+              binding: 'open',
+              props: { label: 'Story points', field: 'points', aggregate: 'sum' },
+            },
+          ],
+        }}
+        graph={graph}
+        ctx={ctx}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText('8')).toBeInTheDocument());
+    expect(screen.getByText('Story points')).toBeInTheDocument();
+  });
+
+  it('renders a List block with primary/secondary fields', async () => {
+    const graph = buildGraph([
+      { id: 'a', title: 'Fix login', status: 'open', points: 2 },
+      { id: 'b', title: 'Ship dashboard', status: 'in_progress', points: 5 },
+    ]);
+    render(
+      <ViewRuntime
+        spec={{
+          id: 'sprint',
+          bindings: { open: { entity: 'issue' } },
+          blocks: [
+            {
+              id: 'list',
+              type: 'List',
+              binding: 'open',
+              props: { title: 'Sprint', primary: 'title', secondary: 'status' },
+            },
+          ],
+        }}
+        graph={graph}
+        ctx={ctx}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText('Fix login')).toBeInTheDocument());
+    expect(screen.getByText('Ship dashboard')).toBeInTheDocument();
+    expect(screen.getByText('in_progress')).toBeInTheDocument();
+  });
+
+  it('renders an UnknownBlock fallback for unregistered block types', async () => {
+    const graph = buildGraph([]);
+    render(
+      <ViewRuntime
+        spec={{
+          id: 'x',
+          blocks: [{ id: 'b1', type: 'NotARealBlock' }],
+        }}
+        graph={graph}
+        ctx={{ scopes: new Set() }}
+      />,
+    );
+    expect(await screen.findByText(/Unknown block type/i)).toBeInTheDocument();
+    expect(screen.getByText('NotARealBlock')).toBeInTheDocument();
+  });
+
+  it('shows binding error in the block when the provider throws', async () => {
+    const graph = createGraph().provide({
+      source: 'linear',
+      entity: Issue,
+      fetch: async () => {
+        throw new Error('upstream timeout');
+      },
+    });
+    render(
+      <ViewRuntime
+        spec={{
+          id: 'x',
+          bindings: { broken: { entity: 'issue' } },
+          blocks: [
+            {
+              id: 'm',
+              type: 'MetricCard',
+              binding: 'broken',
+              props: { label: 'Issues' },
+            },
+          ],
+        }}
+        graph={graph}
+        ctx={ctx}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText(/upstream timeout/i)).toBeInTheDocument());
+  });
+});

--- a/packages/blocks/views/runtime/src/__tests__/setup.ts
+++ b/packages/blocks/views/runtime/src/__tests__/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/packages/blocks/views/runtime/src/__tests__/spec.test.ts
+++ b/packages/blocks/views/runtime/src/__tests__/spec.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { parseViewSpec, safeParseViewSpec } from '../spec.js';
+
+describe('parseViewSpec', () => {
+  it('accepts a minimal valid spec', () => {
+    const spec = parseViewSpec({
+      id: 'cockpit',
+      blocks: [{ id: 'mrr', type: 'MetricCard' }],
+    });
+    expect(spec.id).toBe('cockpit');
+    expect(spec.layout).toBe('grid');
+    expect(spec.bindings).toEqual({});
+    expect(spec.blocks).toHaveLength(1);
+  });
+
+  it('parses bindings + filter + orderBy', () => {
+    const spec = parseViewSpec({
+      id: 'inbox',
+      bindings: {
+        unread: {
+          source: 'gmail',
+          entity: 'email',
+          filter: { isRead: false },
+          orderBy: { field: 'receivedAt', dir: 'desc' },
+          limit: 25,
+        },
+      },
+      blocks: [{ id: 'list', type: 'List', binding: 'unread' }],
+    });
+    expect(spec.bindings['unread']?.source).toBe('gmail');
+    expect(spec.bindings['unread']?.limit).toBe(25);
+  });
+
+  it('rejects missing block id', () => {
+    const result = safeParseViewSpec({
+      id: 'x',
+      blocks: [{ type: 'MetricCard' }],
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects invalid layout enum', () => {
+    const result = safeParseViewSpec({ id: 'x', layout: 'masonry' });
+    expect(result.ok).toBe(false);
+  });
+
+  it('coerces version default', () => {
+    const spec = parseViewSpec({ id: 'x' });
+    expect(spec.version).toBe(1);
+  });
+});

--- a/packages/blocks/views/runtime/src/binding.ts
+++ b/packages/blocks/views/runtime/src/binding.ts
@@ -1,0 +1,27 @@
+import type { CapabilityGraph, ProviderContext, QueryOptions } from '@saas-maker/capability-graph';
+import type { Binding } from './spec.js';
+
+/**
+ * Resolve a binding into a list of rows by routing through the capability graph.
+ * Returned data is whatever the provider yields — caller is responsible for
+ * narrowing/typing per block.
+ */
+export async function resolveBinding(
+  graph: CapabilityGraph,
+  binding: Binding,
+  ctx: ProviderContext,
+): Promise<unknown[]> {
+  const opts: QueryOptions = {};
+  if (binding.filter) opts.filter = binding.filter;
+  if (binding.orderBy) opts.orderBy = binding.orderBy;
+  if (binding.limit !== undefined) opts.limit = binding.limit;
+
+  return graph.query(
+    {
+      entityId: binding.entity,
+      ...(binding.source ? { source: binding.source } : {}),
+      options: opts,
+    },
+    ctx,
+  );
+}

--- a/packages/blocks/views/runtime/src/blocks/empty.tsx
+++ b/packages/blocks/views/runtime/src/blocks/empty.tsx
@@ -1,0 +1,25 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@saas-maker/ui';
+import type { BlockRenderProps } from './types.js';
+
+/**
+ * Fallback block rendered when a spec references an unknown block type.
+ * Surfaces the type so the operator can debug the spec instead of seeing nothing.
+ */
+export function UnknownBlock({ blockId, props }: BlockRenderProps) {
+  const type = (props as { __type?: string }).__type ?? 'unknown';
+  return (
+    <Card className="border-dashed">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-medium text-muted-foreground">
+          Unknown block type: <code className="font-mono">{type}</code>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="text-xs text-muted-foreground">
+          Block id <code className="font-mono">{blockId}</code> referenced a type the runtime does
+          not have registered.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/blocks/views/runtime/src/blocks/list.tsx
+++ b/packages/blocks/views/runtime/src/blocks/list.tsx
@@ -1,0 +1,78 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@saas-maker/ui';
+import { cn } from '../lib/utils.js';
+import type { BlockRenderProps } from './types.js';
+
+interface ListProps {
+  title?: string;
+  primary: string;
+  secondary?: string;
+  meta?: string;
+  emptyText?: string;
+  className?: string;
+}
+
+function getString(row: Record<string, unknown>, key: string | undefined): string | undefined {
+  if (!key) return undefined;
+  const value = row[key];
+  if (value === null || value === undefined) return undefined;
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  if (value instanceof Date) return value.toLocaleString();
+  return JSON.stringify(value);
+}
+
+export function ListBlock({ data, loading, error, props }: BlockRenderProps) {
+  const config = props as unknown as ListProps;
+
+  return (
+    <Card className={cn('overflow-hidden', config.className)}>
+      {config.title ? (
+        <CardHeader className="pb-3">
+          <CardTitle className="text-sm font-medium">{config.title}</CardTitle>
+        </CardHeader>
+      ) : null}
+      <CardContent className="px-0 pb-0">
+        {error ? (
+          <p className="text-destructive text-sm px-6 py-4">{error.message}</p>
+        ) : loading ? (
+          <div className="space-y-3 px-6 py-4">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="h-4 w-full rounded bg-muted animate-pulse" />
+            ))}
+          </div>
+        ) : data.length === 0 ? (
+          <p className="text-muted-foreground text-sm px-6 py-6 text-center">
+            {config.emptyText ?? 'Nothing here yet.'}
+          </p>
+        ) : (
+          <ul className="divide-y">
+            {data.map((row, i) => {
+              const r = row as Record<string, unknown>;
+              const key = getString(r, 'id') ?? String(i);
+              return (
+                <li
+                  key={key}
+                  className="flex items-baseline gap-3 px-6 py-3 text-sm hover:bg-muted/40 transition-colors"
+                >
+                  <span className="font-medium truncate flex-1">
+                    {getString(r, config.primary) ?? '—'}
+                  </span>
+                  {config.secondary ? (
+                    <span className="text-muted-foreground truncate flex-1">
+                      {getString(r, config.secondary) ?? ''}
+                    </span>
+                  ) : null}
+                  {config.meta ? (
+                    <span className="text-muted-foreground text-xs tabular-nums">
+                      {getString(r, config.meta) ?? ''}
+                    </span>
+                  ) : null}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/blocks/views/runtime/src/blocks/metric-card.tsx
+++ b/packages/blocks/views/runtime/src/blocks/metric-card.tsx
@@ -1,0 +1,86 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@saas-maker/ui';
+import { cn } from '../lib/utils.js';
+import type { BlockRenderProps } from './types.js';
+
+interface MetricCardProps {
+  label?: string;
+  description?: string;
+  field?: string;
+  aggregate?: 'sum' | 'count' | 'avg' | 'min' | 'max';
+  prefix?: string;
+  suffix?: string;
+  format?: 'number' | 'currency' | 'percent';
+  trendField?: string;
+  className?: string;
+}
+
+const numberFormatter = new Intl.NumberFormat(undefined, { maximumFractionDigits: 2 });
+const percentFormatter = new Intl.NumberFormat(undefined, {
+  style: 'percent',
+  maximumFractionDigits: 1,
+});
+
+function aggregate(rows: unknown[], field: string | undefined, op: MetricCardProps['aggregate']) {
+  if (op === 'count' || !field) return rows.length;
+  const values = rows
+    .map((row) => (row as Record<string, unknown>)[field])
+    .filter((v): v is number => typeof v === 'number');
+  if (values.length === 0) return 0;
+  switch (op) {
+    case 'avg':
+      return values.reduce((acc, v) => acc + v, 0) / values.length;
+    case 'min':
+      return Math.min(...values);
+    case 'max':
+      return Math.max(...values);
+    case 'sum':
+    default:
+      return values.reduce((acc, v) => acc + v, 0);
+  }
+}
+
+function formatValue(value: number, format: MetricCardProps['format']): string {
+  switch (format) {
+    case 'percent':
+      return percentFormatter.format(value);
+    case 'currency':
+      return new Intl.NumberFormat(undefined, {
+        style: 'currency',
+        currency: 'USD',
+        maximumFractionDigits: 0,
+      }).format(value);
+    case 'number':
+    default:
+      return numberFormatter.format(value);
+  }
+}
+
+export function MetricCardBlock({ data, loading, error, props }: BlockRenderProps) {
+  const config = props as MetricCardProps;
+  const value = aggregate(data, config.field, config.aggregate ?? 'sum');
+  const display = `${config.prefix ?? ''}${formatValue(value, config.format)}${config.suffix ?? ''}`;
+
+  return (
+    <Card className={cn('overflow-hidden', config.className)}>
+      <CardHeader className="pb-2">
+        <CardDescription className="text-xs uppercase tracking-wider">
+          {config.label ?? 'Metric'}
+        </CardDescription>
+        {config.description ? (
+          <CardTitle className="text-sm font-normal text-muted-foreground">
+            {config.description}
+          </CardTitle>
+        ) : null}
+      </CardHeader>
+      <CardContent>
+        {error ? (
+          <span className="text-destructive text-sm">{error.message}</span>
+        ) : loading ? (
+          <div className="h-8 w-24 rounded-md bg-muted animate-pulse" />
+        ) : (
+          <span className="text-3xl font-semibold tracking-tight tabular-nums">{display}</span>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/blocks/views/runtime/src/blocks/registry.ts
+++ b/packages/blocks/views/runtime/src/blocks/registry.ts
@@ -1,0 +1,15 @@
+import { ListBlock } from './list.js';
+import { MetricCardBlock } from './metric-card.js';
+import { TableBlock } from './table.js';
+import { UnknownBlock } from './empty.js';
+import type { BlockComponent } from './types.js';
+
+export type BlockRegistry = Record<string, BlockComponent>;
+
+export const defaultBlocks: BlockRegistry = {
+  MetricCard: MetricCardBlock,
+  List: ListBlock,
+  Table: TableBlock,
+};
+
+export { UnknownBlock };

--- a/packages/blocks/views/runtime/src/blocks/table.tsx
+++ b/packages/blocks/views/runtime/src/blocks/table.tsx
@@ -1,0 +1,98 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@saas-maker/ui';
+import { cn } from '../lib/utils.js';
+import type { BlockRenderProps } from './types.js';
+
+interface ColumnDef {
+  field: string;
+  label?: string;
+  align?: 'left' | 'right' | 'center';
+}
+
+interface TableProps {
+  title?: string;
+  columns: ColumnDef[];
+  emptyText?: string;
+  className?: string;
+}
+
+function format(value: unknown): string {
+  if (value === null || value === undefined) return '—';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number') return value.toLocaleString();
+  if (typeof value === 'boolean') return value ? 'yes' : 'no';
+  if (value instanceof Date) return value.toLocaleString();
+  return JSON.stringify(value);
+}
+
+export function TableBlock({ data, loading, error, props }: BlockRenderProps) {
+  const config = props as unknown as TableProps;
+  const columns = Array.isArray(config.columns) ? config.columns : [];
+
+  return (
+    <Card className={cn('overflow-hidden', config.className)}>
+      {config.title ? (
+        <CardHeader className="pb-3">
+          <CardTitle className="text-sm font-medium">{config.title}</CardTitle>
+        </CardHeader>
+      ) : null}
+      <CardContent className="p-0">
+        {error ? (
+          <p className="text-destructive text-sm px-6 py-4">{error.message}</p>
+        ) : loading ? (
+          <div className="space-y-2 px-6 py-4">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="h-4 w-full rounded bg-muted animate-pulse" />
+            ))}
+          </div>
+        ) : data.length === 0 ? (
+          <p className="text-muted-foreground text-sm px-6 py-6 text-center">
+            {config.emptyText ?? 'No rows.'}
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="text-xs uppercase tracking-wider text-muted-foreground">
+                <tr className="border-b">
+                  {columns.map((col) => (
+                    <th
+                      key={col.field}
+                      className={cn(
+                        'px-6 py-2 font-medium',
+                        col.align === 'right' && 'text-right',
+                        col.align === 'center' && 'text-center',
+                        (!col.align || col.align === 'left') && 'text-left',
+                      )}
+                    >
+                      {col.label ?? col.field}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {data.map((row, i) => {
+                  const r = row as Record<string, unknown>;
+                  return (
+                    <tr key={i} className="border-b last:border-b-0 hover:bg-muted/40">
+                      {columns.map((col) => (
+                        <td
+                          key={col.field}
+                          className={cn(
+                            'px-6 py-2 truncate',
+                            col.align === 'right' && 'text-right tabular-nums',
+                            col.align === 'center' && 'text-center',
+                          )}
+                        >
+                          {format(r[col.field])}
+                        </td>
+                      ))}
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/blocks/views/runtime/src/blocks/types.ts
+++ b/packages/blocks/views/runtime/src/blocks/types.ts
@@ -1,0 +1,16 @@
+import type { ComponentType } from 'react';
+
+export interface BlockRenderProps<TRow = unknown> {
+  /** Rows resolved from the binding (empty array if no binding). */
+  data: TRow[];
+  /** True while the binding fetch is in flight. */
+  loading: boolean;
+  /** Set if the binding fetch threw. */
+  error?: Error;
+  /** Block-specific props from the spec. */
+  props: Record<string, unknown>;
+  /** Block id from the spec. */
+  blockId: string;
+}
+
+export type BlockComponent<TRow = unknown> = ComponentType<BlockRenderProps<TRow>>;

--- a/packages/blocks/views/runtime/src/index.ts
+++ b/packages/blocks/views/runtime/src/index.ts
@@ -1,0 +1,19 @@
+export { ViewRuntime } from './runtime.js';
+export type { ViewRuntimeProps } from './runtime.js';
+
+export {
+  BindingSchema,
+  BlockSpecSchema,
+  ViewSpecSchema,
+  parseViewSpec,
+  safeParseViewSpec,
+} from './spec.js';
+export type { Binding, BlockSpec, ViewSpec } from './spec.js';
+
+export { resolveBinding } from './binding.js';
+export { defaultBlocks, UnknownBlock } from './blocks/registry.js';
+export type { BlockRegistry } from './blocks/registry.js';
+export { MetricCardBlock } from './blocks/metric-card.js';
+export { ListBlock } from './blocks/list.js';
+export { TableBlock } from './blocks/table.js';
+export type { BlockComponent, BlockRenderProps } from './blocks/types.js';

--- a/packages/blocks/views/runtime/src/lib/utils.ts
+++ b/packages/blocks/views/runtime/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/packages/blocks/views/runtime/src/runtime.tsx
+++ b/packages/blocks/views/runtime/src/runtime.tsx
@@ -1,0 +1,202 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { CapabilityGraph, ProviderContext } from '@saas-maker/capability-graph';
+import { resolveBinding } from './binding.js';
+import { defaultBlocks, UnknownBlock, type BlockRegistry } from './blocks/registry.js';
+import { cn } from './lib/utils.js';
+import { parseViewSpec, type Binding, type BlockSpec, type ViewSpec } from './spec.js';
+
+interface BindingState {
+  loading: boolean;
+  data: unknown[];
+  error?: Error;
+}
+
+const initialState: BindingState = { loading: true, data: [] };
+
+export interface ViewRuntimeProps {
+  /** Either a pre-parsed spec or raw JSON to validate. */
+  spec: ViewSpec | unknown;
+  /** Capability graph carrying registered providers. */
+  graph: CapabilityGraph;
+  /** Provider context (scopes, abort signal). Re-fetches when scopes change. */
+  ctx: ProviderContext;
+  /** Optional override map of block type → component. Falls back to defaults. */
+  blocks?: BlockRegistry;
+  /** Extra className on the root container. */
+  className?: string;
+}
+
+/**
+ * Resolves a view spec to a live dashboard.
+ *
+ * - Validates the spec (zod) and renders an error card if invalid.
+ * - Fetches each binding via the capability graph in parallel.
+ * - Mounts blocks from the registry, passing per-binding loading/error state.
+ */
+export function ViewRuntime({ spec, graph, ctx, blocks, className }: ViewRuntimeProps) {
+  const parsed = useMemo(() => {
+    try {
+      return { ok: true as const, spec: parseViewSpec(spec) };
+    } catch (err) {
+      return { ok: false as const, error: err instanceof Error ? err : new Error(String(err)) };
+    }
+  }, [spec]);
+
+  if (!parsed.ok) {
+    return (
+      <div className="rounded-lg border border-destructive/50 bg-destructive/5 p-4 text-sm text-destructive">
+        <p className="font-medium">Invalid view spec</p>
+        <pre className="mt-2 whitespace-pre-wrap text-xs opacity-80">{parsed.error.message}</pre>
+      </div>
+    );
+  }
+
+  return (
+    <ViewRuntimeInner
+      spec={parsed.spec}
+      graph={graph}
+      ctx={ctx}
+      blocks={blocks ?? defaultBlocks}
+      className={className}
+    />
+  );
+}
+
+interface InnerProps {
+  spec: ViewSpec;
+  graph: CapabilityGraph;
+  ctx: ProviderContext;
+  blocks: BlockRegistry;
+  className?: string;
+}
+
+function ViewRuntimeInner({ spec, graph, ctx, blocks, className }: InnerProps) {
+  const bindings = useBindings(spec.bindings, graph, ctx);
+
+  const layoutClass =
+    spec.layout === 'flex'
+      ? 'flex flex-wrap gap-4'
+      : spec.layout === 'stack'
+        ? 'flex flex-col gap-4'
+        : 'grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-4 auto-rows-min';
+
+  return (
+    <div className={cn('w-full', className)}>
+      {spec.title ? (
+        <header className="mb-6">
+          <h1 className="text-2xl font-semibold tracking-tight">{spec.title}</h1>
+          {spec.description ? (
+            <p className="mt-1 text-sm text-muted-foreground">{spec.description}</p>
+          ) : null}
+        </header>
+      ) : null}
+      <div className={layoutClass}>
+        {spec.blocks.map((block) => (
+          <BlockShell key={block.id} block={block} bindings={bindings} blocks={blocks} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function BlockShell({
+  block,
+  bindings,
+  blocks,
+}: {
+  block: BlockSpec;
+  bindings: Record<string, BindingState>;
+  blocks: BlockRegistry;
+}) {
+  const Component = blocks[block.type] ?? UnknownBlock;
+  const state = block.binding ? (bindings[block.binding] ?? initialState) : { loading: false, data: [] };
+  const layout = block.layout;
+  const colSpan = layout?.w ? colSpanClass(layout.w) : undefined;
+  const rowSpan = layout?.h ? rowSpanClass(layout.h) : undefined;
+
+  const propsForBlock: Record<string, unknown> = {
+    ...(block.props ?? {}),
+    __type: block.type,
+  };
+
+  return (
+    <div className={cn(colSpan, rowSpan)}>
+      <Component
+        blockId={block.id}
+        data={state.data}
+        loading={state.loading}
+        {...(state.error ? { error: state.error } : {})}
+        props={propsForBlock}
+      />
+    </div>
+  );
+}
+
+function colSpanClass(w: number): string {
+  // Tailwind needs static class names — map common widths only.
+  const map: Record<number, string> = {
+    1: 'md:col-span-1',
+    2: 'md:col-span-2',
+    3: 'md:col-span-3',
+    4: 'md:col-span-4 lg:col-span-4',
+    6: 'md:col-span-3 lg:col-span-4',
+    12: 'md:col-span-3 lg:col-span-4',
+  };
+  return map[w] ?? '';
+}
+
+function rowSpanClass(h: number): string {
+  const map: Record<number, string> = {
+    1: 'row-span-1',
+    2: 'row-span-2',
+    3: 'row-span-3',
+  };
+  return map[h] ?? '';
+}
+
+/**
+ * Resolves all bindings concurrently. Re-runs when bindings, graph, or ctx changes.
+ */
+function useBindings(
+  specBindings: Record<string, Binding>,
+  graph: CapabilityGraph,
+  ctx: ProviderContext,
+): Record<string, BindingState> {
+  const [state, setState] = useState<Record<string, BindingState>>(() => {
+    const initial: Record<string, BindingState> = {};
+    for (const key of Object.keys(specBindings)) initial[key] = initialState;
+    return initial;
+  });
+
+  const keys = Object.keys(specBindings).sort().join('|');
+  const scopeKey = Array.from(ctx.scopes).sort().join('|');
+
+  useEffect(() => {
+    let cancelled = false;
+    const next: Record<string, BindingState> = {};
+    for (const key of Object.keys(specBindings)) next[key] = { loading: true, data: [] };
+    setState(next);
+
+    const tasks = Object.entries(specBindings).map(async ([key, binding]) => {
+      try {
+        const data = await resolveBinding(graph, binding, ctx);
+        if (cancelled) return;
+        setState((prev) => ({ ...prev, [key]: { loading: false, data } }));
+      } catch (err) {
+        if (cancelled) return;
+        const error = err instanceof Error ? err : new Error(String(err));
+        setState((prev) => ({ ...prev, [key]: { loading: false, data: [], error } }));
+      }
+    });
+
+    void Promise.allSettled(tasks);
+
+    return () => {
+      cancelled = true;
+    };
+    // We intentionally include serialised keys — bindings is a fresh object each render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [keys, scopeKey, graph]);
+
+  return state;
+}

--- a/packages/blocks/views/runtime/src/spec.ts
+++ b/packages/blocks/views/runtime/src/spec.ts
@@ -1,0 +1,63 @@
+import { z } from 'zod';
+
+/**
+ * A binding maps a logical name (used by blocks) to an entity query.
+ * `source` may be omitted to let the graph pick the default provider.
+ */
+export const BindingSchema = z.object({
+  source: z.string().optional(),
+  entity: z.string(),
+  filter: z.record(z.string(), z.unknown()).optional(),
+  orderBy: z
+    .object({
+      field: z.string(),
+      dir: z.enum(['asc', 'desc']),
+    })
+    .optional(),
+  limit: z.number().int().positive().optional(),
+});
+export type Binding = z.infer<typeof BindingSchema>;
+
+/**
+ * Block spec — declarative description of one tile in a view. `binding` references
+ * a key in `view.bindings`. `props` is block-specific (validated by the block itself).
+ */
+export const BlockSpecSchema = z.object({
+  id: z.string().min(1),
+  type: z.string().min(1),
+  binding: z.string().optional(),
+  props: z.record(z.string(), z.unknown()).optional(),
+  layout: z
+    .object({
+      x: z.number().int().nonnegative().optional(),
+      y: z.number().int().nonnegative().optional(),
+      w: z.number().int().positive().optional(),
+      h: z.number().int().positive().optional(),
+    })
+    .optional(),
+});
+export type BlockSpec = z.infer<typeof BlockSpecSchema>;
+
+export const ViewSpecSchema = z.object({
+  id: z.string().min(1),
+  title: z.string().optional(),
+  description: z.string().optional(),
+  layout: z.enum(['grid', 'flex', 'stack']).default('grid'),
+  bindings: z.record(z.string(), BindingSchema).default({}),
+  blocks: z.array(BlockSpecSchema).default([]),
+  version: z.number().int().nonnegative().default(1),
+});
+export type ViewSpec = z.infer<typeof ViewSpecSchema>;
+
+/** Parse + validate a raw spec. Throws ZodError if invalid. */
+export function parseViewSpec(input: unknown): ViewSpec {
+  return ViewSpecSchema.parse(input);
+}
+
+export function safeParseViewSpec(
+  input: unknown,
+): { ok: true; spec: ViewSpec } | { ok: false; error: z.ZodError } {
+  const result = ViewSpecSchema.safeParse(input);
+  if (result.success) return { ok: true, spec: result.data };
+  return { ok: false, error: result.error };
+}

--- a/packages/blocks/views/runtime/tsconfig.json
+++ b/packages/blocks/views/runtime/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@saas-maker/tsconfig/base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "jsx": "react-jsx",
+    "ignoreDeprecations": "6.0",
+    "noEmit": false
+  },
+  "include": ["src"]
+}

--- a/packages/blocks/views/runtime/tsup.config.ts
+++ b/packages/blocks/views/runtime/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  outExtension({ format }) {
+    return { js: format === 'esm' ? '.mjs' : '.js' };
+  },
+  dts: { compilerOptions: { ignoreDeprecations: '6.0' } },
+  clean: true,
+  minify: true,
+  sourcemap: true,
+  external: ['react', 'react-dom', '@saas-maker/ui'],
+});

--- a/packages/blocks/views/runtime/vitest.config.ts
+++ b/packages/blocks/views/runtime/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.{ts,tsx}'],
+    environment: 'happy-dom',
+    setupFiles: ['./src/__tests__/setup.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -391,6 +391,83 @@ importers:
         specifier: 6.0.3
         version: 6.0.3
 
+  packages/blocks/views/capability-graph:
+    dependencies:
+      zod:
+        specifier: 4.1.13
+        version: 4.1.13
+    devDependencies:
+      '@saas-maker/tsconfig':
+        specifier: workspace:*
+        version: link:../../../tooling/tsconfig
+      tsup:
+        specifier: 8.0.0
+        version: 8.0.0(postcss@8.5.10)(typescript@6.0.3)
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 4.1.5
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@29.0.2(@noble/hashes@2.2.0))(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))
+
+  packages/blocks/views/runtime:
+    dependencies:
+      '@saas-maker/capability-graph':
+        specifier: workspace:*
+        version: link:../capability-graph
+      class-variance-authority:
+        specifier: 0.7.1
+        version: 0.7.1
+      clsx:
+        specifier: 2.1.1
+        version: 2.1.1
+      lucide-react:
+        specifier: 1.11.0
+        version: 1.11.0(react@19.2.5)
+      tailwind-merge:
+        specifier: 3.5.0
+        version: 3.5.0
+      zod:
+        specifier: 4.1.13
+        version: 4.1.13
+    devDependencies:
+      '@saas-maker/tsconfig':
+        specifier: workspace:*
+        version: link:../../../tooling/tsconfig
+      '@saas-maker/ui':
+        specifier: workspace:*
+        version: link:../../../ui
+      '@testing-library/jest-dom':
+        specifier: 6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: 16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@types/react':
+        specifier: '19'
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: '19'
+        version: 19.2.3(@types/react@19.2.14)
+      happy-dom:
+        specifier: 20.9.0
+        version: 20.9.0
+      react:
+        specifier: 19.2.5
+        version: 19.2.5
+      react-dom:
+        specifier: 19.2.5
+        version: 19.2.5(react@19.2.5)
+      tsup:
+        specifier: 8.0.0
+        version: 8.0.0(postcss@8.5.10)(typescript@6.0.3)
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 4.1.5
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@29.0.2(@noble/hashes@2.2.0))(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))
+
   packages/cli:
     dependencies:
       chalk:
@@ -527,24 +604,6 @@ importers:
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@29.0.2(@noble/hashes@2.2.0))(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/tooling/tsconfig: {}
-
-  packages/tooling/wrangler-preset:
-    devDependencies:
-      '@saas-maker/tsconfig':
-        specifier: workspace:*
-        version: link:../tsconfig
-      '@types/node':
-        specifier: 25.6.0
-        version: 25.6.0
-      tsup:
-        specifier: 8.0.0
-        version: 8.0.0(postcss@8.5.10)(typescript@6.0.3)
-      typescript:
-        specifier: 6.0.3
-        version: 6.0.3
-      vitest:
-        specifier: 4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@29.0.2(@noble/hashes@2.2.0))(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/ui:
     dependencies:
@@ -9565,6 +9624,9 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zod@4.1.13:
+    resolution: {integrity: sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==}
+
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
@@ -15533,8 +15595,8 @@ snapshots:
       '@babel/parser': 7.29.2
       eslint: 10.2.1(jiti@2.6.1)
       hermes-parser: 0.25.1
-      zod: 4.3.6
-      zod-validation-error: 4.0.2(zod@4.3.6)
+      zod: 4.1.13
+      zod-validation-error: 4.0.2(zod@4.1.13)
     transitivePeerDependencies:
       - supports-color
 
@@ -19684,11 +19746,13 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
-  zod-validation-error@4.0.2(zod@4.3.6):
+  zod-validation-error@4.0.2(zod@4.1.13):
     dependencies:
-      zod: 4.3.6
+      zod: 4.1.13
 
   zod@3.25.76: {}
+
+  zod@4.1.13: {}
 
   zod@4.3.6: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -272,12 +272,24 @@ importers:
 
   packages/blocks/email:
     dependencies:
+      '@react-email/components':
+        specifier: ^1.0.12
+        version: 1.0.12(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@react-email/render':
+        specifier: ^2.0.8
+        version: 2.0.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@saas-maker/ops':
         specifier: workspace:*
         version: link:../ops
       nodemailer:
         specifier: 6.9.0
         version: 6.9.0
+      react:
+        specifier: 19.2.5
+        version: 19.2.5
+      react-dom:
+        specifier: 19.2.5
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       '@types/node':
         specifier: 25.6.0
@@ -285,6 +297,12 @@ importers:
       '@types/nodemailer':
         specifier: 6.4.0
         version: 6.4.0
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
       tsup:
         specifier: 8.0.0
         version: 8.0.0(postcss@8.5.10)(typescript@6.0.3)
@@ -631,28 +649,28 @@ importers:
         version: link:../tooling/tsconfig
       '@storybook/addon-essentials':
         specifier: 8.5.8
-        version: 8.5.8(@types/react@19.2.14)(storybook@8.5.8)
+        version: 8.5.8(@types/react@19.2.14)(storybook@8.5.8(prettier@3.8.3))
       '@storybook/addon-interactions':
         specifier: 8.5.8
-        version: 8.5.8(storybook@8.5.8)
+        version: 8.5.8(storybook@8.5.8(prettier@3.8.3))
       '@storybook/addon-links':
         specifier: 8.5.8
-        version: 8.5.8(react@19.2.5)(storybook@8.5.8)
+        version: 8.5.8(react@19.2.5)(storybook@8.5.8(prettier@3.8.3))
       '@storybook/addon-onboarding':
         specifier: 1.0.11
         version: 1.0.11(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@storybook/blocks':
         specifier: 8.5.8
-        version: 8.5.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@8.5.8)
+        version: 8.5.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@8.5.8(prettier@3.8.3))
       '@storybook/react':
         specifier: 8.5.8
-        version: 8.5.8(@storybook/test@8.5.8(storybook@8.5.8))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@8.5.8)(typescript@6.0.3)
+        version: 8.5.8(@storybook/test@8.5.8(storybook@8.5.8(prettier@3.8.3)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@8.5.8(prettier@3.8.3))(typescript@6.0.3)
       '@storybook/react-vite':
         specifier: 8.5.8
-        version: 8.5.8(@storybook/test@8.5.8(storybook@8.5.8))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rollup@4.60.2)(storybook@8.5.8)(typescript@6.0.3)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))
+        version: 8.5.8(@storybook/test@8.5.8(storybook@8.5.8(prettier@3.8.3)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rollup@4.60.2)(storybook@8.5.8(prettier@3.8.3))(typescript@6.0.3)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))
       '@storybook/test':
         specifier: 8.5.8
-        version: 8.5.8(storybook@8.5.8)
+        version: 8.5.8(storybook@8.5.8(prettier@3.8.3))
       '@types/react':
         specifier: '19'
         version: 19.2.14
@@ -667,7 +685,7 @@ importers:
         version: 19.2.5(react@19.2.5)
       storybook:
         specifier: 8.5.8
-        version: 8.5.8
+        version: 8.5.8(prettier@3.8.3)
       tailwindcss:
         specifier: '4'
         version: 4.2.4
@@ -837,6 +855,9 @@ importers:
       jose:
         specifier: 6.2.2
         version: 6.2.2
+      react:
+        specifier: 19.2.5
+        version: 19.2.5
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 4.20260424.1
@@ -3903,6 +3924,192 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@react-email/body@0.3.0':
+    resolution: {integrity: sha512-uGo0BOOzjbMUo3lu+BIDWayvn5o6Xyfmnlla5VGf05n8gHMvO1ll7U4FtzWe3hxMLwt53pmc4iE0M+B5slG+Ug==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/button@0.2.1':
+    resolution: {integrity: sha512-qXyj7RZLE7POy9BMKSoqQ00tOXThjOZSUnI2Yu9i29IHngPlmrNayIWBoVKtElES7OWwypUcpiajwi1mUWx6/A==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/code-block@0.2.1':
+    resolution: {integrity: sha512-M3B7JpVH4ytgn83/ujRR1k1DQHvTeABiDM61OvAbjLRPhC/5KLHU5KkzIbbuGIrjWwxAbL1kSQzU8MhLEtSxyw==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/code-inline@0.0.6':
+    resolution: {integrity: sha512-jfhebvv3dVsp3OdPgKXnk8+e2pBiDVZejDOBFzBa/IblrAJ9cQDkN6rBD5IyEg8hTOxwbw3iaI/yZFmDmIguIA==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/column@0.0.14':
+    resolution: {integrity: sha512-f+W+Bk2AjNO77zynE33rHuQhyqVICx4RYtGX9NKsGUg0wWjdGP0qAuIkhx9Rnmk4/hFMo1fUrtYNqca9fwJdHg==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/components@1.0.12':
+    resolution: {integrity: sha512-tH18JhPDWgE+3jnYkzyB6ZrZdfNnEsFe4PwmuXmlOw4NGIysP8wPY5aXZg++pTG9qUabXg1nzX/FGHGkObH8xQ==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/container@0.0.16':
+    resolution: {integrity: sha512-QWBB56RkkU0AJ9h+qy33gfT5iuZknPC7Un/IjZv9B0QmMIK+WWacc0cH6y2SV5Cv/b99hU94fjEMOOO4enpkbQ==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/font@0.0.10':
+    resolution: {integrity: sha512-0urVSgCmQIfx5r7Xc586miBnQUVnGp3OTYUm8m5pwtQRdTRO5XrTtEfNJ3JhYhSOruV0nD8fd+dXtKXobum6tA==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/head@0.0.13':
+    resolution: {integrity: sha512-AJg6le/08Gz4tm+6MtKXqtNNyKHzmooOCdmtqmWxD7FxoAdU1eVcizhtQ0gcnVaY6ethEyE/hnEzQxt1zu5Kog==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/heading@0.0.16':
+    resolution: {integrity: sha512-jmsKnQm1ykpBzw4hCYHwBkt5pW2jScXffPeEH5ZRF5tZeF5b1pvlFTO9han7C0pCkZYo1kEvWiRtx69yfCIwuw==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/hr@0.0.12':
+    resolution: {integrity: sha512-TwmOmBDibavUQpXBxpmZYi2Iks/yeZOzFYh+di9EltMSnEabH8dMZXrl+pxNXzCgZ2XE8HY7VmUL65Lenfu5PA==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/html@0.0.12':
+    resolution: {integrity: sha512-KTShZesan+UsreU7PDUV90afrZwU5TLwYlALuCSU0OT+/U8lULNNbAUekg+tGwCnOfIKYtpDPKkAMRdYlqUznw==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/img@0.0.12':
+    resolution: {integrity: sha512-sRCpEARNVTf3FQhZOC+JTvu5r6ubiYWkT0ucYXg8ctkyi4G8QG+jgYPiNUqVeTLA2STOfmPM/nrk1nb84y6CPQ==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/link@0.0.13':
+    resolution: {integrity: sha512-lkWc/NjOcefRZMkQoSDDbuKBEBDES9aXnFEOuPH845wD3TxPwh+QTf0fStuzjoRLUZWpHnio4z7qGGRYusn/sw==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/markdown@0.0.18':
+    resolution: {integrity: sha512-gSuYK5fsMbGk87jDebqQ6fa2fKcWlkf2Dkva8kMONqLgGCq8/0d+ZQYMEJsdidIeBo3kmsnHZPrwdFB4HgjUXg==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/preview@0.0.14':
+    resolution: {integrity: sha512-aYK8q0IPkBXyMsbpMXgxazwHxYJxTrXrV95GFuu2HbEiIToMwSyUgb8HDFYwPqqfV03/jbwqlsXmFxsOd+VNaw==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/render@2.0.6':
+    resolution: {integrity: sha512-xOzaYkH3jLZKqN5MqrTXYnmqBYUnZSVbkxdb5PGGmDcK6sKDVMliaDiSwfXajRC9JtSHTcGc2tmGLHWuCgVpog==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/render@2.0.8':
+    resolution: {integrity: sha512-5udvVr3U/WuGJZfLdLBOhkzrqRWd2Q5ZYmF7ppcy7FzWcwgshdqLMNqJOXcVzAXJXg/2bm7D+WGJzTtZOZMQnQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/row@0.0.13':
+    resolution: {integrity: sha512-bYnOac40vIKCId7IkwuLAAsa3fKfSfqCvv6epJKmPE0JBuu5qI4FHFCl9o9dVpIIS08s/ub+Y/txoMt0dYziGw==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/section@0.0.17':
+    resolution: {integrity: sha512-qNl65ye3W0Rd5udhdORzTV9ezjb+GFqQQSae03NDzXtmJq6sqVXNWNiVolAjvJNypim+zGXmv6J9TcV5aNtE/w==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/tailwind@2.0.7':
+    resolution: {integrity: sha512-kGw80weVFXikcnCXbigTGXGWQ0MRCSYNCudcdkWxebkWYd0FG6/NPoN3V1p/u68/4+NxZwYPVi2fhnp0x23HdA==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      '@react-email/body': '>=0'
+      '@react-email/button': '>=0'
+      '@react-email/code-block': '>=0'
+      '@react-email/code-inline': '>=0'
+      '@react-email/container': '>=0'
+      '@react-email/heading': '>=0'
+      '@react-email/hr': '>=0'
+      '@react-email/img': '>=0'
+      '@react-email/link': '>=0'
+      '@react-email/preview': '>=0'
+      '@react-email/text': '>=0'
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@react-email/body':
+        optional: true
+      '@react-email/button':
+        optional: true
+      '@react-email/code-block':
+        optional: true
+      '@react-email/code-inline':
+        optional: true
+      '@react-email/container':
+        optional: true
+      '@react-email/heading':
+        optional: true
+      '@react-email/hr':
+        optional: true
+      '@react-email/img':
+        optional: true
+      '@react-email/link':
+        optional: true
+      '@react-email/preview':
+        optional: true
+
+  '@react-email/text@0.1.6':
+    resolution: {integrity: sha512-TYqkioRS45wTR5il3dYk/SbUjjEdhSwh9BtRNB99qNH1pXAwA45H7rAuxehiu8iJQJH0IyIr+6n62gBz9ezmsw==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
   '@reduxjs/toolkit@2.11.2':
     resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
     peerDependencies:
@@ -4071,6 +4278,9 @@ packages:
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
+  '@selderee/plugin-htmlparser2@0.11.0':
+    resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
 
   '@shikijs/core@3.23.0':
     resolution: {integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==}
@@ -6852,11 +7062,18 @@ packages:
   html-escaper@3.0.3:
     resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
 
+  html-to-text@9.0.5:
+    resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
+    engines: {node: '>=14'}
+
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   html-whitespace-sensitive-tag-names@3.0.1:
     resolution: {integrity: sha512-q+310vW8zmymYHALr1da4HyXUQ0zgiIwIicEfotYPWGN0OJVEN/58IJ3A4GBYcEq3LGAZqKb+ugvP0GNB9CEAA==}
+
+  htmlparser2@8.0.2:
+    resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
@@ -7288,6 +7505,9 @@ packages:
     resolution: {integrity: sha512-aXpZJRnTkpK6gQ/z4nk+ZBLd/Qdp118cvPruLSIQzQNRhKwEcdXCOzXuF55VDqIiuAaY3UGZ10DJtvZzDcvsxg==}
     engines: {node: '>=14.0.0'}
 
+  leac@0.6.0:
+    resolution: {integrity: sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==}
+
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
@@ -7466,6 +7686,11 @@ packages:
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  marked@15.0.12:
+    resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
+    engines: {node: '>= 18'}
+    hasBin: true
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -8025,6 +8250,9 @@ packages:
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
+  parseley@0.12.1:
+    resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -8075,6 +8303,9 @@ packages:
   pathval@2.0.1:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
+
+  peberminta@0.9.0:
+    resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
 
   piccolore@0.1.3:
     resolution: {integrity: sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==}
@@ -8175,6 +8406,11 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  prettier@3.8.3:
+    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
+    engines: {node: '>=14'}
+    hasBin: true
 
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
@@ -8546,6 +8782,9 @@ packages:
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  selderee@0.11.0:
+    resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
 
   semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
@@ -12842,6 +13081,137 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@react-email/body@0.3.0(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+
+  '@react-email/button@0.2.1(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+
+  '@react-email/code-block@0.2.1(react@19.2.5)':
+    dependencies:
+      prismjs: 1.30.0
+      react: 19.2.5
+
+  '@react-email/code-inline@0.0.6(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+
+  '@react-email/column@0.0.14(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+
+  '@react-email/components@1.0.12(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@react-email/body': 0.3.0(react@19.2.5)
+      '@react-email/button': 0.2.1(react@19.2.5)
+      '@react-email/code-block': 0.2.1(react@19.2.5)
+      '@react-email/code-inline': 0.0.6(react@19.2.5)
+      '@react-email/column': 0.0.14(react@19.2.5)
+      '@react-email/container': 0.0.16(react@19.2.5)
+      '@react-email/font': 0.0.10(react@19.2.5)
+      '@react-email/head': 0.0.13(react@19.2.5)
+      '@react-email/heading': 0.0.16(react@19.2.5)
+      '@react-email/hr': 0.0.12(react@19.2.5)
+      '@react-email/html': 0.0.12(react@19.2.5)
+      '@react-email/img': 0.0.12(react@19.2.5)
+      '@react-email/link': 0.0.13(react@19.2.5)
+      '@react-email/markdown': 0.0.18(react@19.2.5)
+      '@react-email/preview': 0.0.14(react@19.2.5)
+      '@react-email/render': 2.0.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@react-email/row': 0.0.13(react@19.2.5)
+      '@react-email/section': 0.0.17(react@19.2.5)
+      '@react-email/tailwind': 2.0.7(@react-email/body@0.3.0(react@19.2.5))(@react-email/button@0.2.1(react@19.2.5))(@react-email/code-block@0.2.1(react@19.2.5))(@react-email/code-inline@0.0.6(react@19.2.5))(@react-email/container@0.0.16(react@19.2.5))(@react-email/heading@0.0.16(react@19.2.5))(@react-email/hr@0.0.12(react@19.2.5))(@react-email/img@0.0.12(react@19.2.5))(@react-email/link@0.0.13(react@19.2.5))(@react-email/preview@0.0.14(react@19.2.5))(@react-email/text@0.1.6(react@19.2.5))(react@19.2.5)
+      '@react-email/text': 0.1.6(react@19.2.5)
+      react: 19.2.5
+    transitivePeerDependencies:
+      - react-dom
+
+  '@react-email/container@0.0.16(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+
+  '@react-email/font@0.0.10(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+
+  '@react-email/head@0.0.13(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+
+  '@react-email/heading@0.0.16(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+
+  '@react-email/hr@0.0.12(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+
+  '@react-email/html@0.0.12(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+
+  '@react-email/img@0.0.12(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+
+  '@react-email/link@0.0.13(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+
+  '@react-email/markdown@0.0.18(react@19.2.5)':
+    dependencies:
+      marked: 15.0.12
+      react: 19.2.5
+
+  '@react-email/preview@0.0.14(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+
+  '@react-email/render@2.0.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      html-to-text: 9.0.5
+      prettier: 3.8.3
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  '@react-email/render@2.0.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      html-to-text: 9.0.5
+      prettier: 3.8.3
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  '@react-email/row@0.0.13(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+
+  '@react-email/section@0.0.17(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+
+  '@react-email/tailwind@2.0.7(@react-email/body@0.3.0(react@19.2.5))(@react-email/button@0.2.1(react@19.2.5))(@react-email/code-block@0.2.1(react@19.2.5))(@react-email/code-inline@0.0.6(react@19.2.5))(@react-email/container@0.0.16(react@19.2.5))(@react-email/heading@0.0.16(react@19.2.5))(@react-email/hr@0.0.12(react@19.2.5))(@react-email/img@0.0.12(react@19.2.5))(@react-email/link@0.0.13(react@19.2.5))(@react-email/preview@0.0.14(react@19.2.5))(@react-email/text@0.1.6(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@react-email/text': 0.1.6(react@19.2.5)
+      react: 19.2.5
+      tailwindcss: 4.2.4
+    optionalDependencies:
+      '@react-email/body': 0.3.0(react@19.2.5)
+      '@react-email/button': 0.2.1(react@19.2.5)
+      '@react-email/code-block': 0.2.1(react@19.2.5)
+      '@react-email/code-inline': 0.0.6(react@19.2.5)
+      '@react-email/container': 0.0.16(react@19.2.5)
+      '@react-email/heading': 0.0.16(react@19.2.5)
+      '@react-email/hr': 0.0.12(react@19.2.5)
+      '@react-email/img': 0.0.12(react@19.2.5)
+      '@react-email/link': 0.0.13(react@19.2.5)
+      '@react-email/preview': 0.0.14(react@19.2.5)
+
+  '@react-email/text@0.1.6(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+
   '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.5)(redux@5.0.1))(react@19.2.5)':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -12944,6 +13314,11 @@ snapshots:
       eslint: 10.2.1(jiti@2.6.1)
 
   '@sec-ant/readable-stream@0.4.1': {}
+
+  '@selderee/plugin-htmlparser2@0.11.0':
+    dependencies:
+      domhandler: 5.0.3
+      selderee: 0.11.0
 
   '@shikijs/core@3.23.0':
     dependencies:
@@ -13359,85 +13734,85 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
-  '@storybook/addon-actions@8.5.8(storybook@8.5.8)':
+  '@storybook/addon-actions@8.5.8(storybook@8.5.8(prettier@3.8.3))':
     dependencies:
       '@storybook/global': 5.0.0
       '@types/uuid': 9.0.8
       dequal: 2.0.3
       polished: 4.3.1
-      storybook: 8.5.8
+      storybook: 8.5.8(prettier@3.8.3)
       uuid: 9.0.1
 
-  '@storybook/addon-backgrounds@8.5.8(storybook@8.5.8)':
+  '@storybook/addon-backgrounds@8.5.8(storybook@8.5.8(prettier@3.8.3))':
     dependencies:
       '@storybook/global': 5.0.0
       memoizerific: 1.11.3
-      storybook: 8.5.8
+      storybook: 8.5.8(prettier@3.8.3)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-controls@8.5.8(storybook@8.5.8)':
+  '@storybook/addon-controls@8.5.8(storybook@8.5.8(prettier@3.8.3))':
     dependencies:
       '@storybook/global': 5.0.0
       dequal: 2.0.3
-      storybook: 8.5.8
+      storybook: 8.5.8(prettier@3.8.3)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-docs@8.5.8(@types/react@19.2.14)(storybook@8.5.8)':
+  '@storybook/addon-docs@8.5.8(@types/react@19.2.14)(storybook@8.5.8(prettier@3.8.3))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@storybook/blocks': 8.5.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@8.5.8)
-      '@storybook/csf-plugin': 8.5.8(storybook@8.5.8)
-      '@storybook/react-dom-shim': 8.5.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@8.5.8)
+      '@storybook/blocks': 8.5.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@8.5.8(prettier@3.8.3))
+      '@storybook/csf-plugin': 8.5.8(storybook@8.5.8(prettier@3.8.3))
+      '@storybook/react-dom-shim': 8.5.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@8.5.8(prettier@3.8.3))
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
-      storybook: 8.5.8
+      storybook: 8.5.8(prettier@3.8.3)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-essentials@8.5.8(@types/react@19.2.14)(storybook@8.5.8)':
+  '@storybook/addon-essentials@8.5.8(@types/react@19.2.14)(storybook@8.5.8(prettier@3.8.3))':
     dependencies:
-      '@storybook/addon-actions': 8.5.8(storybook@8.5.8)
-      '@storybook/addon-backgrounds': 8.5.8(storybook@8.5.8)
-      '@storybook/addon-controls': 8.5.8(storybook@8.5.8)
-      '@storybook/addon-docs': 8.5.8(@types/react@19.2.14)(storybook@8.5.8)
-      '@storybook/addon-highlight': 8.5.8(storybook@8.5.8)
-      '@storybook/addon-measure': 8.5.8(storybook@8.5.8)
-      '@storybook/addon-outline': 8.5.8(storybook@8.5.8)
-      '@storybook/addon-toolbars': 8.5.8(storybook@8.5.8)
-      '@storybook/addon-viewport': 8.5.8(storybook@8.5.8)
-      storybook: 8.5.8
+      '@storybook/addon-actions': 8.5.8(storybook@8.5.8(prettier@3.8.3))
+      '@storybook/addon-backgrounds': 8.5.8(storybook@8.5.8(prettier@3.8.3))
+      '@storybook/addon-controls': 8.5.8(storybook@8.5.8(prettier@3.8.3))
+      '@storybook/addon-docs': 8.5.8(@types/react@19.2.14)(storybook@8.5.8(prettier@3.8.3))
+      '@storybook/addon-highlight': 8.5.8(storybook@8.5.8(prettier@3.8.3))
+      '@storybook/addon-measure': 8.5.8(storybook@8.5.8(prettier@3.8.3))
+      '@storybook/addon-outline': 8.5.8(storybook@8.5.8(prettier@3.8.3))
+      '@storybook/addon-toolbars': 8.5.8(storybook@8.5.8(prettier@3.8.3))
+      '@storybook/addon-viewport': 8.5.8(storybook@8.5.8(prettier@3.8.3))
+      storybook: 8.5.8(prettier@3.8.3)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-highlight@8.5.8(storybook@8.5.8)':
+  '@storybook/addon-highlight@8.5.8(storybook@8.5.8(prettier@3.8.3))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 8.5.8
+      storybook: 8.5.8(prettier@3.8.3)
 
-  '@storybook/addon-interactions@8.5.8(storybook@8.5.8)':
+  '@storybook/addon-interactions@8.5.8(storybook@8.5.8(prettier@3.8.3))':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/instrumenter': 8.5.8(storybook@8.5.8)
-      '@storybook/test': 8.5.8(storybook@8.5.8)
+      '@storybook/instrumenter': 8.5.8(storybook@8.5.8(prettier@3.8.3))
+      '@storybook/test': 8.5.8(storybook@8.5.8(prettier@3.8.3))
       polished: 4.3.1
-      storybook: 8.5.8
+      storybook: 8.5.8(prettier@3.8.3)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-links@8.5.8(react@19.2.5)(storybook@8.5.8)':
+  '@storybook/addon-links@8.5.8(react@19.2.5)(storybook@8.5.8(prettier@3.8.3))':
     dependencies:
       '@storybook/csf': 0.1.12
       '@storybook/global': 5.0.0
-      storybook: 8.5.8
+      storybook: 8.5.8(prettier@3.8.3)
       ts-dedent: 2.2.0
     optionalDependencies:
       react: 19.2.5
 
-  '@storybook/addon-measure@8.5.8(storybook@8.5.8)':
+  '@storybook/addon-measure@8.5.8(storybook@8.5.8(prettier@3.8.3))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 8.5.8
+      storybook: 8.5.8(prettier@3.8.3)
       tiny-invariant: 1.3.3
 
   '@storybook/addon-onboarding@1.0.11(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
@@ -13450,36 +13825,36 @@ snapshots:
       - encoding
       - supports-color
 
-  '@storybook/addon-outline@8.5.8(storybook@8.5.8)':
+  '@storybook/addon-outline@8.5.8(storybook@8.5.8(prettier@3.8.3))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 8.5.8
+      storybook: 8.5.8(prettier@3.8.3)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-toolbars@8.5.8(storybook@8.5.8)':
+  '@storybook/addon-toolbars@8.5.8(storybook@8.5.8(prettier@3.8.3))':
     dependencies:
-      storybook: 8.5.8
+      storybook: 8.5.8(prettier@3.8.3)
 
-  '@storybook/addon-viewport@8.5.8(storybook@8.5.8)':
+  '@storybook/addon-viewport@8.5.8(storybook@8.5.8(prettier@3.8.3))':
     dependencies:
       memoizerific: 1.11.3
-      storybook: 8.5.8
+      storybook: 8.5.8(prettier@3.8.3)
 
-  '@storybook/blocks@8.5.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@8.5.8)':
+  '@storybook/blocks@8.5.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@8.5.8(prettier@3.8.3))':
     dependencies:
       '@storybook/csf': 0.1.12
       '@storybook/icons': 1.6.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      storybook: 8.5.8
+      storybook: 8.5.8(prettier@3.8.3)
       ts-dedent: 2.2.0
     optionalDependencies:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  '@storybook/builder-vite@8.5.8(storybook@8.5.8)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))':
+  '@storybook/builder-vite@8.5.8(storybook@8.5.8(prettier@3.8.3))(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@storybook/csf-plugin': 8.5.8(storybook@8.5.8)
+      '@storybook/csf-plugin': 8.5.8(storybook@8.5.8(prettier@3.8.3))
       browser-assert: 1.2.1
-      storybook: 8.5.8
+      storybook: 8.5.8(prettier@3.8.3)
       ts-dedent: 2.2.0
       vite: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)
 
@@ -13496,9 +13871,9 @@ snapshots:
     dependencies:
       '@storybook/global': 5.0.0
 
-  '@storybook/components@8.5.8(storybook@8.5.8)':
+  '@storybook/components@8.5.8(storybook@8.5.8(prettier@3.8.3))':
     dependencies:
-      storybook: 8.5.8
+      storybook: 8.5.8(prettier@3.8.3)
 
   '@storybook/core-common@7.6.24':
     dependencies:
@@ -13533,7 +13908,7 @@ snapshots:
     dependencies:
       ts-dedent: 2.2.0
 
-  '@storybook/core@8.5.8':
+  '@storybook/core@8.5.8(prettier@3.8.3)':
     dependencies:
       '@storybook/csf': 0.1.12
       better-opn: 3.0.2
@@ -13546,14 +13921,16 @@ snapshots:
       semver: 7.7.4
       util: 0.12.5
       ws: 8.20.0
+    optionalDependencies:
+      prettier: 3.8.3
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@storybook/csf-plugin@8.5.8(storybook@8.5.8)':
+  '@storybook/csf-plugin@8.5.8(storybook@8.5.8(prettier@3.8.3))':
     dependencies:
-      storybook: 8.5.8
+      storybook: 8.5.8(prettier@3.8.3)
       unplugin: 1.16.1
 
   '@storybook/csf-tools@7.6.24':
@@ -13585,63 +13962,63 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  '@storybook/instrumenter@8.5.8(storybook@8.5.8)':
+  '@storybook/instrumenter@8.5.8(storybook@8.5.8(prettier@3.8.3))':
     dependencies:
       '@storybook/global': 5.0.0
       '@vitest/utils': 2.1.9
-      storybook: 8.5.8
+      storybook: 8.5.8(prettier@3.8.3)
 
-  '@storybook/manager-api@8.5.8(storybook@8.5.8)':
+  '@storybook/manager-api@8.5.8(storybook@8.5.8(prettier@3.8.3))':
     dependencies:
-      storybook: 8.5.8
+      storybook: 8.5.8(prettier@3.8.3)
 
   '@storybook/node-logger@7.6.24': {}
 
-  '@storybook/preview-api@8.5.8(storybook@8.5.8)':
+  '@storybook/preview-api@8.5.8(storybook@8.5.8(prettier@3.8.3))':
     dependencies:
-      storybook: 8.5.8
+      storybook: 8.5.8(prettier@3.8.3)
 
-  '@storybook/react-dom-shim@8.5.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@8.5.8)':
+  '@storybook/react-dom-shim@8.5.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@8.5.8(prettier@3.8.3))':
     dependencies:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
-      storybook: 8.5.8
+      storybook: 8.5.8(prettier@3.8.3)
 
-  '@storybook/react-vite@8.5.8(@storybook/test@8.5.8(storybook@8.5.8))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rollup@4.60.2)(storybook@8.5.8)(typescript@6.0.3)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))':
+  '@storybook/react-vite@8.5.8(@storybook/test@8.5.8(storybook@8.5.8(prettier@3.8.3)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rollup@4.60.2)(storybook@8.5.8(prettier@3.8.3))(typescript@6.0.3)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.5.0(typescript@6.0.3)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))
       '@rollup/pluginutils': 5.3.0(rollup@4.60.2)
-      '@storybook/builder-vite': 8.5.8(storybook@8.5.8)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))
-      '@storybook/react': 8.5.8(@storybook/test@8.5.8(storybook@8.5.8))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@8.5.8)(typescript@6.0.3)
+      '@storybook/builder-vite': 8.5.8(storybook@8.5.8(prettier@3.8.3))(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))
+      '@storybook/react': 8.5.8(@storybook/test@8.5.8(storybook@8.5.8(prettier@3.8.3)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@8.5.8(prettier@3.8.3))(typescript@6.0.3)
       find-up: 5.0.0
       magic-string: 0.30.21
       react: 19.2.5
       react-docgen: 7.1.1
       react-dom: 19.2.5(react@19.2.5)
       resolve: 1.22.12
-      storybook: 8.5.8
+      storybook: 8.5.8(prettier@3.8.3)
       tsconfig-paths: 4.2.0
       vite: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3)
     optionalDependencies:
-      '@storybook/test': 8.5.8(storybook@8.5.8)
+      '@storybook/test': 8.5.8(storybook@8.5.8(prettier@3.8.3))
     transitivePeerDependencies:
       - rollup
       - supports-color
       - typescript
 
-  '@storybook/react@8.5.8(@storybook/test@8.5.8(storybook@8.5.8))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@8.5.8)(typescript@6.0.3)':
+  '@storybook/react@8.5.8(@storybook/test@8.5.8(storybook@8.5.8(prettier@3.8.3)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@8.5.8(prettier@3.8.3))(typescript@6.0.3)':
     dependencies:
-      '@storybook/components': 8.5.8(storybook@8.5.8)
+      '@storybook/components': 8.5.8(storybook@8.5.8(prettier@3.8.3))
       '@storybook/global': 5.0.0
-      '@storybook/manager-api': 8.5.8(storybook@8.5.8)
-      '@storybook/preview-api': 8.5.8(storybook@8.5.8)
-      '@storybook/react-dom-shim': 8.5.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@8.5.8)
-      '@storybook/theming': 8.5.8(storybook@8.5.8)
+      '@storybook/manager-api': 8.5.8(storybook@8.5.8(prettier@3.8.3))
+      '@storybook/preview-api': 8.5.8(storybook@8.5.8(prettier@3.8.3))
+      '@storybook/react-dom-shim': 8.5.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@8.5.8(prettier@3.8.3))
+      '@storybook/theming': 8.5.8(storybook@8.5.8(prettier@3.8.3))
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
-      storybook: 8.5.8
+      storybook: 8.5.8(prettier@3.8.3)
     optionalDependencies:
-      '@storybook/test': 8.5.8(storybook@8.5.8)
+      '@storybook/test': 8.5.8(storybook@8.5.8(prettier@3.8.3))
       typescript: 6.0.3
 
   '@storybook/telemetry@7.6.24':
@@ -13658,21 +14035,21 @@ snapshots:
       - encoding
       - supports-color
 
-  '@storybook/test@8.5.8(storybook@8.5.8)':
+  '@storybook/test@8.5.8(storybook@8.5.8(prettier@3.8.3))':
     dependencies:
       '@storybook/csf': 0.1.12
       '@storybook/global': 5.0.0
-      '@storybook/instrumenter': 8.5.8(storybook@8.5.8)
+      '@storybook/instrumenter': 8.5.8(storybook@8.5.8(prettier@3.8.3))
       '@testing-library/dom': 10.4.0
       '@testing-library/jest-dom': 6.5.0
       '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
       '@vitest/expect': 2.0.5
       '@vitest/spy': 2.0.5
-      storybook: 8.5.8
+      storybook: 8.5.8(prettier@3.8.3)
 
-  '@storybook/theming@8.5.8(storybook@8.5.8)':
+  '@storybook/theming@8.5.8(storybook@8.5.8(prettier@3.8.3))':
     dependencies:
-      storybook: 8.5.8
+      storybook: 8.5.8(prettier@3.8.3)
 
   '@storybook/types@7.6.24':
     dependencies:
@@ -16456,9 +16833,24 @@ snapshots:
 
   html-escaper@3.0.3: {}
 
+  html-to-text@9.0.5:
+    dependencies:
+      '@selderee/plugin-htmlparser2': 0.11.0
+      deepmerge: 4.3.1
+      dom-serializer: 2.0.0
+      htmlparser2: 8.0.2
+      selderee: 0.11.0
+
   html-void-elements@3.0.0: {}
 
   html-whitespace-sensitive-tag-names@3.0.1: {}
+
+  htmlparser2@8.0.2:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 4.5.0
 
   http-cache-semantics@4.2.0: {}
 
@@ -16849,6 +17241,8 @@ snapshots:
       dotenv: 16.6.1
       dotenv-expand: 10.0.0
 
+  leac@0.6.0: {}
+
   levn@0.4.1:
     dependencies:
       prelude-ls: 1.2.1
@@ -16999,6 +17393,8 @@ snapshots:
   markdown-extensions@2.0.0: {}
 
   markdown-table@3.0.4: {}
+
+  marked@15.0.12: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -17892,6 +18288,11 @@ snapshots:
     dependencies:
       entities: 8.0.0
 
+  parseley@0.12.1:
+    dependencies:
+      leac: 0.6.0
+      peberminta: 0.9.0
+
   parseurl@1.3.3: {}
 
   path-browserify@1.0.1: {}
@@ -17925,6 +18326,8 @@ snapshots:
   pathe@2.0.3: {}
 
   pathval@2.0.1: {}
+
+  peberminta@0.9.0: {}
 
   piccolore@0.1.3: {}
 
@@ -18019,6 +18422,8 @@ snapshots:
   preact@10.29.1: {}
 
   prelude-ls@1.2.1: {}
+
+  prettier@3.8.3: {}
 
   pretty-format@27.5.1:
     dependencies:
@@ -18586,6 +18991,10 @@ snapshots:
 
   scheduler@0.27.0: {}
 
+  selderee@0.11.0:
+    dependencies:
+      parseley: 0.12.1
+
   semver@5.7.2: {}
 
   semver@6.3.1: {}
@@ -18845,9 +19254,11 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
-  storybook@8.5.8:
+  storybook@8.5.8(prettier@3.8.3):
     dependencies:
-      '@storybook/core': 8.5.8
+      '@storybook/core': 8.5.8(prettier@3.8.3)
+    optionalDependencies:
+      prettier: 3.8.3
     transitivePeerDependencies:
       - bufferutil
       - supports-color

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - 'packages/tooling/*'
   - 'packages/blocks/*'
+  - 'packages/blocks/views/*'
   - 'packages/widgets/*'
   - 'packages/cli'
   - 'packages/ui'

--- a/workers/api/package.json
+++ b/workers/api/package.json
@@ -10,12 +10,13 @@
   "dependencies": {
     "@saas-maker/db": "workspace:*",
     "@saas-maker/email": "workspace:*",
-    "@saas-maker/shield": "workspace:*",
     "@saas-maker/ops": "workspace:*",
     "@saas-maker/shared-types": "workspace:*",
+    "@saas-maker/shield": "workspace:*",
     "drizzle-orm": "0.45.2",
     "hono": "4.12.15",
-    "jose": "6.2.2"
+    "jose": "6.2.2",
+    "react": "19.2.5"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "4.20260424.1",

--- a/workers/api/src/email.ts
+++ b/workers/api/src/email.ts
@@ -1,3 +1,10 @@
+import { configureEmail, email, NewFeedbackEmail, renderEmail } from '@saas-maker/email';
+import * as React from 'react';
+
+export function initEmail(accountId: string, apiToken: string, from: string): void {
+  configureEmail({ provider: 'cloudflare', accountId, apiToken, from });
+}
+
 interface SendEmailParams {
   to: string;
   projectName: string;
@@ -8,35 +15,25 @@ interface SendEmailParams {
   dashboardUrl: string;
 }
 
-export async function sendNewFeedbackEmail(
-  resendApiKey: string,
-  fromEmail: string,
-  params: SendEmailParams
-): Promise<void> {
+export async function sendNewFeedbackEmail(params: SendEmailParams): Promise<void> {
   const { to, projectName, feedbackTitle, feedbackType, feedbackDescription, submitterEmail, dashboardUrl } = params;
 
-  const response = await fetch('https://api.resend.com/emails', {
-    method: 'POST',
-    headers: { Authorization: `Bearer ${resendApiKey}`, 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      from: fromEmail,
-      to: [to],
-      subject: `[${projectName}] New ${feedbackType}: ${feedbackTitle}`,
-      html: `
-        <div style="font-family: sans-serif; max-width: 600px;">
-          <h2>New ${feedbackType} on ${projectName}</h2>
-          <p><strong>${feedbackTitle}</strong></p>
-          <p>${feedbackDescription}</p>
-          <p style="color: #666;">From: ${submitterEmail}</p>
-          <a href="${dashboardUrl}" style="display: inline-block; padding: 10px 20px; background: #1464ff; color: #fff; text-decoration: none; border-radius: 8px; margin-top: 12px;">
-            View in Dashboard
-          </a>
-        </div>
-      `,
-    }),
-  });
+  const { html, text } = await renderEmail(
+    React.createElement(NewFeedbackEmail, {
+      projectName,
+      feedbackTitle,
+      feedbackType,
+      feedbackDescription,
+      submitterEmail,
+      dashboardUrl,
+    })
+  );
 
-  if (!response.ok) {
-    console.error('Resend email failed:', await response.text());
-  }
+  await email.send({
+    to,
+    subject: `[${projectName}] New ${feedbackType}: ${feedbackTitle}`,
+    html,
+    text,
+    project: 'api',
+  });
 }

--- a/workers/api/src/routes/analytics.ts
+++ b/workers/api/src/routes/analytics.ts
@@ -71,7 +71,7 @@ analytics.post('/events', requireApiKey, async (c) => {
     pathname: extractPathname(body.url),
     session_id: computeSessionId(new Date().toISOString().slice(0, 10), country, device, browser, ipHash),
   };
-  await trace('db:trackEvent', () => db.createEvent(event), { project: 'saasmaker-api' });
+  await trace('db:trackEvent', () => db.createEvent(event));
 
   return c.json({ ok: true }, 201);
 });

--- a/workers/api/src/routes/feedback.ts
+++ b/workers/api/src/routes/feedback.ts
@@ -9,8 +9,9 @@ import {
   FeedbackRecord,
 } from '@saas-maker/shared-types';
 import { getDb } from '../db';
-import { email } from '@saas-maker/email';
+import { email, renderEmail, NewFeedbackEmail } from '@saas-maker/email';
 import { trace, capture } from '@saas-maker/ops';
+import * as React from 'react';
 
 const feedback = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 
@@ -68,19 +69,23 @@ feedback.post('/', requireApiKey, async (c) => {
     if (owner?.email) {
       scheduleBackgroundTask(
         c,
-        email.send({
-          to: owner.email,
-          subject: `New ${record.type} on ${project.name}`,
-          template: `New {{type}} submission on {{projectName}}\n\nFrom: {{submitter}}\nTitle: {{title}}\n{{description}}\n\nView in dashboard: {{dashboardUrl}}`,
-          data: {
+        renderEmail(
+          React.createElement(NewFeedbackEmail, {
             projectName: project.name,
-            type: record.type,
-            title: record.title,
-            description: record.description,
-            submitter: record.submitter_name || record.submitter_email || 'Anonymous',
+            feedbackTitle: record.title,
+            feedbackType: record.type,
+            feedbackDescription: record.description,
+            submitterEmail: record.submitter_name || record.submitter_email || 'Anonymous',
             dashboardUrl: `https://app.sassmaker.com/projects/${project.slug}/feedback`,
-          },
-        }).catch(() => {})
+          })
+        ).then(({ html, text }) =>
+          email.send({
+            to: owner.email,
+            subject: `New ${record.type} on ${project.name}`,
+            html,
+            text,
+          })
+        ).catch(() => {})
       );
     }
   }
@@ -103,7 +108,7 @@ feedback.get('/', requireApiKey, async (c) => {
 
   const db = getDb(c.env.DB);
   const options = { type, status, sort, page, limit: PAGE_SIZE };
-  const result = await trace('db:listFeedback', () => db.listFeedback(projectId, options), { project: 'saasmaker-api' }) as { data: FeedbackRecord[]; total: number };
+  const result = await trace('db:listFeedback', () => db.listFeedback(projectId, options)) as { data: FeedbackRecord[]; total: number };
 
   return c.json({ data: result.data, total: result.total, page, limit: PAGE_SIZE });
 });

--- a/workers/api/src/routes/projects.ts
+++ b/workers/api/src/routes/projects.ts
@@ -29,7 +29,7 @@ projects.get('/', async (c) => {
   const userId = c.get('userId')!;
   const source = c.req.query('source') || 'dashboard';
   const db = getDb(c.env.DB);
-  const data = await trace('db:listProjects', () => db.listProjectsByOwner(userId, source), { project: 'saasmaker-api' });
+  const data = await trace('db:listProjects', () => db.listProjectsByOwner(userId, source));
   return c.json({ data });
 });
 

--- a/workers/api/src/routes/waitlist.ts
+++ b/workers/api/src/routes/waitlist.ts
@@ -4,7 +4,8 @@ import { requireApiKey, requireSession } from '../middleware/auth';
 import { getDb } from '../db';
 import type { WaitlistSignupRequest } from '@saas-maker/shared-types';
 import { capture } from '@saas-maker/ops';
-import { email } from '@saas-maker/email';
+import { email, renderEmail, WaitlistSignupEmail } from '@saas-maker/email';
+import * as React from 'react';
 
 const waitlist = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 
@@ -35,18 +36,21 @@ waitlist.post('/', requireApiKey, async (c) => {
     if (project) {
       const owner = await db.getUserById(project.owner_id);
       if (owner?.email) {
-        email.send({
-          to: owner.email,
-          subject: `New waitlist signup for ${project.name}`,
-          template: `New {{type}} on {{projectName}}\n\nFrom: {{submitter}}\nTitle: {{title}}\n\nView in dashboard: {{dashboardUrl}}`,
-          data: {
+        renderEmail(
+          React.createElement(WaitlistSignupEmail, {
             projectName: project.name,
-            type: 'waitlist signup',
-            title: `New signup from ${entry.email}`,
-            submitter: entry.email,
+            signupEmail: entry.email,
+            signupName: entry.name ?? undefined,
             dashboardUrl: `https://app.sassmaker.com/projects/${project.slug}/waitlist`,
-          },
-        }).catch(() => {});
+          })
+        ).then(({ html, text }) =>
+          email.send({
+            to: owner.email,
+            subject: `New waitlist signup for ${project.name}`,
+            html,
+            text,
+          })
+        ).catch(() => {});
       }
     }
 

--- a/workers/api/wrangler.toml
+++ b/workers/api/wrangler.toml
@@ -6,6 +6,10 @@ workers_dev = true
 
 [observability]
 enabled = true
+head_sampling_rate = 0.1
+
+[limits]
+cpu_ms = 30000
 
 [ai]
 binding = "AI"


### PR DESCRIPTION
## Summary

Two new packages under `packages/blocks/views/` that lay the substrate for AI-personalisable, source-agnostic dashboards inside Foundry's cockpit.

- `@saas-maker/capability-graph` — typed entity registry. Sources register entities they provide; views declare what they need. Scopes enforced on every read/write; action args validated by Zod.
- `@saas-maker/views-runtime` — `<ViewRuntime>` mounts a live React dashboard from a JSON spec. Three default blocks (`MetricCard`, `List`, `Table`) styled via `@saas-maker/ui`. Pluggable block registry. Unknown-block fallback surfaces malformed specs instead of failing silently.

Both packages typecheck clean and ship with **26 passing unit tests** (15 graph + 11 runtime). Both are Phase 1 of a longer plan documented in `docs/views-runtime-roadmap.md`.

## Why this shape

- **Inside saas-maker, not a new repo** — cockpit shell, D1, auth, UI lib, hooks, OpenAPI machinery already exist. Saves weeks of bootstrap.
- **Two packages, not one** — graph has zero React deps, so it's reusable in workers/CLI/agents.
- **JSON spec, Zod-validated** — LLM-emittable, persistable, language-agnostic. The runtime renders an explicit error card on bad input.
- **shadcn via `@saas-maker/ui`** — no new styling surface; respects `@saas-maker/tailwind-preset`.
- **No marketplace / sandboxing / signing yet** — those come in Phase 7 once we have users. See roadmap.

## Quick API tour

\`\`\`tsx
import { z } from 'zod';
import { createGraph, entity } from '@saas-maker/capability-graph';
import { ViewRuntime } from '@saas-maker/views-runtime';

const Issue = entity({
  id: 'issue',
  fields: { id: z.string(), title: z.string(), status: z.string(), points: z.number() },
});

const graph = createGraph().provide({
  source: 'linear',
  entity: Issue,
  fetch: async () => [{ id: '1', title: 'Fix login', status: 'open', points: 3 }],
});

<ViewRuntime
  spec={{
    id: 'sprint',
    title: 'Sprint health',
    bindings: { open: { entity: 'issue' } },
    blocks: [
      { id: 'pts', type: 'MetricCard', binding: 'open',
        props: { label: 'Story points', field: 'points', aggregate: 'sum' } },
      { id: 'list', type: 'List', binding: 'open',
        props: { primary: 'title', secondary: 'status' } },
    ],
  }}
  graph={graph}
  ctx={{ scopes: new Set(['issue:read']) }}
/>
\`\`\`

## What's NOT in this PR (intentional)

- No cockpit page refactored to use the runtime yet — that's Phase 2.
- No persistence — specs live in code only.
- No external integrations (Gmail/GitHub/Stripe) — Phase 3.
- No prompt-to-tweak loop — Phase 4.
- No drag-and-drop layout — Phase 5+ once we know which views need it.
- No marketplace, signing, or sandboxing — Phase 7.

## Roadmap

See [`docs/views-runtime-roadmap.md`](./docs/views-runtime-roadmap.md) for the full phased plan, decision log, and cross-cutting concerns (security, performance, testing).

## Test plan

- [x] `pnpm -F @saas-maker/capability-graph test` — 15/15 pass
- [x] `pnpm -F @saas-maker/capability-graph typecheck` — clean
- [x] `pnpm -F @saas-maker/views-runtime test` — 11/11 pass
- [x] `pnpm -F @saas-maker/views-runtime typecheck` — clean
- [ ] Reviewer reads `docs/views-runtime-roadmap.md` and challenges any phase ordering
- [ ] Reviewer skims the spec schema in `packages/blocks/views/runtime/src/spec.ts` and pushes back if too restrictive / too loose
- [ ] Reviewer scans `CapabilityGraph` for the scope-enforcement model

## Known fleet-wide issues (not introduced here)

- `packages/tooling/tailwind-preset` and `packages/blocks/posthog-client` have pre-existing TS errors in their tests. Verified on clean main. Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)