### PR TITLE
Add Droid run room coordinator

### DIFF
--- a/tests/droid/runs.test.ts
+++ b/tests/droid/runs.test.ts
@@ -271,6 +271,45 @@ describe('droid runs', () => {
     });
   });
 
+  it('mirrors run events into the live run room when configured', async () => {
+    const rooms = new FakeRunRoomNamespace();
+    const app = createApp(fakeExecutor());
+    const env = createEnv({ DROID_RUN_ROOMS: rooms as unknown as DurableObjectNamespace });
+
+    const response = await app.request(
+      '/v0/runs',
+      {
+        method: 'POST',
+        body: JSON.stringify({ command: 'echo ok', wait_for_completion: true }),
+        headers: {
+          Authorization: 'Bearer test-token',
+          'Content-Type': 'application/json',
+        },
+      },
+      env
+    );
+    const payload = (await response.json()) as { data: { id: string } };
+
+    const statusResponse = await app.request(
+      `/v0/runs/${payload.data.id}/live-status`,
+      {
+        headers: { Authorization: 'Bearer test-token' },
+      },
+      env
+    );
+
+    expect(statusResponse.status).toBe(200);
+    await expect(statusResponse.json()).resolves.toMatchObject({
+      data: {
+        run_id: payload.data.id,
+        event_count: 5,
+        recent_events: expect.arrayContaining([
+          expect.objectContaining({ type: 'command_finish' }),
+        ]),
+      },
+    });
+  });
+
   it('lists recent runs by task id', async () => {
     const app = createApp(fakeExecutor());
     const env = createEnv();
@@ -509,7 +548,9 @@ describe('droid runs', () => {
 
     releaseFirst();
     await firstResponsePromise;
-    for (let i = 0; i < 5 && executeCommands.length < 2; i += 1) await Promise.resolve();
+    for (let i = 0; i < 25 && executeCommands.length < 2; i += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
 
     const dequeuedResponse = await app.request(
       `/v0/runs/${queuedPayload.data.id}`,
@@ -733,6 +774,45 @@ class FakeD1 {
 
   prepare(sql: string) {
     return new FakeStatement(this, sql);
+  }
+}
+
+class FakeRunRoomNamespace {
+  private rooms = new Map<string, FakeRunRoom>();
+
+  getByName(name: string) {
+    let room = this.rooms.get(name);
+    if (!room) {
+      room = new FakeRunRoom(name);
+      this.rooms.set(name, room);
+    }
+    return room;
+  }
+}
+
+class FakeRunRoom {
+  private events: Array<Record<string, unknown>> = [];
+
+  constructor(private runId: string) {}
+
+  async recordEvent(input: { runId: string; event: { type: string } & Record<string, unknown> }) {
+    const event = {
+      id: `event-${this.events.length}`,
+      run_id: input.runId,
+      ...input.event,
+      created_at: `2026-05-11T00:00:0${this.events.length}.000Z`,
+    };
+    this.events.push(event);
+    return event;
+  }
+
+  async getStatus() {
+    return {
+      run_id: this.runId,
+      last_event_at: this.events.at(-1)?.created_at ?? null,
+      event_count: this.events.length,
+      recent_events: this.events,
+    };
   }
 }
 

--- a/workers/droid/src/app.ts
+++ b/workers/droid/src/app.ts
@@ -3,7 +3,7 @@ import { cors } from 'hono/cors';
 import {
   createRun,
   createRunArtifact,
-  createRunEvent,
+  createRunEvent as createRunEventInDb,
   finishRun,
   getActiveRunForQueue,
   getLatestRunEvent,
@@ -16,9 +16,11 @@ import {
   listRuns,
   markRunStarted,
 } from './db';
+import { fetchRunRoom, getRunRoomStatus, recordRunRoomEvent } from './run-room-client';
 import type {
   CommandResult,
   Env,
+  RunEventInput,
   RunExecutionInput,
   RunExecutor,
   RunMode,
@@ -216,6 +218,22 @@ export function createApp(executor: RunExecutor) {
     return c.json({ data: events });
   });
 
+  app.get('/v0/runs/:id/live', async (c) => {
+    const run = await getRun(c.env, c.req.param('id'));
+    if (!run) return c.json({ error: 'Run not found' }, 404);
+    const response = fetchRunRoom(c.env, run.id, c.req.raw);
+    if (!response) return c.json({ error: 'Droid run rooms are not configured' }, 501);
+    return response;
+  });
+
+  app.get('/v0/runs/:id/live-status', async (c) => {
+    const run = await getRun(c.env, c.req.param('id'));
+    if (!run) return c.json({ error: 'Run not found' }, 404);
+    const status = await getRunRoomStatus(c.env, run.id);
+    if (!status) return c.json({ error: 'Droid run rooms are not configured' }, 501);
+    return c.json({ data: status });
+  });
+
   app.get('/v0/runs/:id/artifacts', async (c) => {
     const run = await getRun(c.env, c.req.param('id'));
     if (!run) return c.json({ error: 'Run not found' }, 404);
@@ -411,6 +429,15 @@ function isStaleEvent(createdAt: string, thresholdMs: number): boolean {
   const parsed = Date.parse(`${createdAt.replace(' ', 'T')}Z`);
   if (!Number.isFinite(parsed)) return false;
   return Date.now() - parsed >= thresholdMs;
+}
+
+async function createRunEvent(env: Env, runId: string, input: RunEventInput): Promise<void> {
+  await createRunEventInDb(env, runId, input);
+  try {
+    await recordRunRoomEvent(env, runId, input);
+  } catch (error) {
+    console.warn('Failed to record Droid run room event', error);
+  }
 }
 
 async function executeRun(

--- a/workers/droid/src/index.ts
+++ b/workers/droid/src/index.ts
@@ -2,5 +2,6 @@ import { createApp } from './app';
 import { sandboxExecutor } from './executor';
 
 export { Sandbox } from '@cloudflare/sandbox';
+export { DroidRunRoom } from './run-room';
 
 export default createApp(sandboxExecutor);

--- a/workers/droid/src/run-room-client.ts
+++ b/workers/droid/src/run-room-client.ts
@@ -1,0 +1,62 @@
+import type { Env, RunEventInput } from './types';
+
+export interface RunRoomEvent {
+  id: string;
+  run_id: string;
+  type: string;
+  actor: string;
+  source: string;
+  message: string | null;
+  command: string | null;
+  cwd: string | null;
+  exit_code: number | null;
+  stdout: string | null;
+  stderr: string | null;
+  metadata: Record<string, unknown>;
+  created_at: string;
+}
+
+export interface RunRoomStatus {
+  run_id: string;
+  last_event_at: string | null;
+  event_count: number;
+  recent_events: RunRoomEvent[];
+}
+
+type RunRoomStub = {
+  recordEvent(input: { runId: string; event: RunEventInput }): Promise<RunRoomEvent>;
+  getStatus(runId: string): Promise<RunRoomStatus>;
+  fetch(request: Request): Promise<Response>;
+};
+
+type RunRoomNamespace = DurableObjectNamespace & {
+  getByName(name: string): RunRoomStub;
+};
+
+export async function recordRunRoomEvent(
+  env: Env,
+  runId: string,
+  event: RunEventInput
+): Promise<void> {
+  const room = getRunRoom(env, runId);
+  if (!room) return;
+  await room.recordEvent({ runId, event });
+}
+
+export async function getRunRoomStatus(env: Env, runId: string): Promise<RunRoomStatus | null> {
+  const room = getRunRoom(env, runId);
+  return room ? room.getStatus(runId) : null;
+}
+
+export function fetchRunRoom(env: Env, runId: string, request: Request): Promise<Response> | null {
+  const room = getRunRoom(env, runId);
+  if (!room) return null;
+  const url = new URL(request.url);
+  url.searchParams.set('run_id', runId);
+  return room.fetch(new Request(url, request));
+}
+
+function getRunRoom(env: Env, runId: string): RunRoomStub | null {
+  const namespace = env.DROID_RUN_ROOMS as RunRoomNamespace | undefined;
+  return namespace ? (namespace.getByName(runId) as unknown as RunRoomStub) : null;
+}

--- a/workers/droid/src/run-room.ts
+++ b/workers/droid/src/run-room.ts
@@ -1,0 +1,167 @@
+import { DurableObject } from 'cloudflare:workers';
+import type { Env, RunEventInput } from './types';
+import type { RunRoomEvent, RunRoomStatus } from './run-room-client';
+
+export class DroidRunRoom extends DurableObject<Env> {
+  constructor(ctx: DurableObjectState, env: Env) {
+    super(ctx, env);
+    ctx.blockConcurrencyWhile(async () => {
+      ctx.storage.sql.exec(`
+        CREATE TABLE IF NOT EXISTS run_events (
+          id TEXT PRIMARY KEY,
+          run_id TEXT NOT NULL,
+          type TEXT NOT NULL,
+          actor TEXT NOT NULL,
+          source TEXT NOT NULL,
+          message TEXT,
+          command TEXT,
+          cwd TEXT,
+          exit_code INTEGER,
+          stdout TEXT,
+          stderr TEXT,
+          metadata TEXT NOT NULL,
+          created_at TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_run_events_run_created
+          ON run_events(run_id, created_at);
+        CREATE TABLE IF NOT EXISTS run_state (
+          run_id TEXT PRIMARY KEY,
+          last_event_at TEXT,
+          event_count INTEGER NOT NULL DEFAULT 0
+        );
+      `);
+    });
+  }
+
+  async recordEvent(input: { runId: string; event: RunEventInput }): Promise<RunRoomEvent> {
+    const event: RunRoomEvent = {
+      id: crypto.randomUUID(),
+      run_id: input.runId,
+      type: input.event.type,
+      actor: input.event.actor ?? 'droid',
+      source: input.event.source ?? 'worker',
+      message: input.event.message ?? null,
+      command: input.event.command ?? null,
+      cwd: input.event.cwd ?? null,
+      exit_code: input.event.exit_code ?? null,
+      stdout: truncate(input.event.stdout),
+      stderr: truncate(input.event.stderr),
+      metadata: input.event.metadata ?? {},
+      created_at: new Date().toISOString(),
+    };
+
+    this.ctx.storage.sql.exec(
+      `INSERT INTO run_events (
+        id, run_id, type, actor, source, message, command, cwd, exit_code, stdout, stderr, metadata, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      event.id,
+      event.run_id,
+      event.type,
+      event.actor,
+      event.source,
+      event.message,
+      event.command,
+      event.cwd,
+      event.exit_code,
+      event.stdout,
+      event.stderr,
+      JSON.stringify(event.metadata),
+      event.created_at
+    );
+    this.ctx.storage.sql.exec(
+      `INSERT INTO run_state (run_id, last_event_at, event_count)
+       VALUES (?, ?, 1)
+       ON CONFLICT(run_id) DO UPDATE SET
+         last_event_at = excluded.last_event_at,
+         event_count = event_count + 1`,
+      input.runId,
+      event.created_at
+    );
+
+    this.broadcast({ type: 'event', data: event });
+    return event;
+  }
+
+  async getStatus(runId: string): Promise<RunRoomStatus> {
+    const state = this.ctx.storage.sql
+      .exec<{
+        run_id: string;
+        last_event_at: string | null;
+        event_count: number;
+      }>(`SELECT run_id, last_event_at, event_count FROM run_state WHERE run_id = ?`, runId)
+      .toArray()[0];
+    return {
+      run_id: runId,
+      last_event_at: state?.last_event_at ?? null,
+      event_count: Number(state?.event_count ?? 0),
+      recent_events: await this.listEvents(runId, 50),
+    };
+  }
+
+  async listEvents(runId: string, limit = 100): Promise<RunRoomEvent[]> {
+    const boundedLimit = Math.min(Math.max(limit, 1), 250);
+    return this.ctx.storage.sql
+      .exec<StoredRunRoomEvent>(
+        `SELECT * FROM run_events WHERE run_id = ? ORDER BY created_at ASC LIMIT ?`,
+        runId,
+        boundedLimit
+      )
+      .toArray()
+      .map(parseStoredEvent);
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    const runId = url.searchParams.get('run_id') ?? roomRunIdFromUrl(url);
+
+    if (request.headers.get('Upgrade')?.toLowerCase() === 'websocket') {
+      const pair = new WebSocketPair();
+      const [client, server] = Object.values(pair) as [WebSocket, WebSocket];
+      server.serializeAttachment({ runId });
+      this.ctx.acceptWebSocket(server);
+      server.send(JSON.stringify({ type: 'snapshot', data: await this.getStatus(runId) }));
+      return new Response(null, { status: 101, webSocket: client });
+    }
+
+    return Response.json({ data: await this.getStatus(runId) });
+  }
+
+  async webSocketMessage(ws: WebSocket, message: string | ArrayBuffer): Promise<void> {
+    if (message === 'ping') {
+      ws.send(JSON.stringify({ type: 'pong', at: new Date().toISOString() }));
+    }
+  }
+
+  private broadcast(payload: unknown): void {
+    const text = JSON.stringify(payload);
+    for (const socket of this.ctx.getWebSockets()) {
+      try {
+        socket.send(text);
+      } catch {
+        socket.close(1011, 'Failed to send Droid run event.');
+      }
+    }
+  }
+}
+
+type StoredRunRoomEvent = Omit<RunRoomEvent, 'metadata'> & { metadata: string };
+
+function parseStoredEvent(row: StoredRunRoomEvent): RunRoomEvent {
+  let metadata: Record<string, unknown> = {};
+  try {
+    metadata = JSON.parse(row.metadata) as Record<string, unknown>;
+  } catch {
+    metadata = {};
+  }
+  return { ...row, metadata };
+}
+
+function roomRunIdFromUrl(url: URL): string {
+  const parts = url.pathname.split('/').filter(Boolean);
+  return parts.at(-1) ?? 'unknown';
+}
+
+function truncate(value: string | undefined): string | null {
+  if (value === undefined) return null;
+  return value.length > 16000 ? `${value.slice(0, 16000)}\n...[truncated]` : value;
+}

--- a/workers/droid/src/types.ts
+++ b/workers/droid/src/types.ts
@@ -10,6 +10,7 @@ export interface Env {
   DROID_SAASMAKER_TOKEN?: string;
   SAASMAKER_API_URL?: string;
   Sandbox: DurableObjectNamespace<Sandbox>;
+  DROID_RUN_ROOMS?: DurableObjectNamespace;
 }
 
 export type RunMode = 'command' | 'native';

--- a/workers/droid/wrangler.jsonc
+++ b/workers/droid/wrangler.jsonc
@@ -6,38 +6,46 @@
   "workers_dev": true,
   "vars": {
     "DROID_DEEPSEEK_MODEL": "deepseek-v4-pro",
-    "DROID_DEEPSEEK_REVIEW_MODEL": "deepseek-chat"
+    "DROID_DEEPSEEK_REVIEW_MODEL": "deepseek-chat",
   },
   "observability": {
-    "enabled": true
+    "enabled": true,
   },
   "containers": [
     {
       "class_name": "Sandbox",
       "image": "./Dockerfile",
       "instance_type": "basic",
-      "max_instances": 3
-    }
+      "max_instances": 3,
+    },
   ],
   "durable_objects": {
     "bindings": [
       {
         "class_name": "Sandbox",
-        "name": "Sandbox"
-      }
-    ]
+        "name": "Sandbox",
+      },
+      {
+        "class_name": "DroidRunRoom",
+        "name": "DROID_RUN_ROOMS",
+      },
+    ],
   },
   "migrations": [
     {
       "tag": "v1",
-      "new_sqlite_classes": ["Sandbox"]
-    }
+      "new_sqlite_classes": ["Sandbox"],
+    },
+    {
+      "tag": "v2",
+      "new_sqlite_classes": ["DroidRunRoom"],
+    },
   ],
   "d1_databases": [
     {
       "binding": "DB",
       "database_name": "saasmaker-db",
-      "database_id": "4fe6cffc-593a-4540-9577-1c33e8c64491"
-    }
-  ]
+      "database_id": "4fe6cffc-593a-4540-9577-1c33e8c64491",
+    },
+  ],
 }


### PR DESCRIPTION
## Summary
- add a SQLite-backed DroidRunRoom Durable Object for per-run live state
- mirror Droid run events into the run room while keeping D1 as the permanent record
- add live status and WebSocket-ready live endpoints for run subscribers
- add a test that verifies events are mirrored into the live run room when configured

## Research signal
The parallel research pass points to the same spine: durable run object first, then blueprints/provider abstraction/quality gates. This PR implements the first slice.

## Tests
- pnpm -F @saas-maker/droid typecheck
- pnpm vitest run tests/droid/runs.test.ts tests/droid/patch.test.ts
- pnpm test
- git diff --check