### PR TITLE
Show Droid audit logs in Cockpit tasks

### DIFF
--- a/apps/cockpit/src/app/(app)/tasks/[id]/page.tsx
+++ b/apps/cockpit/src/app/(app)/tasks/[id]/page.tsx
@@ -4,7 +4,7 @@ import { headers } from 'next/headers';
 import { apiFetchAuthed } from '@/lib/api-client';
 import { isLocalAuthBypassEnabled } from '@/lib/local-auth';
 import { TaskDetailClient } from '@/components/tasks/TaskDetailClient';
-import type { SymphonyRunRow, TaskCommentRow, TaskRow } from '@/components/tasks/TaskBoard';
+import type { SymphonyAuditLogRow, SymphonyRunRow, TaskCommentRow, TaskRow } from '@/components/tasks/TaskBoard';
 
 export const dynamic = 'force-dynamic';
 

--- a/apps/cockpit/src/components/tasks/TaskBoard.tsx
+++ b/apps/cockpit/src/components/tasks/TaskBoard.tsx
@@ -67,6 +67,18 @@ export interface SymphonyRunRow {
   created_at?: string;
 }
 
+export interface SymphonyAuditLogRow {
+  id: string;
+  owner_id: string;
+  task_id: string | null;
+  action: string;
+  actor_source: string;
+  agent_profile: string | null;
+  project_slug: string | null;
+  metadata: string;
+  created_at: string;
+}
+
 function getDependencies(task: TaskRow): string[] {
   return Array.isArray(task.dependencies) ? task.dependencies : [];
 }


### PR DESCRIPTION
Droid autonomous opencode run for the audit-log task after capped parent supervisor hardening.