### PR TITLE
Prepare public repo and improve Droid blocking

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Contributing
+
+Thanks for taking a look at SaaS Maker. This repo is public, but it is still an active product workspace, so small focused changes are easiest to review.
+
+## Development
+
+```bash
+pnpm install
+pnpm test
+pnpm typecheck
+```
+
+Prefer the smallest relevant check before broader test runs. If you change API routes, also run:
+
+```bash
+pnpm generate:openapi
+pnpm check:openapi
+```
+
+## Pull Requests
+
+- Keep diffs focused.
+- Include tests or a clear reason they are not needed.
+- Update docs when behavior changes.
+- Do not commit secrets, local environment files, generated credentials, or production config.
+- Do not deploy from a PR unless the maintainer explicitly asks for it.
+
+## Project Notes
+
+Agent-facing repo rules live in [AGENTS.md](AGENTS.md). They are part of the working contract for humans and AI agents in this repo.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Sarthak Agrawal
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,78 +1,74 @@
-# Foundry ⚒️
+# SaaS Maker
 
-**The Industrial Software Factory for Project Fleets.**
+SaaS Maker is a TypeScript monorepo for building and operating small SaaS products across a project fleet. It includes a Cloudflare Workers API, a Next.js cockpit, embeddable widgets, shared backend blocks, documentation, and an experimental autonomous runner called Droid.
 
-Foundry is a high-leverage engineering system designed for developers and AI agents to manage multiple JavaScript/TypeScript projects at scale. It moves beyond "Tooling" into "Industrialization," providing a standardized factory floor, automated assembly lines, and a registry of operational protocols (Skills) for autonomous fleet management.
+The repo is public, but parts of the deployment are still personal/internal. Treat this as an active product workspace rather than a polished framework release.
 
----
+## What Is Inside
 
-## 🏛️ The Five Pillars
+- `workers/api` - Hono API on Cloudflare Workers with D1 and Drizzle.
+- `workers/droid` - Experimental Cloudflare Sandbox runner for task execution and PR creation.
+- `apps/cockpit` - Next.js dashboard for projects, tasks, fleet state, and Droid runs.
+- `apps/docs` - Astro/Starlight docs site.
+- `apps/showcase` - Widget and product showcase.
+- `packages/cli` - `fnd` CLI backed by the generated OpenAPI spec.
+- `packages/blocks` - Shared backend and operational packages.
+- `packages/widgets` - Embeddable feedback, changelog, progress, testimonials, waitlist, and badge widgets.
+- `packages/tooling` - Shared TypeScript, ESLint, Prettier, test, Renovate, and Tailwind config.
 
-### 1. The Standard (Tooling)
-Standardize your entire fleet with versioned, shared configurations.
-*   **`@saas-maker/eslint-config`**: Unified rules for Next.js, Vite, and Node.
-*   **`@saas-maker/tsconfig`**: Strict, optimized TypeScript bases.
+## Current Status
 
-### 2. The Blocks (Shared Logic)
-Headless capabilities that every project needs, optimized for Edge and Node.
-*   **`@saas-maker/ops`**: Unified error handling and tracing.
-*   **`@saas-maker/db`**: Environment-aware SQLite factory (D1/Turso).
+- API, cockpit, docs, widgets, and CLI are actively developed.
+- Droid v1 can run sandboxed tasks and create draft PRs, but it is still experimental.
+- Public docs are being cleaned up as the repository becomes more open-source friendly.
 
-### 3. The Commander (CLI)
-Automate your assembly line.
-*   `fnd fleet run`: Parallel command execution across 22+ repos.
-*   `fnd fleet audit`: Deep health checks (dead code, drift, debt).
-*   `fnd fleet fix`: Automated correction of fleet-wide issues.
+## Quick Start
 
-### 4. The Forge (Scaffolding)
-Blueprint-based project creation.
-*   `fnd forge`: Start "Foundry Compliant" projects in 5 seconds.
-*   **Agent-Native**: Every project is born with an `AGENTS.md` foreman.
+```bash
+pnpm install
+pnpm test
+pnpm typecheck
+```
 
-### 5. The Registry (Agent Skills)
-The brain of the factory.
-*   **`skills/`**: Standardized Markdown protocols that teach AI agents how to migrate, debug, and expand the fleet autonomously.
+Run the main apps locally:
 
----
+```bash
+pnpm dev:api
+pnpm dev:cockpit
+pnpm dev:cockpit:local
+```
 
-## 🚀 Quick Start
+Useful checks:
 
-1. **Install the CLI**:
-   ```bash
-   pnpm add -g @saas-maker/cli
-   ```
+```bash
+pnpm lint
+pnpm smoke
+pnpm check:openapi
+```
 
-2. **Forge a Project**:
-   ```bash
-   fnd forge --name my-new-app --type next
-   ```
+Some commands require Cloudflare, GitHub, or SaaS Maker production credentials. Do not commit secrets or local environment files.
 
-3. **Link the Agent Hook**:
-   Connect your global agent harness (e.g. Claude Code) to the Foundry Factory.
-   ```bash
-   # Add this to your shell profile or .claude/hooks
-   source ./scripts/foundry-agent-hook.sh
-   ```
+## API And CLI
 
-4. **Audit the Fleet**:
-   ```bash
-   fnd fleet audit
-   ```
+SaaS Maker is API-first. When API routes change, regenerate and check the OpenAPI artifacts:
 
----
+```bash
+pnpm generate:openapi
+pnpm check:openapi
+```
 
-## 📂 Repository Structure
+The CLI validates commands against the generated OpenAPI spec. Prefer `fnd api` and generated SDK flows over one-off scripts for product features.
 
-*   `packages/tooling/`: Gold Standard configurations.
-*   `packages/blocks/`: Operational Layer logic.
-*   `packages/widgets/`: Modular UI blocks.
-*   `skills/`: Agentic Operational Protocols.
-*   `apps/cockpit/`: The Mission Control Dashboard (Next.js).
-*   `apps/docs/`: The Factory Manual (Astro Starlight).
-*   `apps/showcase/`: The Production Landing Page & Widget Showcase (Next.js).
+## Droid
 
----
+Droid is the autonomous task runner for SaaS Maker. It starts a Cloudflare Sandbox, hydrates a repo, runs a command or agent, captures logs and patches, and can raise a draft PR.
 
-## ⚖️ License
+See [docs/droid-roadmap.md](docs/droid-roadmap.md) for what is next before Droid should be treated as a hands-off production employee.
 
-Open source under the MIT License.
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md). For security issues, use [SECURITY.md](SECURITY.md) instead of opening a public issue.
+
+## License
+
+MIT. See [LICENSE](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Reporting
+
+Please do not open a public issue for security reports.
+
+Send a private report to the repository owner with:
+
+- affected package, app, or worker
+- reproduction steps
+- expected impact
+- any relevant logs with secrets removed
+
+## Secrets
+
+Never commit API keys, tokens, SSH keys, `.env` files, Cloudflare credentials, GitHub credentials, or production config. If a secret is exposed, rotate it immediately and remove it from history if it was committed.
+
+## Supported Versions
+
+This repository is under active development. Security fixes target `main` unless a separate supported release branch is announced.

--- a/docs/droid-roadmap.md
+++ b/docs/droid-roadmap.md
@@ -1,0 +1,103 @@
+# Droid Roadmap
+
+Droid is usable as an experimental v1 runner: it can start a Cloudflare Sandbox, hydrate a repository, run work, capture audit events, and raise a draft PR. The next work is about making it reliable enough to trust without hand-holding.
+
+## Next Tasks
+
+1. Runner contract
+   - Define a provider interface for command, native DeepSeek, OpenCode, Codebuff, Codex, Claude Code, and future backends.
+   - Require streaming or heartbeat events from every provider.
+   - Treat buffered CLIs as unreliable unless wrapped by a parent watcher.
+
+2. Completion and idle semantics
+   - Add an explicit completion marker for agent prompts.
+   - Stop early when the marker or structured final response appears.
+   - Track last output time separately from hard run timeout.
+
+3. Stuck-run recovery
+   - Add a timeout policy for runs with no events.
+   - Auto-cancel or mark stale runs failed.
+   - Release the repo queue when a run is stale.
+
+4. Runner observability
+   - Show active run, queue depth, sandbox id, duration, last event, and failure reason in Cockpit.
+   - Add a compact stats endpoint for Droid health.
+
+5. Better PR quality gate
+   - Require changed-file summary, patch review result, and test command output before PR creation.
+   - Keep PRs draft by default.
+   - Add a clear failure summary when no meaningful diff is produced.
+
+6. Safer task context
+   - Hydrate Droid prompts with task title, comments, project metadata, repo guidance, and acceptance criteria.
+   - Support prompt templates with safe variables such as task id, source branch, target branch, project slug, and acceptance criteria.
+   - Keep secrets out of logs and prompts.
+
+7. Task feedback loop
+   - Let Droid post agent comments back to `/v1/tasks/:id/comments`.
+   - Let Droid mark a task `blocked_on_user` when it needs credentials, a product decision, a review, or permission to deploy.
+   - Include the blocker reason, run id, last command, changed-file summary, and exact question for the user.
+   - Use a scoped SaaS Maker service or CLI token stored as a Droid Worker secret.
+   - Keep raw command logs in Droid run events; keep task comments concise.
+
+8. Branch and workspace policy
+   - Use explicit Droid branches for every PR-capable run.
+   - Preserve dirty workspaces on failure when possible.
+   - Clean up successful clean workspaces automatically.
+
+9. Multi-step run plans
+   - Split larger jobs into implement, review, and fix phases.
+   - Reuse the same sandbox/workspace across those phases.
+   - Record per-phase outputs and checks.
+
+10. Model and tool routing
+
+- Keep command mode as the fallback.
+- Add configurable agent backends.
+- Test Codebuff, OpenCode, and the custom runner against the same task fixture.
+
+11. Structured outputs
+
+- Require final agent output to include machine-readable summary, files changed, tests run, risks, and next action.
+- Validate that payload before PR creation.
+
+12. Cost controls
+
+- Track sandbox duration, vCPU seconds, memory hours, disk hours, and egress per run.
+- Surface estimated cost in the run summary.
+
+13. Production controls
+
+- Add task-level permissions for edit, push, PR, deploy, and release.
+- Require explicit approval for deploy/release tasks.
+- Add audit-log search and export.
+
+## Sandcastle Ideas To Borrow
+
+[Sandcastle](https://github.com/mattpocock/sandcastle) is a useful reference for Droid because it focuses on orchestrating coding agents rather than being another agent. Relevant ideas:
+
+- Provider abstraction: sandbox runtime and agent runtime should be pluggable.
+- Line-by-line event streaming: this powers live logs and idle timeout detection.
+- Explicit branch strategy: head, merge-to-head, or named branch. Droid should default to named PR branches.
+- Reusable sandbox: run implement and review agents in the same workspace before opening a PR.
+- Lifecycle hooks: separate setup steps from the agent prompt.
+- Prompt templates: support safe variables and controlled context expansion.
+- Completion signal: stop the loop early when the agent proves it is done.
+- Structured final output: parse a tagged JSON result before deciding whether to PR.
+- Abort and cleanup: preserve dirty workspaces after failure; clean up when safe.
+
+Do not vendor Sandcastle for Droid v1. Borrow the architecture and contracts, then add a Cloudflare Sandbox provider only if the custom runner starts duplicating too much orchestration code.
+
+## Definition Of Hands-Off
+
+Droid becomes a hands-off production employee when it can:
+
+- pick up a task from Cockpit
+- create a meaningful patch without manual intervention
+- run the smallest relevant checks
+- produce a draft PR with audit logs and test output
+- comment back on the task when it needs help
+- mark the task blocked when user input is required
+- recover or fail clearly when stuck
+- avoid leaking secrets
+- show cost and runtime stats for the run

--- a/docs/plans/2026-05-11-foundry-droid-sandbox-runner.md
+++ b/docs/plans/2026-05-11-foundry-droid-sandbox-runner.md
@@ -135,10 +135,29 @@ These belong mostly in V2, after V0 proves execution and V1 makes the runner usa
 - **Blueprints:** workflow steps in code. Deterministic steps run git, lint, tests, CI, PR/deploy; agent steps handle ambiguous code changes.
 - **Tool registry:** SaaS Maker MCP/API tools for tasks, docs, project metadata, GitHub, CI, deploys, and logs. Expose only the tools needed for the task.
 - **Context preflight:** hydrate the prompt with task comments, linked docs, project metadata, `AGENTS.md`, recent failures, and relevant files before the agent starts.
+- **Task feedback loop:** let Droid post concise task comments and set `blocked_on_user` when it needs a decision, credential, review, or deploy approval.
 - **Fast local checks:** run the smallest lint/type/test checks before CI.
 - **Retry budget:** cap automated CI/test repair loops, then return to the user with a clear failure summary.
 - **Scoped rules:** apply repo/subdirectory-specific guidance, not one giant global prompt.
 - **Review gate:** PRs are human-reviewed by default; deploys require task-level permission.
+
+## Sandcastle Reference
+
+[Sandcastle](https://github.com/mattpocock/sandcastle) is relevant because it treats coding agents as orchestrated jobs with provider contracts, branch strategies, lifecycle hooks, completion signals, idle timeouts, and structured output.
+
+Borrow these ideas:
+
+- **Provider contracts:** separate agent providers from sandbox providers. Droid should eventually support native DeepSeek, OpenCode, Codebuff, Codex, Claude Code, local Mac runners, and Cloudflare Sandbox through the same runner contract.
+- **Streaming requirement:** every provider must emit line-by-line output or heartbeat events. This is the key fix for stuck headless CLIs.
+- **Named branches:** every PR-capable run should work on an explicit `droid/<run>` branch, not a vague working tree.
+- **Reusable phases:** implement, review, and fix can run in the same sandbox before PR creation.
+- **Lifecycle hooks:** setup, dependency install, and context hydration should be first-class steps, not hidden inside the prompt.
+- **Prompt templates:** task prompts should support safe variables such as source branch, target branch, task id, project slug, and acceptance criteria.
+- **Completion signal:** teach agents to emit an explicit done marker or structured final payload so the runner can stop early.
+- **Structured output:** require final JSON with summary, files changed, checks run, risks, and recommended next action.
+- **Cleanup policy:** preserve dirty workspaces after failure; destroy clean successful sandboxes.
+
+Do not adopt Sandcastle wholesale yet. Droid already has Cloudflare-specific queueing, audit events, PR creation, and task integration. The useful path is to steal the orchestration contracts and add a Cloudflare Sandbox provider later only if it reduces custom code.
 
 ## Version Split
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "foundry",
   "version": "1.0.0",
   "private": true,
+  "license": "MIT",
   "scripts": {
     "dev:api": "pnpm -F @saas-maker/api dev",
     "dev:cockpit": "pnpm -F @saas-maker/dashboard dev",

--- a/tests/droid/runs.test.ts
+++ b/tests/droid/runs.test.ts
@@ -7,11 +7,15 @@ describe('droid runs', () => {
     const app = createApp(fakeExecutor());
     const env = createEnv();
 
-    const response = await app.request('/v0/runs', {
-      method: 'POST',
-      body: JSON.stringify({ command: 'echo ok' }),
-      headers: { 'Content-Type': 'application/json' },
-    }, env);
+    const response = await app.request(
+      '/v0/runs',
+      {
+        method: 'POST',
+        body: JSON.stringify({ command: 'echo ok' }),
+        headers: { 'Content-Type': 'application/json' },
+      },
+      env
+    );
 
     expect(response.status).toBe(401);
   });
@@ -20,14 +24,18 @@ describe('droid runs', () => {
     const app = createApp(fakeExecutor());
     const env = createEnv();
 
-    const response = await app.request('/v0/runs', {
-      method: 'POST',
-      body: JSON.stringify({ repo_url: 'ftp://example.test/repo.git' }),
-      headers: {
-        'Authorization': 'Bearer test-token',
-        'Content-Type': 'application/json',
+    const response = await app.request(
+      '/v0/runs',
+      {
+        method: 'POST',
+        body: JSON.stringify({ repo_url: 'ftp://example.test/repo.git' }),
+        headers: {
+          Authorization: 'Bearer test-token',
+          'Content-Type': 'application/json',
+        },
       },
-    }, env);
+      env
+    );
 
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({ error: 'command is required' });
@@ -37,14 +45,18 @@ describe('droid runs', () => {
     const app = createApp(fakeExecutor());
     const env = createEnv();
 
-    const response = await app.request('/v0/runs', {
-      method: 'POST',
-      body: JSON.stringify({ mode: 'native', provider: 'deepseek' }),
-      headers: {
-        'Authorization': 'Bearer test-token',
-        'Content-Type': 'application/json',
+    const response = await app.request(
+      '/v0/runs',
+      {
+        method: 'POST',
+        body: JSON.stringify({ mode: 'native', provider: 'deepseek' }),
+        headers: {
+          Authorization: 'Bearer test-token',
+          'Content-Type': 'application/json',
+        },
       },
-    }, env);
+      env
+    );
 
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({ error: 'prompt is required' });
@@ -54,17 +66,23 @@ describe('droid runs', () => {
     const app = createApp(fakeExecutor());
     const env = createEnv({ DROID_DEEPSEEK_API_KEY: undefined });
 
-    const response = await app.request('/v0/runs', {
-      method: 'POST',
-      body: JSON.stringify({ mode: 'native', provider: 'deepseek', prompt: 'inspect the repo' }),
-      headers: {
-        'Authorization': 'Bearer test-token',
-        'Content-Type': 'application/json',
+    const response = await app.request(
+      '/v0/runs',
+      {
+        method: 'POST',
+        body: JSON.stringify({ mode: 'native', provider: 'deepseek', prompt: 'inspect the repo' }),
+        headers: {
+          Authorization: 'Bearer test-token',
+          'Content-Type': 'application/json',
+        },
       },
-    }, env);
+      env
+    );
 
     expect(response.status).toBe(503);
-    await expect(response.json()).resolves.toEqual({ error: 'DROID_DEEPSEEK_API_KEY is required for native Droid runs' });
+    await expect(response.json()).resolves.toEqual({
+      error: 'DROID_DEEPSEEK_API_KEY is required for native Droid runs',
+    });
     expect((env.DB as unknown as FakeD1).runs.size).toBe(0);
   });
 
@@ -72,17 +90,23 @@ describe('droid runs', () => {
     const app = createApp(fakeExecutor());
     const env = createEnv({ DROID_GITHUB_TOKEN: undefined });
 
-    const response = await app.request('/v0/runs', {
-      method: 'POST',
-      body: JSON.stringify({ command: 'echo ok', create_pr: true }),
-      headers: {
-        'Authorization': 'Bearer test-token',
-        'Content-Type': 'application/json',
+    const response = await app.request(
+      '/v0/runs',
+      {
+        method: 'POST',
+        body: JSON.stringify({ command: 'echo ok', create_pr: true }),
+        headers: {
+          Authorization: 'Bearer test-token',
+          'Content-Type': 'application/json',
+        },
       },
-    }, env);
+      env
+    );
 
     expect(response.status).toBe(503);
-    await expect(response.json()).resolves.toEqual({ error: 'DROID_GITHUB_TOKEN is required when create_pr is true' });
+    await expect(response.json()).resolves.toEqual({
+      error: 'DROID_GITHUB_TOKEN is required when create_pr is true',
+    });
     expect((env.DB as unknown as FakeD1).runs.size).toBe(0);
   });
 
@@ -90,17 +114,27 @@ describe('droid runs', () => {
     const app = createApp(fakeExecutor());
     const env = createEnv();
 
-    const response = await app.request('/v0/runs', {
-      method: 'POST',
-      body: JSON.stringify({ mode: 'native', provider: 'deepseek', prompt: 'inspect the repo', max_turns: 3, wait_for_completion: true }),
-      headers: {
-        'Authorization': 'Bearer test-token',
-        'Content-Type': 'application/json',
+    const response = await app.request(
+      '/v0/runs',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          mode: 'native',
+          provider: 'deepseek',
+          prompt: 'inspect the repo',
+          max_turns: 3,
+          wait_for_completion: true,
+        }),
+        headers: {
+          Authorization: 'Bearer test-token',
+          'Content-Type': 'application/json',
+        },
       },
-    }, env);
+      env
+    );
 
     expect(response.status).toBe(201);
-    const payload = await response.json() as { data: { command: string; status: string } };
+    const payload = (await response.json()) as { data: { command: string; status: string } };
     expect(payload.data.command).toBe('native: inspect the repo');
     expect(payload.data.status).toBe('completed');
   });
@@ -109,32 +143,44 @@ describe('droid runs', () => {
     const app = createApp(fakeExecutor());
     const env = createEnv();
 
-    const response = await app.request('/v0/runs', {
-      method: 'POST',
-      body: JSON.stringify({
-        task_id: 'task-1',
-        project_slug: 'saas-maker',
-        repo_url: 'https://github.com/example/repo.git',
-        branch: 'main',
-        command: 'echo ok',
-        wait_for_completion: true,
-      }),
-      headers: {
-        'Authorization': 'Bearer test-token',
-        'Content-Type': 'application/json',
+    const response = await app.request(
+      '/v0/runs',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          task_id: 'task-1',
+          project_slug: 'saas-maker',
+          repo_url: 'https://github.com/example/repo.git',
+          branch: 'main',
+          command: 'echo ok',
+          wait_for_completion: true,
+        }),
+        headers: {
+          Authorization: 'Bearer test-token',
+          'Content-Type': 'application/json',
+        },
       },
-    }, env);
+      env
+    );
 
     expect(response.status).toBe(201);
-    const payload = await response.json() as { data: { id: string; status: string; exit_code: number } };
+    const payload = (await response.json()) as {
+      data: { id: string; status: string; exit_code: number };
+    };
     expect(payload.data.status).toBe('completed');
     expect(payload.data.exit_code).toBe(0);
 
-    const eventsResponse = await app.request(`/v0/runs/${payload.data.id}/events`, {
-      headers: { Authorization: 'Bearer test-token' },
-    }, env);
+    const eventsResponse = await app.request(
+      `/v0/runs/${payload.data.id}/events`,
+      {
+        headers: { Authorization: 'Bearer test-token' },
+      },
+      env
+    );
     expect(eventsResponse.status).toBe(200);
-    const eventsPayload = await eventsResponse.json() as { data: Array<{ type: string; stdout: string | null }> };
+    const eventsPayload = (await eventsResponse.json()) as {
+      data: Array<{ type: string; stdout: string | null }>;
+    };
     expect(eventsPayload.data.map((event) => event.type)).toEqual([
       'run_request',
       'run_started',
@@ -143,6 +189,38 @@ describe('droid runs', () => {
       'run_finished',
     ]);
     expect(eventsPayload.data[3].stdout).toBe('ok\n');
+  });
+
+  it('passes task metadata through to the executor', async () => {
+    const seen: Array<{ taskId?: string; projectSlug?: string }> = [];
+    const app = createApp({
+      async execute(input) {
+        seen.push({ taskId: input.taskId, projectSlug: input.projectSlug });
+        return { stdout: 'ok\n', stderr: '', exitCode: 0, success: true };
+      },
+    });
+    const env = createEnv();
+
+    const response = await app.request(
+      '/v0/runs',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          task_id: 'task-blockable',
+          project_slug: 'saas-maker',
+          command: 'echo ok',
+          wait_for_completion: true,
+        }),
+        headers: {
+          Authorization: 'Bearer test-token',
+          'Content-Type': 'application/json',
+        },
+      },
+      env
+    );
+
+    expect(response.status).toBe(201);
+    expect(seen).toEqual([{ taskId: 'task-blockable', projectSlug: 'saas-maker' }]);
   });
 
   it('lists run artifacts', async () => {
@@ -159,19 +237,27 @@ describe('droid runs', () => {
     });
     const env = createEnv();
 
-    const response = await app.request('/v0/runs', {
-      method: 'POST',
-      body: JSON.stringify({ command: 'echo ok', wait_for_completion: true }),
-      headers: {
-        'Authorization': 'Bearer test-token',
-        'Content-Type': 'application/json',
+    const response = await app.request(
+      '/v0/runs',
+      {
+        method: 'POST',
+        body: JSON.stringify({ command: 'echo ok', wait_for_completion: true }),
+        headers: {
+          Authorization: 'Bearer test-token',
+          'Content-Type': 'application/json',
+        },
       },
-    }, env);
-    const payload = await response.json() as { data: { id: string } };
+      env
+    );
+    const payload = (await response.json()) as { data: { id: string } };
 
-    const artifactsResponse = await app.request(`/v0/runs/${payload.data.id}/artifacts`, {
-      headers: { Authorization: 'Bearer test-token' },
-    }, env);
+    const artifactsResponse = await app.request(
+      `/v0/runs/${payload.data.id}/artifacts`,
+      {
+        headers: { Authorization: 'Bearer test-token' },
+      },
+      env
+    );
 
     expect(artifactsResponse.status).toBe(200);
     await expect(artifactsResponse.json()).resolves.toMatchObject({
@@ -189,24 +275,32 @@ describe('droid runs', () => {
     const app = createApp(fakeExecutor());
     const env = createEnv();
 
-    const response = await app.request('/v0/runs', {
-      method: 'POST',
-      body: JSON.stringify({
-        task_id: 'task-logs',
-        project_slug: 'saas-maker',
-        command: 'echo ok',
-        wait_for_completion: true,
-      }),
-      headers: {
-        'Authorization': 'Bearer test-token',
-        'Content-Type': 'application/json',
+    const response = await app.request(
+      '/v0/runs',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          task_id: 'task-logs',
+          project_slug: 'saas-maker',
+          command: 'echo ok',
+          wait_for_completion: true,
+        }),
+        headers: {
+          Authorization: 'Bearer test-token',
+          'Content-Type': 'application/json',
+        },
       },
-    }, env);
+      env
+    );
     expect(response.status).toBe(201);
 
-    const listResponse = await app.request('/v0/runs?task_id=task-logs&limit=1', {
-      headers: { Authorization: 'Bearer test-token' },
-    }, env);
+    const listResponse = await app.request(
+      '/v0/runs?task_id=task-logs&limit=1',
+      {
+        headers: { Authorization: 'Bearer test-token' },
+      },
+      env
+    );
 
     expect(listResponse.status).toBe(200);
     await expect(listResponse.json()).resolves.toMatchObject({
@@ -224,35 +318,60 @@ describe('droid runs', () => {
     const app = createApp({
       async execute(input) {
         if (input.command === 'hang') return new Promise(() => undefined);
-        if (input.command === 'fail') return { stdout: '', stderr: 'nope', exitCode: 1, success: false };
+        if (input.command === 'fail')
+          return { stdout: '', stderr: 'nope', exitCode: 1, success: false };
         return { stdout: 'ok\n', stderr: '', exitCode: 0, success: true };
       },
     });
     const env = createEnv();
     const headers = {
-      'Authorization': 'Bearer test-token',
+      Authorization: 'Bearer test-token',
       'Content-Type': 'application/json',
     };
 
-    await app.request('/v0/runs', {
-      method: 'POST',
-      body: JSON.stringify({ project_slug: 'saas-maker', command: 'pass', wait_for_completion: true }),
-      headers,
-    }, env);
-    await app.request('/v0/runs', {
-      method: 'POST',
-      body: JSON.stringify({ project_slug: 'saas-maker', command: 'fail', wait_for_completion: true }),
-      headers,
-    }, env);
-    await app.request('/v0/runs', {
-      method: 'POST',
-      body: JSON.stringify({ project_slug: 'saas-maker', command: 'hang' }),
-      headers,
-    }, env);
+    await app.request(
+      '/v0/runs',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          project_slug: 'saas-maker',
+          command: 'pass',
+          wait_for_completion: true,
+        }),
+        headers,
+      },
+      env
+    );
+    await app.request(
+      '/v0/runs',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          project_slug: 'saas-maker',
+          command: 'fail',
+          wait_for_completion: true,
+        }),
+        headers,
+      },
+      env
+    );
+    await app.request(
+      '/v0/runs',
+      {
+        method: 'POST',
+        body: JSON.stringify({ project_slug: 'saas-maker', command: 'hang' }),
+        headers,
+      },
+      env
+    );
 
-    const response = await app.request('/v0/stats?project_slug=saas-maker&limit=2', {
-      headers: { Authorization: 'Bearer test-token' },
-    }, env);
+    const response = await app.request(
+      '/v0/stats?project_slug=saas-maker&limit=2',
+      {
+        headers: { Authorization: 'Bearer test-token' },
+      },
+      env
+    );
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({
@@ -265,9 +384,7 @@ describe('droid runs', () => {
           failed: 1,
         },
         stale_running: 1,
-        recent: expect.arrayContaining([
-          expect.objectContaining({ project_slug: 'saas-maker' }),
-        ]),
+        recent: expect.arrayContaining([expect.objectContaining({ project_slug: 'saas-maker' })]),
       },
     });
   });
@@ -282,48 +399,60 @@ describe('droid runs', () => {
     });
     const env = createEnv();
     const headers = {
-      'Authorization': 'Bearer test-token',
+      Authorization: 'Bearer test-token',
       'Content-Type': 'application/json',
     };
 
-    const firstResponse = await app.request('/v0/runs', {
-      method: 'POST',
-      body: JSON.stringify({
-        project_slug: 'saas-maker',
-        repo_url: 'https://github.com/example/repo.git',
-        command: 'first',
-      }),
-      headers,
-    }, env);
+    const firstResponse = await app.request(
+      '/v0/runs',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          project_slug: 'saas-maker',
+          repo_url: 'https://github.com/example/repo.git',
+          command: 'first',
+        }),
+        headers,
+      },
+      env
+    );
     expect(firstResponse.status).toBe(202);
-    const firstPayload = await firstResponse.json() as { data: { id: string; status: string } };
+    const firstPayload = (await firstResponse.json()) as { data: { id: string; status: string } };
     expect(firstPayload.data.status).toBe('running');
 
-    const secondResponse = await app.request('/v0/runs', {
-      method: 'POST',
-      body: JSON.stringify({
-        project_slug: 'saas-maker',
-        repo_url: 'https://github.com/example/repo.git',
-        command: 'second',
-        wait_for_completion: true,
-      }),
-      headers,
-    }, env);
+    const secondResponse = await app.request(
+      '/v0/runs',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          project_slug: 'saas-maker',
+          repo_url: 'https://github.com/example/repo.git',
+          command: 'second',
+          wait_for_completion: true,
+        }),
+        headers,
+      },
+      env
+    );
 
     expect(secondResponse.status).toBe(202);
-    const secondPayload = await secondResponse.json() as { data: { id: string; status: string }; queued_after: string };
+    const secondPayload = (await secondResponse.json()) as {
+      data: { id: string; status: string };
+      queued_after: string;
+    };
     expect(secondPayload.data.status).toBe('queued');
     expect(secondPayload.queued_after).toBe(firstPayload.data.id);
     expect(executeCalls).toBe(1);
 
-    const eventsResponse = await app.request(`/v0/runs/${secondPayload.data.id}/events`, {
-      headers: { Authorization: 'Bearer test-token' },
-    }, env);
-    const eventsPayload = await eventsResponse.json() as { data: Array<{ type: string }> };
-    expect(eventsPayload.data.map((event) => event.type)).toEqual([
-      'run_request',
-      'run_queued',
-    ]);
+    const eventsResponse = await app.request(
+      `/v0/runs/${secondPayload.data.id}/events`,
+      {
+        headers: { Authorization: 'Bearer test-token' },
+      },
+      env
+    );
+    const eventsPayload = (await eventsResponse.json()) as { data: Array<{ type: string }> };
+    expect(eventsPayload.data.map((event) => event.type)).toEqual(['run_request', 'run_queued']);
   });
 
   it('auto-dequeues a queued same-repo run after the active run finishes', async () => {
@@ -342,50 +471,68 @@ describe('droid runs', () => {
     });
     const env = createEnv();
     const headers = {
-      'Authorization': 'Bearer test-token',
+      Authorization: 'Bearer test-token',
       'Content-Type': 'application/json',
     };
 
-    const firstResponsePromise = app.request('/v0/runs', {
-      method: 'POST',
-      body: JSON.stringify({
-        project_slug: 'saas-maker',
-        repo_url: 'https://github.com/example/repo.git',
-        command: 'first',
-        wait_for_completion: true,
-      }),
-      headers,
-    }, env);
+    const firstResponsePromise = app.request(
+      '/v0/runs',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          project_slug: 'saas-maker',
+          repo_url: 'https://github.com/example/repo.git',
+          command: 'first',
+          wait_for_completion: true,
+        }),
+        headers,
+      },
+      env
+    );
     while (!releaseFirst) await Promise.resolve();
 
-    const queuedResponse = await app.request('/v0/runs', {
-      method: 'POST',
-      body: JSON.stringify({
-        project_slug: 'saas-maker',
-        repo_url: 'https://github.com/example/repo.git',
-        command: 'second',
-      }),
-      headers,
-    }, env);
-    const queuedPayload = await queuedResponse.json() as { data: { id: string; status: string } };
+    const queuedResponse = await app.request(
+      '/v0/runs',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          project_slug: 'saas-maker',
+          repo_url: 'https://github.com/example/repo.git',
+          command: 'second',
+        }),
+        headers,
+      },
+      env
+    );
+    const queuedPayload = (await queuedResponse.json()) as { data: { id: string; status: string } };
     expect(queuedPayload.data.status).toBe('queued');
 
     releaseFirst();
     await firstResponsePromise;
     for (let i = 0; i < 5 && executeCommands.length < 2; i += 1) await Promise.resolve();
 
-    const dequeuedResponse = await app.request(`/v0/runs/${queuedPayload.data.id}`, {
-      headers: { Authorization: 'Bearer test-token' },
-    }, env);
-    const dequeuedPayload = await dequeuedResponse.json() as { data: { status: string; exit_code: number } };
+    const dequeuedResponse = await app.request(
+      `/v0/runs/${queuedPayload.data.id}`,
+      {
+        headers: { Authorization: 'Bearer test-token' },
+      },
+      env
+    );
+    const dequeuedPayload = (await dequeuedResponse.json()) as {
+      data: { status: string; exit_code: number };
+    };
     expect(dequeuedPayload.data.status).toBe('completed');
     expect(dequeuedPayload.data.exit_code).toBe(0);
     expect(executeCommands).toEqual(['first', 'second']);
 
-    const eventsResponse = await app.request(`/v0/runs/${queuedPayload.data.id}/events`, {
-      headers: { Authorization: 'Bearer test-token' },
-    }, env);
-    const eventsPayload = await eventsResponse.json() as { data: Array<{ type: string }> };
+    const eventsResponse = await app.request(
+      `/v0/runs/${queuedPayload.data.id}/events`,
+      {
+        headers: { Authorization: 'Bearer test-token' },
+      },
+      env
+    );
+    const eventsPayload = (await eventsResponse.json()) as { data: Array<{ type: string }> };
     expect(eventsPayload.data.map((event) => event.type)).toEqual([
       'run_request',
       'run_queued',
@@ -404,17 +551,21 @@ describe('droid runs', () => {
     });
     const env = createEnv();
 
-    const response = await app.request('/v0/runs', {
-      method: 'POST',
-      body: JSON.stringify({ command: 'echo ok' }),
-      headers: {
-        'Authorization': 'Bearer test-token',
-        'Content-Type': 'application/json',
+    const response = await app.request(
+      '/v0/runs',
+      {
+        method: 'POST',
+        body: JSON.stringify({ command: 'echo ok' }),
+        headers: {
+          Authorization: 'Bearer test-token',
+          'Content-Type': 'application/json',
+        },
       },
-    }, env);
+      env
+    );
 
     expect(response.status).toBe(202);
-    const payload = await response.json() as { data: { status: string } };
+    const payload = (await response.json()) as { data: { status: string } };
     expect(payload.data.status).toBe('running');
   });
 
@@ -432,27 +583,42 @@ describe('droid runs', () => {
     });
     const env = createEnv();
 
-    const createResponse = await app.request('/v0/runs', {
-      method: 'POST',
-      body: JSON.stringify({ mode: 'native', provider: 'deepseek', prompt: 'make the change', create_pr: true }),
-      headers: {
-        'Authorization': 'Bearer test-token',
-        'Content-Type': 'application/json',
+    const createResponse = await app.request(
+      '/v0/runs',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          mode: 'native',
+          provider: 'deepseek',
+          prompt: 'make the change',
+          create_pr: true,
+        }),
+        headers: {
+          Authorization: 'Bearer test-token',
+          'Content-Type': 'application/json',
+        },
       },
-    }, env);
-    const createPayload = await createResponse.json() as { data: { id: string } };
+      env
+    );
+    const createPayload = (await createResponse.json()) as { data: { id: string } };
 
-    const reconcileResponse = await app.request(`/v0/runs/${createPayload.data.id}/reconcile`, {
-      method: 'POST',
-      body: JSON.stringify({ wait_for_completion: true }),
-      headers: {
-        'Authorization': 'Bearer test-token',
-        'Content-Type': 'application/json',
+    const reconcileResponse = await app.request(
+      `/v0/runs/${createPayload.data.id}/reconcile`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ wait_for_completion: true }),
+        headers: {
+          Authorization: 'Bearer test-token',
+          'Content-Type': 'application/json',
+        },
       },
-    }, env);
+      env
+    );
 
     expect(reconcileResponse.status).toBe(200);
-    const reconcilePayload = await reconcileResponse.json() as { data: { status: string; summary: string } };
+    const reconcilePayload = (await reconcileResponse.json()) as {
+      data: { status: string; summary: string };
+    };
     expect(reconcilePayload.data.status).toBe('completed');
     expect(reconcilePayload.data.summary).toBe('Command completed with exit code 0.');
   });
@@ -477,29 +643,43 @@ describe('droid runs', () => {
     const env = createEnv();
 
     try {
-      const responsePromise = app.request('/v0/runs', {
-        method: 'POST',
-        body: JSON.stringify({ command: 'sleep forever', timeout_seconds: 60, wait_for_completion: true }),
-        headers: {
-          'Authorization': 'Bearer test-token',
-          'Content-Type': 'application/json',
+      const responsePromise = app.request(
+        '/v0/runs',
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            command: 'sleep forever',
+            timeout_seconds: 60,
+            wait_for_completion: true,
+          }),
+          headers: {
+            Authorization: 'Bearer test-token',
+            'Content-Type': 'application/json',
+          },
         },
-      }, env);
+        env
+      );
 
       await vi.advanceTimersByTimeAsync(60_001);
       const response = await responsePromise;
 
       expect(response.status).toBe(201);
-      const payload = await response.json() as { data: { id: string; status: string; exit_code: number; error_message: string } };
+      const payload = (await response.json()) as {
+        data: { id: string; status: string; exit_code: number; error_message: string };
+      };
       expect(payload.data.status).toBe('failed');
       expect(payload.data.exit_code).toBe(124);
       expect(payload.data.error_message).toBe('Droid run timed out after 60 seconds.');
       expect(cancelCalls).toHaveLength(1);
 
-      const eventsResponse = await app.request(`/v0/runs/${payload.data.id}/events`, {
-        headers: { Authorization: 'Bearer test-token' },
-      }, env);
-      const eventsPayload = await eventsResponse.json() as { data: Array<{ type: string }> };
+      const eventsResponse = await app.request(
+        `/v0/runs/${payload.data.id}/events`,
+        {
+          headers: { Authorization: 'Bearer test-token' },
+        },
+        env
+      );
+      const eventsPayload = (await eventsResponse.json()) as { data: Array<{ type: string }> };
       expect(eventsPayload.data.map((event) => event.type)).toEqual([
         'run_request',
         'run_started',
@@ -517,7 +697,11 @@ describe('droid runs', () => {
 function fakeExecutor(): RunExecutor {
   return {
     async execute(input) {
-      await input.recordEvent({ type: 'command_start', command: input.command, cwd: '/workspace/repo' });
+      await input.recordEvent({
+        type: 'command_start',
+        command: input.command,
+        cwd: '/workspace/repo',
+      });
       await input.recordEvent({
         type: 'command_finish',
         command: input.command,
@@ -555,7 +739,10 @@ class FakeD1 {
 class FakeStatement {
   private params: unknown[] = [];
 
-  constructor(private db: FakeD1, private sql: string) {}
+  constructor(
+    private db: FakeD1,
+    private sql: string
+  ) {}
 
   bind(...params: unknown[]) {
     this.params = params;
@@ -564,16 +751,7 @@ class FakeStatement {
 
   async run() {
     if (this.sql.includes('INSERT INTO droid_runs')) {
-      const [
-        id,
-        task_id,
-        project_slug,
-        repo_url,
-        branch,
-        command,
-        cwd,
-        sandbox_id,
-      ] = this.params;
+      const [id, task_id, project_slug, repo_url, branch, command, cwd, sandbox_id] = this.params;
       this.db.runs.set(String(id), {
         id,
         task_id,
@@ -596,7 +774,10 @@ class FakeStatement {
 
     if (this.sql.includes("SET status = 'running'")) {
       const id = String(this.params[0]);
-      Object.assign(this.db.runs.get(id)!, { status: 'running', started_at: '2026-05-11 00:00:01' });
+      Object.assign(this.db.runs.get(id)!, {
+        status: 'running',
+        started_at: '2026-05-11 00:00:01',
+      });
     }
 
     if (this.sql.includes('SET status = ?, exit_code = ?')) {
@@ -644,14 +825,7 @@ class FakeStatement {
     }
 
     if (this.sql.includes('INSERT INTO droid_run_artifacts')) {
-      const [
-        id,
-        run_id,
-        type,
-        name,
-        uri,
-        metadata,
-      ] = this.params;
+      const [id, run_id, type, name, uri, metadata] = this.params;
       this.db.artifacts.push({
         id,
         run_id,
@@ -674,9 +848,10 @@ class FakeStatement {
         .map((run) => run.duration_ms)
         .filter((duration): duration is number => typeof duration === 'number');
       return {
-        avg_duration_ms: durations.length === 0
-          ? null
-          : durations.reduce((sum, duration) => sum + duration, 0) / durations.length,
+        avg_duration_ms:
+          durations.length === 0
+            ? null
+            : durations.reduce((sum, duration) => sum + duration, 0) / durations.length,
       };
     }
     if (this.sql.includes('SELECT COUNT(*) AS count FROM droid_runs')) {
@@ -684,11 +859,10 @@ class FakeStatement {
       return {
         count: Array.from(this.db.runs.values())
           .filter((run) => projectSlug === undefined || run.project_slug === projectSlug)
-          .filter((run) => run.status === 'running' && run.started_at)
-          .length,
+          .filter((run) => run.status === 'running' && run.started_at).length,
       };
     }
-    if (this.sql.includes("FROM droid_run_events") && this.sql.includes("type = 'run_request'")) {
+    if (this.sql.includes('FROM droid_run_events') && this.sql.includes("type = 'run_request'")) {
       const [runId] = this.params;
       const event = this.db.events
         .filter((item) => item.run_id === runId && item.type === 'run_request')
@@ -699,15 +873,19 @@ class FakeStatement {
       const [runId] = this.params;
       return this.db.events.filter((item) => item.run_id === runId).at(-1) ?? null;
     }
-    if (this.sql.includes('FROM droid_runs') && this.sql.includes('id != ?') && (this.sql.includes("status = 'running'") || this.sql.includes("status = 'queued'"))) {
+    if (
+      this.sql.includes('FROM droid_runs') &&
+      this.sql.includes('id != ?') &&
+      (this.sql.includes("status = 'running'") || this.sql.includes("status = 'queued'"))
+    ) {
       const [queueValue, excludeRunId] = this.params;
       const key = this.sql.includes('repo_url = ?') ? 'repo_url' : 'project_slug';
       const status = this.sql.includes("status = 'queued'") ? 'queued' : 'running';
-      return Array.from(this.db.runs.values()).find((run) => (
-        run[key] === queueValue &&
-        run.status === status &&
-        run.id !== excludeRunId
-      )) ?? null;
+      return (
+        Array.from(this.db.runs.values()).find(
+          (run) => run[key] === queueValue && run.status === status && run.id !== excludeRunId
+        ) ?? null
+      );
     }
     if (this.sql.includes('SELECT * FROM droid_runs WHERE id = ?')) {
       return this.db.runs.get(String(this.params[0])) ?? null;
@@ -752,7 +930,9 @@ class FakeStatement {
       return { results: this.db.events.filter((event) => event.run_id === this.params[0]) };
     }
     if (this.sql.includes('SELECT * FROM droid_run_artifacts WHERE run_id = ?')) {
-      return { results: this.db.artifacts.filter((artifact) => artifact.run_id === this.params[0]) };
+      return {
+        results: this.db.artifacts.filter((artifact) => artifact.run_id === this.params[0]),
+      };
     }
     return { results: [] };
   }

--- a/workers/droid/src/app.ts
+++ b/workers/droid/src/app.ts
@@ -1,7 +1,29 @@
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
-import { createRun, createRunArtifact, createRunEvent, finishRun, getActiveRunForQueue, getLatestRunEvent, getLatestRunRequest, getNextQueuedRunForQueue, getRun, getRunStats, listRunArtifacts, listRunEvents, listRuns, markRunStarted } from './db';
-import type { CommandResult, Env, RunExecutionInput, RunExecutor, RunMode, RunRequest } from './types';
+import {
+  createRun,
+  createRunArtifact,
+  createRunEvent,
+  finishRun,
+  getActiveRunForQueue,
+  getLatestRunEvent,
+  getLatestRunRequest,
+  getNextQueuedRunForQueue,
+  getRun,
+  getRunStats,
+  listRunArtifacts,
+  listRunEvents,
+  listRuns,
+  markRunStarted,
+} from './db';
+import type {
+  CommandResult,
+  Env,
+  RunExecutionInput,
+  RunExecutor,
+  RunMode,
+  RunRequest,
+} from './types';
 
 const DEFAULT_TIMEOUT_SECONDS = 900;
 const DEFAULT_RECONCILE_TIMEOUT_SECONDS = 240;
@@ -14,11 +36,14 @@ type Variables = {
 export function createApp(executor: RunExecutor) {
   const app = new Hono<{ Bindings: Env; Variables: Variables }>();
 
-  app.use('*', cors({
-    origin: '*',
-    allowHeaders: ['Authorization', 'Content-Type'],
-    allowMethods: ['GET', 'POST', 'OPTIONS'],
-  }));
+  app.use(
+    '*',
+    cors({
+      origin: '*',
+      allowHeaders: ['Authorization', 'Content-Type'],
+      allowMethods: ['GET', 'POST', 'OPTIONS'],
+    })
+  );
 
   app.use('*', async (c, next) => {
     c.set('requestId', crypto.randomUUID());
@@ -42,7 +67,7 @@ export function createApp(executor: RunExecutor) {
   });
 
   app.post('/v0/runs', async (c) => {
-    const body = await c.req.json().catch(() => null) as RunRequest | null;
+    const body = (await c.req.json().catch(() => null)) as RunRequest | null;
     const validation = validateRunRequest(body);
     if (!validation.ok) return c.json({ error: validation.error }, 400);
 
@@ -52,9 +77,10 @@ export function createApp(executor: RunExecutor) {
     const mode = normalizeMode(body?.mode);
     const environmentValidation = validateRunEnvironment(c.env, body, mode);
     if (!environmentValidation.ok) return c.json({ error: environmentValidation.error }, 503);
-    const command = mode !== 'command'
-      ? buildAgentLedgerCommand(mode, body?.prompt?.trim() ?? '')
-      : body!.command!.trim();
+    const command =
+      mode !== 'command'
+        ? buildAgentLedgerCommand(mode, body?.prompt?.trim() ?? '')
+        : body!.command!.trim();
 
     const run = await createRun(c.env, {
       id: runId,
@@ -88,7 +114,8 @@ export function createApp(executor: RunExecutor) {
     if (activeRun) {
       await createRunEvent(c.env, runId, {
         type: 'run_queued',
-        message: 'Droid run queued because another run is already active for this repository/project.',
+        message:
+          'Droid run queued because another run is already active for this repository/project.',
         command,
         metadata: {
           active_run_id: activeRun.id,
@@ -122,6 +149,8 @@ export function createApp(executor: RunExecutor) {
       runId,
       sandboxId,
       startedAt,
+      taskId: body?.task_id?.trim(),
+      projectSlug: body?.project_slug?.trim(),
       repoUrl: body?.repo_url?.trim(),
       branch: body?.branch?.trim(),
       command,
@@ -151,7 +180,10 @@ export function createApp(executor: RunExecutor) {
     }
 
     const updatedRun = await getRun(c.env, runId);
-    return c.json({ data: updatedRun ?? run }, updatedRun ? (body?.wait_for_completion === true ? 201 : 202) : 500);
+    return c.json(
+      { data: updatedRun ?? run },
+      updatedRun ? (body?.wait_for_completion === true ? 201 : 202) : 500
+    );
   });
 
   app.get('/v0/runs/:id', async (c) => {
@@ -200,17 +232,21 @@ export function createApp(executor: RunExecutor) {
       metadata: { sandbox_id: run.sandbox_id },
     });
     if (!executor.cancel) return c.json({ error: 'Run cancellation is not supported' }, 501);
-    const cancelPromise = executor.cancel({
-      env: c.env,
-      runId: run.id,
-      sandboxId: run.sandbox_id,
-      recordEvent: (event) => createRunEvent(c.env, run.id, event),
-      recordArtifact: (artifact) => createRunArtifact(c.env, run.id, artifact),
-    }).catch((error) => createRunEvent(c.env, run.id, {
-      type: 'sandbox_destroy_failed',
-      message: error instanceof Error ? error.message : 'Sandbox destroy failed.',
-      metadata: { sandbox_id: run.sandbox_id },
-    }));
+    const cancelPromise = executor
+      .cancel({
+        env: c.env,
+        runId: run.id,
+        sandboxId: run.sandbox_id,
+        recordEvent: (event) => createRunEvent(c.env, run.id, event),
+        recordArtifact: (artifact) => createRunArtifact(c.env, run.id, artifact),
+      })
+      .catch((error) =>
+        createRunEvent(c.env, run.id, {
+          type: 'sandbox_destroy_failed',
+          message: error instanceof Error ? error.message : 'Sandbox destroy failed.',
+          metadata: { sandbox_id: run.sandbox_id },
+        })
+      );
     try {
       c.executionCtx.waitUntil(cancelPromise);
     } catch {
@@ -239,7 +275,10 @@ export function createApp(executor: RunExecutor) {
     if (run.status === 'completed' || run.status === 'failed') {
       return c.json({ data: run, reconciled: false });
     }
-    const incoming = await c.req.json().catch(() => null) as { wait_for_completion?: boolean; force?: boolean } | null;
+    const incoming = (await c.req.json().catch(() => null)) as {
+      wait_for_completion?: boolean;
+      force?: boolean;
+    } | null;
     const request = await getLatestRunRequest(c.env, run.id);
     if (run.status === 'queued') {
       const queuedInput = executionInputFromRun(run, request);
@@ -249,10 +288,13 @@ export function createApp(executor: RunExecutor) {
         excludeRunId: run.id,
       });
       if (!incoming?.force && activeRun) {
-        return c.json({
-          error: 'Run is queued behind an active Droid run.',
-          active_run_id: activeRun.id,
-        }, 409);
+        return c.json(
+          {
+            error: 'Run is queued behind an active Droid run.',
+            active_run_id: activeRun.id,
+          },
+          409
+        );
       }
 
       await createRunEvent(c.env, run.id, {
@@ -298,16 +340,27 @@ export function createApp(executor: RunExecutor) {
       }
 
       const updatedRun = await getRun(c.env, run.id);
-      return c.json({ data: updatedRun ?? run, dequeued: true }, incoming?.wait_for_completion === true ? 200 : 202);
+      return c.json(
+        { data: updatedRun ?? run, dequeued: true },
+        incoming?.wait_for_completion === true ? 200 : 202
+      );
     }
 
     if (!executor.reconcile) return c.json({ error: 'Run reconciliation is not supported' }, 501);
     const latestEvent = await getLatestRunEvent(c.env, run.id);
-    if (!incoming?.force && latestEvent && !isStaleEvent(latestEvent.created_at, RECONCILE_STALE_AFTER_MS)) {
-      return c.json({
-        error: 'Run still appears active; reconcile is only allowed after 6 minutes of no events unless force is true.',
-        latest_event_at: latestEvent.created_at,
-      }, 409);
+    if (
+      !incoming?.force &&
+      latestEvent &&
+      !isStaleEvent(latestEvent.created_at, RECONCILE_STALE_AFTER_MS)
+    ) {
+      return c.json(
+        {
+          error:
+            'Run still appears active; reconcile is only allowed after 6 minutes of no events unless force is true.',
+          latest_event_at: latestEvent.created_at,
+        },
+        409
+      );
     }
 
     await createRunEvent(c.env, run.id, {
@@ -334,13 +387,19 @@ export function createApp(executor: RunExecutor) {
     }
 
     const updatedRun = await getRun(c.env, run.id);
-    return c.json({ data: updatedRun ?? run, reconciled: true }, incoming?.wait_for_completion === true ? 200 : 202);
+    return c.json(
+      { data: updatedRun ?? run, reconciled: true },
+      incoming?.wait_for_completion === true ? 200 : 202
+    );
   });
 
   return app;
 }
 
-function scheduleBackground(c: { executionCtx: { waitUntil: (promise: Promise<unknown>) => void } }, promise: Promise<void>) {
+function scheduleBackground(
+  c: { executionCtx: { waitUntil: (promise: Promise<unknown>) => void } },
+  promise: Promise<void>
+) {
   try {
     c.executionCtx.waitUntil(promise);
   } catch {
@@ -354,32 +413,40 @@ function isStaleEvent(createdAt: string, thresholdMs: number): boolean {
   return Date.now() - parsed >= thresholdMs;
 }
 
-async function executeRun(env: Env, executor: RunExecutor, input: {
-  runId: string;
-  sandboxId: string;
-  startedAt: number;
-  repoUrl?: string;
-  branch?: string;
-  command: string;
-  mode: RunMode;
-  prompt?: string;
-  provider?: 'deepseek';
-  maxTurns?: number;
-  timeoutSeconds: number;
-  createPr: boolean;
-  prTitle?: string;
-  prBody?: string;
-  prBaseBranch?: string;
-  cwd?: string;
-  destroyAfterRun: boolean;
-  reconcile?: boolean;
-  waitUntil?: (promise: Promise<void>) => void;
-}): Promise<void> {
+async function executeRun(
+  env: Env,
+  executor: RunExecutor,
+  input: {
+    runId: string;
+    sandboxId: string;
+    startedAt: number;
+    taskId?: string;
+    projectSlug?: string;
+    repoUrl?: string;
+    branch?: string;
+    command: string;
+    mode: RunMode;
+    prompt?: string;
+    provider?: 'deepseek';
+    maxTurns?: number;
+    timeoutSeconds: number;
+    createPr: boolean;
+    prTitle?: string;
+    prBody?: string;
+    prBaseBranch?: string;
+    cwd?: string;
+    destroyAfterRun: boolean;
+    reconcile?: boolean;
+    waitUntil?: (promise: Promise<void>) => void;
+  }
+): Promise<void> {
   try {
     const executionInput: RunExecutionInput = {
       env,
       runId: input.runId,
       sandboxId: input.sandboxId,
+      taskId: input.taskId,
+      projectSlug: input.projectSlug,
       repoUrl: input.repoUrl,
       branch: input.branch,
       command: input.command,
@@ -397,9 +464,10 @@ async function executeRun(env: Env, executor: RunExecutor, input: {
       recordEvent: (event) => createRunEvent(env, input.runId, event),
       recordArtifact: (artifact) => createRunArtifact(env, input.runId, artifact),
     };
-    const operation = input.reconcile && executor.reconcile
-      ? executor.reconcile(executionInput)
-      : executor.execute(executionInput);
+    const operation =
+      input.reconcile && executor.reconcile
+        ? executor.reconcile(executionInput)
+        : executor.execute(executionInput);
     const result = await runWithTimeout(operation, input.timeoutSeconds * 1000);
 
     const durationMs = Date.now() - input.startedAt;
@@ -441,11 +509,13 @@ async function executeRun(env: Env, executor: RunExecutor, input: {
       metadata: { duration_ms: durationMs },
     });
   } finally {
-    const nextPromise = dispatchNextQueuedRun(env, executor, input).catch((error) => createRunEvent(env, input.runId, {
-      type: 'queue_dispatch_failed',
-      message: error instanceof Error ? error.message : 'Droid queue dispatch failed.',
-      metadata: { run_id: input.runId },
-    }));
+    const nextPromise = dispatchNextQueuedRun(env, executor, input).catch((error) =>
+      createRunEvent(env, input.runId, {
+        type: 'queue_dispatch_failed',
+        message: error instanceof Error ? error.message : 'Droid queue dispatch failed.',
+        metadata: { run_id: input.runId },
+      })
+    );
     if (input.waitUntil) {
       input.waitUntil(nextPromise);
     } else {
@@ -454,11 +524,15 @@ async function executeRun(env: Env, executor: RunExecutor, input: {
   }
 }
 
-async function dispatchNextQueuedRun(env: Env, executor: RunExecutor, input: {
-  runId: string;
-  repoUrl?: string;
-  waitUntil?: (promise: Promise<void>) => void;
-}): Promise<void> {
+async function dispatchNextQueuedRun(
+  env: Env,
+  executor: RunExecutor,
+  input: {
+    runId: string;
+    repoUrl?: string;
+    waitUntil?: (promise: Promise<void>) => void;
+  }
+): Promise<void> {
   const finishedRun = await getRun(env, input.runId);
   if (!finishedRun) return;
   const nextRun = await getNextQueuedRunForQueue(env, {
@@ -530,12 +604,17 @@ class RunTimeoutError extends Error {
   }
 }
 
-async function handleRunTimeout(env: Env, executor: RunExecutor, input: {
-  runId: string;
-  sandboxId: string;
-  startedAt: number;
-  timeoutSeconds: number;
-}, error: RunTimeoutError): Promise<void> {
+async function handleRunTimeout(
+  env: Env,
+  executor: RunExecutor,
+  input: {
+    runId: string;
+    sandboxId: string;
+    startedAt: number;
+    timeoutSeconds: number;
+  },
+  error: RunTimeoutError
+): Promise<void> {
   const durationMs = Date.now() - input.startedAt;
   await createRunEvent(env, input.runId, {
     type: 'run_timeout',
@@ -560,7 +639,8 @@ async function handleRunTimeout(env: Env, executor: RunExecutor, input: {
     } catch (cancelError) {
       await createRunEvent(env, input.runId, {
         type: 'run_timeout_cancel_failed',
-        message: cancelError instanceof Error ? cancelError.message : 'Timed out sandbox cleanup failed.',
+        message:
+          cancelError instanceof Error ? cancelError.message : 'Timed out sandbox cleanup failed.',
         metadata: { sandbox_id: input.sandboxId },
       });
     }
@@ -581,13 +661,16 @@ async function handleRunTimeout(env: Env, executor: RunExecutor, input: {
   });
 }
 
-function buildRunRequestMetadata(body: RunRequest | null, normalized: {
-  mode: RunMode;
-  command: string;
-  repoUrl?: string;
-  branch?: string;
-  timeoutSeconds: number;
-}): Record<string, unknown> {
+function buildRunRequestMetadata(
+  body: RunRequest | null,
+  normalized: {
+    mode: RunMode;
+    command: string;
+    repoUrl?: string;
+    branch?: string;
+    timeoutSeconds: number;
+  }
+): Record<string, unknown> {
   return {
     mode: normalized.mode,
     provider: body?.provider ?? null,
@@ -608,18 +691,24 @@ function buildRunRequestMetadata(body: RunRequest | null, normalized: {
   };
 }
 
-function executionInputFromRun(run: Awaited<ReturnType<typeof getRun>> & {}, request: Record<string, unknown> | null) {
+function executionInputFromRun(
+  run: Awaited<ReturnType<typeof getRun>> & {},
+  request: Record<string, unknown> | null
+) {
   const mode = normalizeMode(request?.mode);
-  const timeoutSeconds = normalizeTimeoutSeconds(request?.timeout_seconds) ?? DEFAULT_RECONCILE_TIMEOUT_SECONDS;
+  const timeoutSeconds =
+    normalizeTimeoutSeconds(request?.timeout_seconds) ?? DEFAULT_RECONCILE_TIMEOUT_SECONDS;
   return {
     runId: run.id,
     sandboxId: run.sandbox_id,
+    taskId: run.task_id ?? undefined,
+    projectSlug: run.project_slug ?? undefined,
     repoUrl: stringFromUnknown(request?.repo_url) ?? run.repo_url ?? undefined,
     branch: stringFromUnknown(request?.branch) ?? run.branch ?? undefined,
     command: stringFromUnknown(request?.command) ?? run.command,
     mode,
     prompt: stringFromUnknown(request?.prompt),
-    provider: request?.provider === 'deepseek' ? 'deepseek' as const : undefined,
+    provider: request?.provider === 'deepseek' ? ('deepseek' as const) : undefined,
     maxTurns: normalizeMaxTurns(request?.max_turns),
     timeoutSeconds,
     createPr: request?.create_pr === true,
@@ -661,7 +750,10 @@ function validateRunRequest(body: RunRequest | null): { ok: true } | { ok: false
   if (body.max_turns !== undefined && normalizeMaxTurns(body.max_turns) === undefined) {
     return { ok: false, error: 'max_turns must be between 1 and 50' };
   }
-  if (body.timeout_seconds !== undefined && normalizeTimeoutSeconds(body.timeout_seconds) === undefined) {
+  if (
+    body.timeout_seconds !== undefined &&
+    normalizeTimeoutSeconds(body.timeout_seconds) === undefined
+  ) {
     return { ok: false, error: 'timeout_seconds must be between 60 and 1800' };
   }
   if (body.pr_title !== undefined && typeof body.pr_title !== 'string') {
@@ -676,7 +768,11 @@ function validateRunRequest(body: RunRequest | null): { ok: true } | { ok: false
   return { ok: true };
 }
 
-function validateRunEnvironment(env: Env, body: RunRequest | null, mode: RunMode): { ok: true } | { ok: false; error: string } {
+function validateRunEnvironment(
+  env: Env,
+  body: RunRequest | null,
+  mode: RunMode
+): { ok: true } | { ok: false; error: string } {
   if (mode === 'native' && !env.DROID_DEEPSEEK_API_KEY?.trim()) {
     return { ok: false, error: 'DROID_DEEPSEEK_API_KEY is required for native Droid runs' };
   }

--- a/workers/droid/src/executor.ts
+++ b/workers/droid/src/executor.ts
@@ -20,6 +20,7 @@ type NativeAgentAction =
   | { action: 'read'; path: string; start_line?: number; end_line?: number }
   | { action: 'write'; path: string; content: string }
   | { action: 'command'; command: string; timeout_seconds?: number }
+  | { action: 'block'; reason: string; question: string; summary?: string }
   | { action: 'final'; summary: string };
 
 type NativeChatMessage = {
@@ -54,7 +55,10 @@ export const sandboxExecutor: RunExecutor = {
         stderr: ready.stderr,
       });
       if (input.destroyAfterRun) {
-        await input.recordEvent({ type: 'sandbox_destroy', message: `Destroying sandbox ${input.sandboxId}` });
+        await input.recordEvent({
+          type: 'sandbox_destroy',
+          message: `Destroying sandbox ${input.sandboxId}`,
+        });
         await sandbox.destroy();
       }
       return ready;
@@ -72,16 +76,27 @@ export const sandboxExecutor: RunExecutor = {
     const cwd = resolveWorkspaceCwd(workspace, input.cwd);
     if (input.mode !== 'command') {
       const result = await runAgent(input, sandbox, cwd);
-      const finalResult = await finalizeWorkspacePatch(input, sandbox, workspace, hydration, result);
+      const finalResult = await finalizeWorkspacePatch(
+        input,
+        sandbox,
+        workspace,
+        hydration,
+        result
+      );
       if (input.destroyAfterRun) {
-        await input.recordEvent({ type: 'sandbox_destroy', message: `Destroying sandbox ${input.sandboxId}` });
+        await input.recordEvent({
+          type: 'sandbox_destroy',
+          message: `Destroying sandbox ${input.sandboxId}`,
+        });
         await sandbox.destroy();
       }
       return finalResult;
     }
 
     await input.recordEvent({ type: 'command_start', command: input.command, cwd });
-    const result = await sandbox.exec(`cd ${quote(cwd)} && ${input.command}`, { timeout: input.timeoutSeconds * 1000 });
+    const result = await sandbox.exec(`cd ${quote(cwd)} && ${input.command}`, {
+      timeout: input.timeoutSeconds * 1000,
+    });
     await input.recordEvent({
       type: 'command_finish',
       command: input.command,
@@ -94,7 +109,10 @@ export const sandboxExecutor: RunExecutor = {
     const finalResult = await finalizeWorkspacePatch(input, sandbox, workspace, hydration, result);
 
     if (input.destroyAfterRun) {
-      await input.recordEvent({ type: 'sandbox_destroy', message: `Destroying sandbox ${input.sandboxId}` });
+      await input.recordEvent({
+        type: 'sandbox_destroy',
+        message: `Destroying sandbox ${input.sandboxId}`,
+      });
       await sandbox.destroy();
     }
 
@@ -137,7 +155,10 @@ export const sandboxExecutor: RunExecutor = {
         exit_code: missing.exitCode,
       });
       if (input.destroyAfterRun) {
-        await input.recordEvent({ type: 'sandbox_destroy', message: `Destroying sandbox ${input.sandboxId}` });
+        await input.recordEvent({
+          type: 'sandbox_destroy',
+          message: `Destroying sandbox ${input.sandboxId}`,
+        });
         await sandbox.destroy();
       }
       return missing;
@@ -146,12 +167,17 @@ export const sandboxExecutor: RunExecutor = {
     const hydration = await resolveHydrationForExistingWorkspace(input, sandbox, workspace);
     const finalResult = await finalizeWorkspacePatch(input, sandbox, workspace, hydration, result);
     if (input.destroyAfterRun) {
-      await input.recordEvent({ type: 'sandbox_destroy', message: `Destroying sandbox ${input.sandboxId}` });
+      await input.recordEvent({
+        type: 'sandbox_destroy',
+        message: `Destroying sandbox ${input.sandboxId}`,
+      });
       await sandbox.destroy();
     }
     await input.recordEvent({
       type: 'reconcile_finish',
-      message: finalResult.success ? 'Droid reconcile finished.' : 'Droid reconcile found unresolved work.',
+      message: finalResult.success
+        ? 'Droid reconcile finished.'
+        : 'Droid reconcile found unresolved work.',
       command: 'droid reconcile',
       cwd: workspace,
       exit_code: finalResult.exitCode,
@@ -160,28 +186,35 @@ export const sandboxExecutor: RunExecutor = {
   },
   async cancel(input): Promise<void> {
     const sandbox = getDroidSandbox(input.env.Sandbox, input.sandboxId);
-    const capturePromise = captureGitPatch({
-      env: input.env,
-      runId: input.runId,
-      sandboxId: input.sandboxId,
-      command: 'cancel',
-      mode: 'command',
-      timeoutSeconds: 60,
-      createPr: false,
-      destroyAfterRun: true,
-      recordEvent: input.recordEvent,
-      recordArtifact: input.recordArtifact,
-    }, sandbox, '/workspace/repo', {
-      stdout: '',
-      stderr: 'Run cancelled.',
-      exitCode: 130,
-      success: false,
-    }).catch((error) => input.recordEvent({
-      type: 'patch_capture_failed',
-      source: 'sandbox',
-      message: error instanceof Error ? error.message : 'Patch capture during cancel failed.',
-      exit_code: 1,
-    }));
+    const capturePromise = captureGitPatch(
+      {
+        env: input.env,
+        runId: input.runId,
+        sandboxId: input.sandboxId,
+        command: 'cancel',
+        mode: 'command',
+        timeoutSeconds: 60,
+        createPr: false,
+        destroyAfterRun: true,
+        recordEvent: input.recordEvent,
+        recordArtifact: input.recordArtifact,
+      },
+      sandbox,
+      '/workspace/repo',
+      {
+        stdout: '',
+        stderr: 'Run cancelled.',
+        exitCode: 130,
+        success: false,
+      }
+    ).catch((error) =>
+      input.recordEvent({
+        type: 'patch_capture_failed',
+        source: 'sandbox',
+        message: error instanceof Error ? error.message : 'Patch capture during cancel failed.',
+        exit_code: 1,
+      })
+    );
     const captureTimedOut = await Promise.race([
       capturePromise.then(() => false),
       new Promise<boolean>((resolve) => setTimeout(() => resolve(true), 8000)),
@@ -195,12 +228,18 @@ export const sandboxExecutor: RunExecutor = {
         exit_code: 124,
       });
     }
-    await input.recordEvent({ type: 'sandbox_destroy', message: `Destroying sandbox ${input.sandboxId}` });
+    await input.recordEvent({
+      type: 'sandbox_destroy',
+      message: `Destroying sandbox ${input.sandboxId}`,
+    });
     await sandbox.destroy();
   },
 };
 
-function getDroidSandbox(ns: Parameters<typeof getSandbox>[0], sandboxId: string): ReturnType<typeof getSandbox> {
+function getDroidSandbox(
+  ns: Parameters<typeof getSandbox>[0],
+  sandboxId: string
+): ReturnType<typeof getSandbox> {
   return getSandbox(ns, sandboxId, {
     keepAlive: true,
     containerTimeouts: {
@@ -248,7 +287,9 @@ async function runAgent(
   return runNativeAgent(input, sandbox, cwd);
 }
 
-async function requireDeepSeekKey(input: Parameters<RunExecutor['execute']>[0]): Promise<CommandResult | null> {
+async function requireDeepSeekKey(
+  input: Parameters<RunExecutor['execute']>[0]
+): Promise<CommandResult | null> {
   if (input.env.DROID_DEEPSEEK_API_KEY) return null;
   const result = {
     stdout: '',
@@ -293,7 +334,12 @@ async function runNativeAgent(
     source: 'deepseek',
     command: 'droid native tool loop',
     cwd,
-    metadata: { provider: input.provider ?? 'deepseek', model, max_turns: maxTurns, timeout_seconds: input.timeoutSeconds },
+    metadata: {
+      provider: input.provider ?? 'deepseek',
+      model,
+      max_turns: maxTurns,
+      timeout_seconds: input.timeoutSeconds,
+    },
   });
 
   for (let turn = 1; turn <= maxTurns; turn += 1) {
@@ -317,9 +363,47 @@ async function runNativeAgent(
         cwd,
         exit_code: 0,
         stdout: action.summary,
-        metadata: { provider: input.provider ?? 'deepseek', model, max_turns: maxTurns, turns: turn },
+        metadata: {
+          provider: input.provider ?? 'deepseek',
+          model,
+          max_turns: maxTurns,
+          turns: turn,
+        },
       });
-      return { stdout: `${transcript.join('\n')}\n\n${action.summary}\n`, stderr: '', exitCode: 0, success: true };
+      return {
+        stdout: `${transcript.join('\n')}\n\n${action.summary}\n`,
+        stderr: '',
+        exitCode: 0,
+        success: true,
+      };
+    }
+
+    if (action.action === 'block') {
+      const blocked = await markTaskBlocked(input, action, transcript);
+      const stderr = blocked
+        ? `Droid blocked the task: ${action.reason}`
+        : `Droid needs user input but could not update the task: ${action.reason}`;
+      await input.recordEvent({
+        type: 'agent_blocked',
+        actor: 'native',
+        source: 'deepseek',
+        command: 'droid native tool loop',
+        cwd,
+        exit_code: 75,
+        stderr,
+        metadata: {
+          reason: action.reason,
+          question: action.question,
+          task_id: input.taskId ?? null,
+          callback_updated: blocked,
+        },
+      });
+      return {
+        stdout: `${transcript.join('\n')}\n\n${action.summary ?? action.reason}\nQuestion: ${action.question}\n`,
+        stderr,
+        exitCode: 75,
+        success: false,
+      };
     }
 
     const toolResult = await executeNativeTool(input, sandbox, cwd, action);
@@ -360,18 +444,19 @@ function buildNativeSystemPrompt(cwd: string): string {
     '{"action":"read","path":"relative/file.ts","start_line":1,"end_line":160}',
     '{"action":"write","path":"relative/file.ts","content":"full file contents"}',
     '{"action":"command","command":"pnpm test","timeout_seconds":120}',
+    '{"action":"block","reason":"what is blocking you","question":"specific question for the user","summary":"optional current state"}',
     '{"action":"final","summary":"what changed and what was verified"}',
     'Use relative paths only. Read files before editing unless the task is explicitly to create a new file.',
     'Prefer small diffs. Run the smallest useful check before final when possible.',
+    'Use block only when you need a user decision, credential, review, or deploy permission.',
     'Use the provided repository context as orientation, but verify details by reading files before editing.',
   ].join('\n');
 }
 
 function buildNativeUserPrompt(prompt: string, taskContext: string): string {
-  return [
-    taskContext ? `Repository context:\n${taskContext}` : '',
-    `Task:\n${prompt}`,
-  ].filter(Boolean).join('\n\n');
+  return [taskContext ? `Repository context:\n${taskContext}` : '', `Task:\n${prompt}`]
+    .filter(Boolean)
+    .join('\n\n');
 }
 
 async function hydrateNativeTaskContext(
@@ -457,7 +542,7 @@ async function requestNativeAgentActionOnce(
       method: 'POST',
       signal: controller.signal,
       headers: {
-        'Authorization': `Bearer ${input.env.DROID_DEEPSEEK_API_KEY}`,
+        Authorization: `Bearer ${input.env.DROID_DEEPSEEK_API_KEY}`,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
@@ -476,10 +561,14 @@ async function requestNativeAgentActionOnce(
 
   if (!response.ok) {
     const text = await response.text();
-    throw new Error(`DeepSeek API ${response.status} ${response.statusText}: ${text.slice(0, 500)}`);
+    throw new Error(
+      `DeepSeek API ${response.status} ${response.statusText}: ${text.slice(0, 500)}`
+    );
   }
 
-  const payload = await response.json() as { choices?: Array<{ message?: { content?: string } }> };
+  const payload = (await response.json()) as {
+    choices?: Array<{ message?: { content?: string } }>;
+  };
   const content = payload.choices?.[0]?.message?.content;
   if (!content) throw new Error('DeepSeek response did not include message content');
   return parseNativeAction(content);
@@ -499,11 +588,31 @@ function parseNativeAction(content: string): NativeAgentAction {
       end_line: numberOrUndefined(parsed.end_line),
     };
   }
-  if (parsed.action === 'write' && typeof parsed.path === 'string' && typeof parsed.content === 'string') {
+  if (
+    parsed.action === 'write' &&
+    typeof parsed.path === 'string' &&
+    typeof parsed.content === 'string'
+  ) {
     return { action: 'write', path: parsed.path, content: parsed.content };
   }
   if (parsed.action === 'command' && typeof parsed.command === 'string') {
-    return { action: 'command', command: parsed.command, timeout_seconds: numberOrUndefined(parsed.timeout_seconds) };
+    return {
+      action: 'command',
+      command: parsed.command,
+      timeout_seconds: numberOrUndefined(parsed.timeout_seconds),
+    };
+  }
+  if (
+    parsed.action === 'block' &&
+    typeof parsed.reason === 'string' &&
+    typeof parsed.question === 'string'
+  ) {
+    return {
+      action: 'block',
+      reason: parsed.reason,
+      question: parsed.question,
+      summary: stringOrUndefined(parsed.summary),
+    };
   }
   if (parsed.action === 'final' && typeof parsed.summary === 'string') {
     return { action: 'final', summary: parsed.summary };
@@ -515,7 +624,7 @@ async function executeNativeTool(
   input: Parameters<RunExecutor['execute']>[0],
   sandbox: Awaited<ReturnType<typeof getSandbox>>,
   cwd: string,
-  action: Exclude<NativeAgentAction, { action: 'final' }>
+  action: Exclude<NativeAgentAction, { action: 'final' } | { action: 'block' }>
 ): Promise<NativeToolResult> {
   try {
     if (action.action === 'list') return nativeList(input, sandbox, cwd, action.path);
@@ -524,6 +633,105 @@ async function executeNativeTool(
     return nativeCommand(input, sandbox, cwd, action);
   } catch (error) {
     return { ok: false, output: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+async function markTaskBlocked(
+  input: Parameters<RunExecutor['execute']>[0],
+  action: Extract<NativeAgentAction, { action: 'block' }>,
+  transcript: string[]
+): Promise<boolean> {
+  if (!input.taskId) {
+    await input.recordEvent({
+      type: 'task_blocked_callback_skipped',
+      actor: 'droid',
+      source: 'worker',
+      message: 'Droid wanted to block the task, but no task_id was attached to the run.',
+      metadata: { reason: action.reason, question: action.question },
+    });
+    return false;
+  }
+
+  const token = input.env.DROID_SAASMAKER_TOKEN?.trim();
+  if (!token) {
+    await input.recordEvent({
+      type: 'task_blocked_callback_skipped',
+      actor: 'droid',
+      source: 'worker',
+      message: 'DROID_SAASMAKER_TOKEN is not configured.',
+      metadata: { task_id: input.taskId, reason: action.reason, question: action.question },
+    });
+    return false;
+  }
+
+  const apiUrl = (input.env.SAASMAKER_API_URL?.trim() || 'https://api.sassmaker.com').replace(
+    /\/+$/,
+    ''
+  );
+  const taskPath = `/v1/tasks/${encodeURIComponent(input.taskId)}`;
+  const commentBody = [
+    'Droid is blocked and needs user input.',
+    '',
+    `Reason: ${action.reason}`,
+    `Question: ${action.question}`,
+    action.summary ? `Summary: ${action.summary}` : '',
+    '',
+    `Run: ${input.runId}`,
+    `Project: ${input.projectSlug ?? 'unknown'}`,
+    `Recent action: ${transcript.at(-1) ?? 'none'}`,
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  try {
+    const commentResponse = await fetch(`${apiUrl}${taskPath}/comments`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        body: commentBody,
+        author_type: 'agent',
+      }),
+    });
+    if (!commentResponse.ok) {
+      const text = await commentResponse.text();
+      throw new Error(`comment failed with HTTP ${commentResponse.status}: ${text.slice(0, 300)}`);
+    }
+
+    const patchResponse = await fetch(`${apiUrl}${taskPath}`, {
+      method: 'PATCH',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ blocked_on_user: true }),
+    });
+    if (!patchResponse.ok) {
+      const text = await patchResponse.text();
+      throw new Error(
+        `block update failed with HTTP ${patchResponse.status}: ${text.slice(0, 300)}`
+      );
+    }
+
+    await input.recordEvent({
+      type: 'task_blocked_callback_succeeded',
+      actor: 'droid',
+      source: 'saas-maker-api',
+      message: 'Droid posted an agent comment and marked the task blocked.',
+      metadata: { task_id: input.taskId, reason: action.reason, question: action.question },
+    });
+    return true;
+  } catch (error) {
+    await input.recordEvent({
+      type: 'task_blocked_callback_failed',
+      actor: 'droid',
+      source: 'saas-maker-api',
+      message: error instanceof Error ? error.message : 'Failed to mark task blocked.',
+      metadata: { task_id: input.taskId, reason: action.reason, question: action.question },
+    });
+    return false;
   }
 }
 
@@ -620,7 +828,11 @@ async function nativeWrite(
     exit_code: 0,
     metadata: { path: action.path, bytes: new TextEncoder().encode(action.content).length },
   });
-  return { ok: true, output: `wrote ${action.path} (${new TextEncoder().encode(action.content).length} bytes)`, exitCode: 0 };
+  return {
+    ok: true,
+    output: `wrote ${action.path} (${new TextEncoder().encode(action.content).length} bytes)`,
+    exitCode: 0,
+  };
 }
 
 async function nativeCommand(
@@ -629,7 +841,10 @@ async function nativeCommand(
   cwd: string,
   action: Extract<NativeAgentAction, { action: 'command' }>
 ): Promise<NativeToolResult> {
-  const timeoutSeconds = Math.min(Math.max(action.timeout_seconds ?? 120, 5), Math.min(input.timeoutSeconds, 300));
+  const timeoutSeconds = Math.min(
+    Math.max(action.timeout_seconds ?? 120, 5),
+    Math.min(input.timeoutSeconds, 300)
+  );
   await input.recordEvent({
     type: 'command_start',
     actor: 'native',
@@ -638,9 +853,12 @@ async function nativeCommand(
     cwd,
     metadata: { timeout_seconds: timeoutSeconds },
   });
-  const result = await sandbox.exec(`cd ${quote(cwd)} && timeout ${timeoutSeconds}s bash -lc ${quote(action.command)}`, {
-    timeout: (timeoutSeconds + 15) * 1000,
-  });
+  const result = await sandbox.exec(
+    `cd ${quote(cwd)} && timeout ${timeoutSeconds}s bash -lc ${quote(action.command)}`,
+    {
+      timeout: (timeoutSeconds + 15) * 1000,
+    }
+  );
   await input.recordEvent({
     type: 'command_finish',
     actor: 'native',
@@ -654,7 +872,10 @@ async function nativeCommand(
   });
   return {
     ok: result.success,
-    output: truncateForModel([result.stdout, result.stderr ? `stderr:\n${result.stderr}` : ''].filter(Boolean).join('\n'), 12000),
+    output: truncateForModel(
+      [result.stdout, result.stderr ? `stderr:\n${result.stderr}` : ''].filter(Boolean).join('\n'),
+      12000
+    ),
     exitCode: result.exitCode,
   };
 }
@@ -672,7 +893,10 @@ async function hydrateRepository(
   try {
     const repoInfo = await githubRequest<{ default_branch: string }>(input, `/repos/${repo}`);
     const baseBranch = input.branch || repoInfo.default_branch || 'main';
-    const baseRef = await githubRequest<{ object: { sha: string } }>(input, `/repos/${repo}/git/ref/heads/${encodePath(baseBranch)}`);
+    const baseRef = await githubRequest<{ object: { sha: string } }>(
+      input,
+      `/repos/${repo}/git/ref/heads/${encodePath(baseBranch)}`
+    );
     const tarballUrl = `https://api.github.com/repos/${repo}/tarball/${encodeURIComponent(baseBranch)}`;
     const script = [
       'set -euo pipefail',
@@ -696,7 +920,12 @@ async function hydrateRepository(
       type: 'command_start',
       command: 'github tarball hydrate',
       cwd: '/workspace',
-      metadata: { repo, branch: baseBranch, github_token: Boolean(input.env.DROID_GITHUB_TOKEN), method: 'github_tarball' },
+      metadata: {
+        repo,
+        branch: baseBranch,
+        github_token: Boolean(input.env.DROID_GITHUB_TOKEN),
+        method: 'github_tarball',
+      },
     });
     const result = await sandbox.exec(`bash -lc ${quote(script)}`, {
       timeout: 180000,
@@ -753,18 +982,21 @@ async function hydrateWithGitClone(
   const branchArgs = input.branch ? ` --branch ${quote(input.branch)}` : '';
   const repoArg = gitAuth.cloneRepoArg ?? quote(input.repoUrl ?? '');
   const gitClone = `${gitAuth.prefix}git clone --depth 1${branchArgs} ${repoArg} ${quote(workspace)}`;
-  const result = await sandbox.exec([
-    `rm -rf ${quote(workspace)}`,
-    'code=1',
-    'for attempt in 1 2; do',
-    `  timeout 120s bash -lc ${quote(gitClone)}`,
-    '  code=$?',
-    '  [ "$code" -eq 0 ] && break',
-    '  echo "git clone attempt ${attempt} failed with exit ${code}" >&2',
-    '  sleep $((attempt * 3))',
-    'done',
-    '[ "$code" -eq 0 ] || exit "$code"',
-  ].join('\n'), { timeout: 150000 });
+  const result = await sandbox.exec(
+    [
+      `rm -rf ${quote(workspace)}`,
+      'code=1',
+      'for attempt in 1 2; do',
+      `  timeout 120s bash -lc ${quote(gitClone)}`,
+      '  code=$?',
+      '  [ "$code" -eq 0 ] && break',
+      '  echo "git clone attempt ${attempt} failed with exit ${code}" >&2',
+      '  sleep $((attempt * 3))',
+      'done',
+      '[ "$code" -eq 0 ] || exit "$code"',
+    ].join('\n'),
+    { timeout: 150000 }
+  );
   await input.recordEvent({
     type: 'command_finish',
     command: 'git clone',
@@ -785,18 +1017,27 @@ async function configureGitAuth(
     return { prefix: 'GIT_TERMINAL_PROMPT=0 ', githubToken: false };
   }
 
-  const authedRepoUrl = input.repoUrl.replace('https://github.com/', `https://x-access-token:${input.env.DROID_GITHUB_TOKEN}@github.com/`);
+  const authedRepoUrl = input.repoUrl.replace(
+    'https://github.com/',
+    `https://x-access-token:${input.env.DROID_GITHUB_TOKEN}@github.com/`
+  );
   await sandbox.writeFile('/tmp/droid-github-repo-url', authedRepoUrl);
   await sandbox.writeFile('/tmp/droid-github-token', input.env.DROID_GITHUB_TOKEN);
-  await sandbox.writeFile('/tmp/droid-git-askpass', [
-    '#!/bin/sh',
-    'case "$1" in',
-    '  *Username*) echo x-access-token ;;',
-    '  *Password*) cat /tmp/droid-github-token ;;',
-    '  *) echo "" ;;',
-    'esac',
-  ].join('\n'));
-  await sandbox.exec('chmod 700 /tmp/droid-git-askpass && chmod 600 /tmp/droid-github-token /tmp/droid-github-repo-url', { timeout: 30000 });
+  await sandbox.writeFile(
+    '/tmp/droid-git-askpass',
+    [
+      '#!/bin/sh',
+      'case "$1" in',
+      '  *Username*) echo x-access-token ;;',
+      '  *Password*) cat /tmp/droid-github-token ;;',
+      '  *) echo "" ;;',
+      'esac',
+    ].join('\n')
+  );
+  await sandbox.exec(
+    'chmod 700 /tmp/droid-git-askpass && chmod 600 /tmp/droid-github-token /tmp/droid-github-repo-url',
+    { timeout: 30000 }
+  );
   return {
     prefix: 'GIT_TERMINAL_PROMPT=0 GIT_ASKPASS=/tmp/droid-git-askpass ',
     githubToken: true,
@@ -816,7 +1057,11 @@ async function createDraftPullRequest(
       type: 'pr_skipped',
       source: 'github',
       message: 'DROID_GITHUB_TOKEN or GitHub repo metadata is not configured.',
-      metadata: { github_token: Boolean(input.env.DROID_GITHUB_TOKEN), repo_url: input.repoUrl ?? null, method: hydration.method },
+      metadata: {
+        github_token: Boolean(input.env.DROID_GITHUB_TOKEN),
+        repo_url: input.repoUrl ?? null,
+        method: hydration.method,
+      },
     });
     return false;
   }
@@ -825,14 +1070,16 @@ async function createDraftPullRequest(
   const baseBranch = input.prBaseBranch || hydration.baseBranch || input.branch || 'main';
   const branchName = `droid/${sanitizeBranchPart(input.runId).slice(0, 12)}`;
   const title = input.prTitle || `Droid run ${input.runId.slice(0, 8)}`;
-  const body = input.prBody || [
-    `Droid run: ${input.runId}`,
-    '',
-    'Captured changes:',
-    '```',
-    patch.stat.trim() || patch.status.trim() || 'No diff stat available.',
-    '```',
-  ].join('\n');
+  const body =
+    input.prBody ||
+    [
+      `Droid run: ${input.runId}`,
+      '',
+      'Captured changes:',
+      '```',
+      patch.stat.trim() || patch.status.trim() || 'No diff stat available.',
+      '```',
+    ].join('\n');
 
   await input.recordEvent({
     type: 'pr_start',
@@ -851,8 +1098,14 @@ async function createDraftPullRequest(
   try {
     const baseRef = hydration.baseSha
       ? { object: { sha: hydration.baseSha } }
-      : await githubRequest<{ object: { sha: string } }>(input, `/repos/${repo}/git/ref/heads/${encodePath(baseBranch)}`);
-    const baseCommit = await githubRequest<{ tree: { sha: string } }>(input, `/repos/${repo}/git/commits/${baseRef.object.sha}`);
+      : await githubRequest<{ object: { sha: string } }>(
+          input,
+          `/repos/${repo}/git/ref/heads/${encodePath(baseBranch)}`
+        );
+    const baseCommit = await githubRequest<{ tree: { sha: string } }>(
+      input,
+      `/repos/${repo}/git/commits/${baseRef.object.sha}`
+    );
     const tree = await collectChangedTree(input, sandbox, workspace, repo, baseCommit.tree.sha);
     if (tree.entryCount === 0) {
       await input.recordEvent({
@@ -879,16 +1132,20 @@ async function createDraftPullRequest(
         sha: commit.sha,
       }),
     });
-    const pr = await githubRequest<{ html_url: string; number: number }>(input, `/repos/${repo}/pulls`, {
-      method: 'POST',
-      body: JSON.stringify({
-        title,
-        body,
-        head: branchName,
-        base: baseBranch,
-        draft: true,
-      }),
-    });
+    const pr = await githubRequest<{ html_url: string; number: number }>(
+      input,
+      `/repos/${repo}/pulls`,
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          title,
+          body,
+          head: branchName,
+          base: baseBranch,
+          draft: true,
+        }),
+      }
+    );
 
     await input.recordEvent({
       type: 'pr_created',
@@ -910,7 +1167,13 @@ async function createDraftPullRequest(
       type: 'pull_request',
       name: 'GitHub draft PR',
       uri: pr.html_url,
-      metadata: { repo, base_branch: baseBranch, head_branch: branchName, title, pr_number: pr.number },
+      metadata: {
+        repo,
+        base_branch: baseBranch,
+        head_branch: branchName,
+        title,
+        pr_number: pr.number,
+      },
     });
     return true;
   } catch (error) {
@@ -946,13 +1209,22 @@ async function finalizeWorkspacePatch(
   if (!review.approved) {
     return {
       stdout: result.stdout,
-      stderr: appendTail(result.stderr, review.summary || 'Droid patch review rejected PR creation.'),
+      stderr: appendTail(
+        result.stderr,
+        review.summary || 'Droid patch review rejected PR creation.'
+      ),
       exitCode: result.success ? 78 : result.exitCode,
       success: false,
     };
   }
 
-  const prCreated = await createDraftPullRequestWithTimeout(input, sandbox, workspace, hydration, patch);
+  const prCreated = await createDraftPullRequestWithTimeout(
+    input,
+    sandbox,
+    workspace,
+    hydration,
+    patch
+  );
   if (!prCreated) {
     return {
       stdout: result.stdout,
@@ -1000,7 +1272,8 @@ async function reviewPatchForPr(
       source: 'git',
       command: 'git diff --check -- .',
       cwd: workspace,
-      message: 'Patch passed local review. DeepSeek review skipped because no API key is configured.',
+      message:
+        'Patch passed local review. DeepSeek review skipped because no API key is configured.',
       metadata: { patch_bytes: patch.patchBytes, review: 'local_only' },
     });
     return { approved: true, summary: 'Patch passed local review.' };
@@ -1045,7 +1318,7 @@ async function requestPatchReview(
       method: 'POST',
       signal: controller.signal,
       headers: {
-        'Authorization': `Bearer ${input.env.DROID_DEEPSEEK_API_KEY}`,
+        Authorization: `Bearer ${input.env.DROID_DEEPSEEK_API_KEY}`,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
@@ -1085,7 +1358,9 @@ async function requestPatchReview(
       const text = await response.text();
       throw new Error(`DeepSeek review API ${response.status}: ${text.slice(0, 500)}`);
     }
-    const payload = await response.json() as { choices?: Array<{ message?: { content?: string } }> };
+    const payload = (await response.json()) as {
+      choices?: Array<{ message?: { content?: string } }>;
+    };
     const content = payload.choices?.[0]?.message?.content;
     if (!content) throw new Error('DeepSeek review response did not include content.');
     const parsed = parseReviewJson(content);
@@ -1107,14 +1382,34 @@ async function requestPatchReview(
   }
 }
 
-function parseReviewJson(content: string): { approved: boolean; summary: string; concerns: string[] } {
-  const jsonText = content.trim().startsWith('{') ? content.trim() : content.match(/\{[\s\S]*\}/)?.[0];
-  if (!jsonText) return { approved: false, summary: 'Patch review returned non-JSON output.', concerns: [content.slice(0, 300)] };
-  const parsed = JSON.parse(jsonText) as { decision?: unknown; summary?: unknown; concerns?: unknown };
-  const concerns = Array.isArray(parsed.concerns) ? parsed.concerns.filter((item): item is string => typeof item === 'string') : [];
+function parseReviewJson(content: string): {
+  approved: boolean;
+  summary: string;
+  concerns: string[];
+} {
+  const jsonText = content.trim().startsWith('{')
+    ? content.trim()
+    : content.match(/\{[\s\S]*\}/)?.[0];
+  if (!jsonText)
+    return {
+      approved: false,
+      summary: 'Patch review returned non-JSON output.',
+      concerns: [content.slice(0, 300)],
+    };
+  const parsed = JSON.parse(jsonText) as {
+    decision?: unknown;
+    summary?: unknown;
+    concerns?: unknown;
+  };
+  const concerns = Array.isArray(parsed.concerns)
+    ? parsed.concerns.filter((item): item is string => typeof item === 'string')
+    : [];
   return {
     approved: parsed.decision === 'approve',
-    summary: typeof parsed.summary === 'string' ? parsed.summary : String(parsed.decision ?? 'No review summary.'),
+    summary:
+      typeof parsed.summary === 'string'
+        ? parsed.summary
+        : String(parsed.decision ?? 'No review summary.'),
     concerns,
   };
 }
@@ -1125,7 +1420,8 @@ async function resolveHydrationForExistingWorkspace(
   workspace: string
 ): Promise<RepoHydration> {
   const repo = parseGitHubRepo(input.repoUrl ?? '');
-  const branch = input.prBaseBranch || input.branch || await currentGitBranch(sandbox, workspace) || 'main';
+  const branch =
+    input.prBaseBranch || input.branch || (await currentGitBranch(sandbox, workspace)) || 'main';
   if (!repo) return { method: 'git_clone', baseBranch: branch };
   return { method: 'github_tarball', repo, baseBranch: branch };
 }
@@ -1190,14 +1486,22 @@ async function collectChangedTree(
   repo: string,
   baseTreeSha: string
 ): Promise<{ sha: string; entryCount: number }> {
-  const changed = await sandbox.exec(`git -C ${quote(workspace)} diff --name-only --diff-filter=ACMRT HEAD -- .`, { timeout: 30000 });
-  const deleted = await sandbox.exec(`git -C ${quote(workspace)} diff --name-only --diff-filter=D HEAD -- .`, { timeout: 30000 });
+  const changed = await sandbox.exec(
+    `git -C ${quote(workspace)} diff --name-only --diff-filter=ACMRT HEAD -- .`,
+    { timeout: 30000 }
+  );
+  const deleted = await sandbox.exec(
+    `git -C ${quote(workspace)} diff --name-only --diff-filter=D HEAD -- .`,
+    { timeout: 30000 }
+  );
   const changedPaths = uniqueLines(changed.stdout);
   const deletedPaths = uniqueLines(deleted.stdout);
   const entries: Array<{ path: string; mode: '100644'; type: 'blob'; sha: string | null }> = [];
 
   for (const path of changedPaths) {
-    const content = await sandbox.exec(`base64 -w0 ${quote(`${workspace}/${path}`)}`, { timeout: 30000 });
+    const content = await sandbox.exec(`base64 -w0 ${quote(`${workspace}/${path}`)}`, {
+      timeout: 30000,
+    });
     if (!content.success) continue;
     const blob = await githubRequest<{ sha: string }>(input, `/repos/${repo}/git/blobs`, {
       method: 'POST',
@@ -1241,8 +1545,8 @@ async function githubRequest<T>(
       ...init,
       signal: controller.signal,
       headers: {
-        'Accept': 'application/vnd.github+json',
-        'Authorization': `Bearer ${input.env.DROID_GITHUB_TOKEN}`,
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${input.env.DROID_GITHUB_TOKEN}`,
         'Content-Type': 'application/json',
         'User-Agent': 'saas-maker-droid',
         'X-GitHub-Api-Version': '2022-11-28',
@@ -1265,7 +1569,14 @@ async function githubRequest<T>(
 }
 
 function uniqueLines(value: string): string[] {
-  return Array.from(new Set(value.split('\n').map((line) => line.trim()).filter(Boolean)));
+  return Array.from(
+    new Set(
+      value
+        .split('\n')
+        .map((line) => line.trim())
+        .filter(Boolean)
+    )
+  );
 }
 
 function encodePath(value: string): string {
@@ -1273,7 +1584,12 @@ function encodePath(value: string): string {
 }
 
 function sanitizeBranchPart(value: string): string {
-  return value.toLowerCase().replace(/[^a-z0-9._/-]+/g, '-').replace(/^[-/.]+|[-/.]+$/g, '') || 'run';
+  return (
+    value
+      .toLowerCase()
+      .replace(/[^a-z0-9._/-]+/g, '-')
+      .replace(/^[-/.]+|[-/.]+$/g, '') || 'run'
+  );
 }
 
 async function sandboxExecWithWorkerTimeout(
@@ -1289,12 +1605,16 @@ async function sandboxExecWithWorkerTimeout(
     return await Promise.race([
       execPromise,
       new Promise<CommandResult>((resolve) => {
-        timeout = setTimeout(() => resolve({
-          stdout: '',
-          stderr: `Sandbox exec Worker watchdog timed out after ${timeoutMs}ms.`,
-          exitCode: 124,
-          success: false,
-        }), timeoutMs);
+        timeout = setTimeout(
+          () =>
+            resolve({
+              stdout: '',
+              stderr: `Sandbox exec Worker watchdog timed out after ${timeoutMs}ms.`,
+              exitCode: 124,
+              success: false,
+            }),
+          timeoutMs
+        );
       }),
     ]);
   } finally {
@@ -1337,15 +1657,30 @@ function summarizeNativeAction(action: NativeAgentAction): string {
   if (action.action === 'read') return `read ${action.path}`;
   if (action.action === 'write') return `write ${action.path}`;
   if (action.action === 'command') return `command ${action.command}`;
+  if (action.action === 'block') return `block ${action.reason.slice(0, 120)}`;
   return `final ${action.summary.slice(0, 120)}`;
 }
 
 function scrubNativeAction(action: NativeAgentAction, turn: number): Record<string, unknown> {
   if (action.action === 'write') {
-    return { turn, action: action.action, path: action.path, bytes: new TextEncoder().encode(action.content).length };
+    return {
+      turn,
+      action: action.action,
+      path: action.path,
+      bytes: new TextEncoder().encode(action.content).length,
+    };
   }
   if (action.action === 'final') {
     return { turn, action: action.action, summary: action.summary.slice(0, 500) };
+  }
+  if (action.action === 'block') {
+    return {
+      turn,
+      action: action.action,
+      reason: action.reason.slice(0, 500),
+      question: action.question.slice(0, 500),
+      summary: action.summary?.slice(0, 500) ?? null,
+    };
   }
   return { turn, ...action };
 }
@@ -1365,7 +1700,10 @@ function quote(value: string): string {
 
 function resolveWorkspaceCwd(workspace: string, cwd: string | undefined): string {
   if (!cwd || cwd === '.') return workspace;
-  const normalized = cwd.replace(/^\/+/, '').split('/').filter((part) => part && part !== '.');
+  const normalized = cwd
+    .replace(/^\/+/, '')
+    .split('/')
+    .filter((part) => part && part !== '.');
   if (normalized.includes('..')) return workspace;
   return `${workspace}/${normalized.join('/')}`;
 }

--- a/workers/droid/src/types.ts
+++ b/workers/droid/src/types.ts
@@ -7,6 +7,8 @@ export interface Env {
   DROID_DEEPSEEK_MODEL?: string;
   DROID_DEEPSEEK_REVIEW_MODEL?: string;
   DROID_GITHUB_TOKEN?: string;
+  DROID_SAASMAKER_TOKEN?: string;
+  SAASMAKER_API_URL?: string;
   Sandbox: DurableObjectNamespace<Sandbox>;
 }
 
@@ -96,6 +98,8 @@ export interface RunExecutionInput {
   env: Env;
   runId: string;
   sandboxId: string;
+  taskId?: string;
+  projectSlug?: string;
   repoUrl?: string;
   branch?: string;
   command: string;


### PR DESCRIPTION
## Summary
- refresh the public README and add MIT license, contributing, and security docs
- add a Droid roadmap with Sandcastle-inspired orchestration contracts
- let Droid native runs emit a block action that comments on the SaaS Maker task and marks it blocked when configured with a scoped token

## Tests
- pnpm vitest run tests/droid/runs.test.ts tests/droid/patch.test.ts
- pnpm -F @saas-maker/droid typecheck
- pnpm test
- git diff --check