### PR TITLE
Add Droid stale run recovery

### DIFF
--- a/apps/cockpit/src/app/api/droid/runs/[id]/mark-stale/route.ts
+++ b/apps/cockpit/src/app/api/droid/runs/[id]/mark-stale/route.ts
@@ -1,0 +1,14 @@
+import { droidApiUrl, droidJsonResponse, requireDroidAccess } from "@/app/api/droid/_lib";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const denied = await requireDroidAccess();
+  if (denied) return denied;
+  const { id } = await params;
+  const body = await req.text();
+  return droidJsonResponse(droidApiUrl(`/v0/runs/${encodeURIComponent(id)}/mark-stale`), {
+    method: "POST",
+    body: body || "{}",
+  });
+}

--- a/apps/cockpit/src/components/tasks/DroidDialog.tsx
+++ b/apps/cockpit/src/components/tasks/DroidDialog.tsx
@@ -94,6 +94,7 @@ interface DroidDialogProps {
   onRun: () => void;
   onReconcile: () => void;
   onCancel: () => void;
+  onMarkStale: () => void;
   onClose: () => void;
 }
 
@@ -124,6 +125,7 @@ export function DroidDialog({
   onRun,
   onReconcile,
   onCancel,
+  onMarkStale,
   onClose,
 }: DroidDialogProps) {
   return (
@@ -257,7 +259,13 @@ export function DroidDialog({
             <div className="space-y-3">
               <DroidStats stats={stats} />
               <DroidError error={error} />
-              <DroidResult run={run} running={running} onReconcile={onReconcile} onCancel={onCancel} />
+              <DroidResult
+                run={run}
+                running={running}
+                onReconcile={onReconcile}
+                onCancel={onCancel}
+                onMarkStale={onMarkStale}
+              />
               <DroidArtifacts artifacts={artifacts} />
               <DroidEvents events={events} />
             </div>
@@ -311,14 +319,17 @@ function DroidResult({
   running,
   onReconcile,
   onCancel,
+  onMarkStale,
 }: {
   run: DroidRunRow | null;
   running: boolean;
   onReconcile: () => void;
   onCancel: () => void;
+  onMarkStale: () => void;
 }) {
   const reconcileLabel = run?.status === 'queued' ? 'Start queued' : 'Check run';
   const canControl = run?.status === 'queued' || run?.status === 'running';
+  const canMarkStale = run?.status === 'running';
   return (
     <div className="rounded-lg border bg-muted/20 p-3">
       <div className="flex items-center justify-between gap-2">
@@ -334,6 +345,11 @@ function DroidResult({
             {canControl ? (
               <Button type="button" size="sm" variant="outline" onClick={onReconcile} disabled={running}>
                 {reconcileLabel}
+              </Button>
+            ) : null}
+            {canMarkStale ? (
+              <Button type="button" size="sm" variant="outline" onClick={onMarkStale} disabled={running}>
+                Mark stale
               </Button>
             ) : null}
             <Badge variant="outline" className={cn(

--- a/apps/cockpit/src/components/tasks/TaskBoard.tsx
+++ b/apps/cockpit/src/components/tasks/TaskBoard.tsx
@@ -781,6 +781,31 @@ export function TaskBoard({
     }
   };
 
+  const handleDroidMarkStale = async () => {
+    if (!droidRun) return;
+    setStartingDroidRun(true);
+    setDroidError(null);
+    try {
+      const res = await fetch(`/api/droid/runs/${droidRun.id}/mark-stale`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ wait_for_dispatch: true }),
+      });
+      const payload = await res.json() as { data?: DroidRunRow; error?: string };
+      if (!res.ok || !payload.data) throw new Error(payload.error || 'Droid stale recovery failed');
+      setDroidRun(payload.data);
+      await loadDroidRunDetails(payload.data.id);
+      await loadDroidStats(payload.data.project_slug);
+      showToast('Droid stale run released');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Droid stale recovery failed';
+      setDroidError(message);
+      showToast(`Stale recovery failed: ${message.slice(0, 120)}`);
+    } finally {
+      setStartingDroidRun(false);
+    }
+  };
+
   const handleBatchDispatch = async () => {
     if (runnableSelectedTasks.length === 0) {
       showToast('Select runnable todo tasks first');
@@ -1293,6 +1318,7 @@ export function TaskBoard({
         onRun={handleDroidRun}
         onReconcile={handleDroidReconcile}
         onCancel={handleDroidCancel}
+        onMarkStale={handleDroidMarkStale}
         onClose={() => {
           setDroidTask(null);
           setDroidMode('native');

--- a/tests/droid/runs.test.ts
+++ b/tests/droid/runs.test.ts
@@ -632,6 +632,105 @@ describe('droid runs', () => {
     ]);
   });
 
+  it('marks stale running runs failed and releases the repo queue', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-14T12:00:00.000Z'));
+    const executeCommands: string[] = [];
+    const app = createApp({
+      async execute(input) {
+        executeCommands.push(input.command);
+        if (input.command === 'first') return new Promise(() => undefined);
+        return { stdout: `${input.command}\n`, stderr: '', exitCode: 0, success: true };
+      },
+    });
+    const env = createEnv();
+    const headers = {
+      Authorization: 'Bearer test-token',
+      'Content-Type': 'application/json',
+    };
+
+    try {
+      const firstResponse = await app.request(
+        '/v0/runs',
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            project_slug: 'saas-maker',
+            repo_url: 'https://github.com/example/repo.git',
+            command: 'first',
+          }),
+          headers,
+        },
+        env
+      );
+      const firstPayload = (await firstResponse.json()) as { data: { id: string } };
+
+      const queuedResponse = await app.request(
+        '/v0/runs',
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            project_slug: 'saas-maker',
+            repo_url: 'https://github.com/example/repo.git',
+            command: 'second',
+          }),
+          headers,
+        },
+        env
+      );
+      const queuedPayload = (await queuedResponse.json()) as { data: { id: string } };
+
+      const staleResponse = await app.request(
+        `/v0/runs/${firstPayload.data.id}/mark-stale`,
+        {
+          method: 'POST',
+          body: JSON.stringify({ wait_for_dispatch: true }),
+          headers,
+        },
+        env
+      );
+
+      expect(staleResponse.status).toBe(200);
+      await expect(staleResponse.json()).resolves.toMatchObject({
+        data: {
+          status: 'failed',
+          exit_code: 124,
+          error_message: 'Droid run marked stale after no recent activity.',
+        },
+        marked_stale: true,
+      });
+
+      const queuedRunResponse = await app.request(
+        `/v0/runs/${queuedPayload.data.id}`,
+        {
+          headers: { Authorization: 'Bearer test-token' },
+        },
+        env
+      );
+      await expect(queuedRunResponse.json()).resolves.toMatchObject({
+        data: {
+          status: 'completed',
+          exit_code: 0,
+        },
+      });
+      expect(executeCommands).toEqual(['first', 'second']);
+
+      const firstEventsResponse = await app.request(
+        `/v0/runs/${firstPayload.data.id}/events`,
+        {
+          headers: { Authorization: 'Bearer test-token' },
+        },
+        env
+      );
+      const firstEventsPayload = (await firstEventsResponse.json()) as {
+        data: Array<{ type: string }>;
+      };
+      expect(firstEventsPayload.data.map((event) => event.type)).toContain('run_marked_stale');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('starts runs asynchronously by default', async () => {
     const app = createApp({
       async execute() {

--- a/workers/droid/src/app.ts
+++ b/workers/droid/src/app.ts
@@ -287,6 +287,96 @@ export function createApp(executor: RunExecutor) {
     return c.json({ data: updatedRun ?? run });
   });
 
+  app.post('/v0/runs/:id/mark-stale', async (c) => {
+    const run = await getRun(c.env, c.req.param('id'));
+    if (!run) return c.json({ error: 'Run not found' }, 404);
+    if (run.status === 'completed' || run.status === 'failed') {
+      return c.json({ data: run, marked_stale: false });
+    }
+    if (run.status !== 'running') {
+      return c.json({ error: 'Only running Droid runs can be marked stale.' }, 409);
+    }
+
+    const incoming = (await c.req.json().catch(() => null)) as {
+      force?: boolean;
+      wait_for_dispatch?: boolean;
+    } | null;
+    const latestActivity = await getLatestRunActivityWithStart(c.env, run);
+    if (
+      !incoming?.force &&
+      latestActivity &&
+      !isStaleEvent(latestActivity.created_at, RECONCILE_STALE_AFTER_MS)
+    ) {
+      return c.json(
+        {
+          error:
+            'Run still appears active; stale recovery is only allowed after 6 minutes of no activity unless force is true.',
+          latest_event_at: latestActivity.created_at,
+          latest_event_source: latestActivity.source,
+        },
+        409
+      );
+    }
+
+    await createRunEvent(c.env, run.id, {
+      type: 'run_marked_stale',
+      message: 'Droid run marked stale after no recent activity.',
+      exit_code: 124,
+      metadata: {
+        sandbox_id: run.sandbox_id,
+        latest_event_at: latestActivity?.created_at ?? null,
+        latest_event_source: latestActivity?.source ?? null,
+        forced: incoming?.force === true,
+      },
+    });
+    await finishRun(c.env, run.id, {
+      status: 'failed',
+      exitCode: 124,
+      durationMs: durationSince(run.started_at),
+      summary: 'Droid run marked stale after no recent activity.',
+      errorMessage: 'Droid run marked stale after no recent activity.',
+    });
+
+    if (executor.cancel) {
+      const cancelPromise = executor
+        .cancel({
+          env: c.env,
+          runId: run.id,
+          sandboxId: run.sandbox_id,
+          recordEvent: (event) => createRunEvent(c.env, run.id, event),
+          recordArtifact: (artifact) => createRunArtifact(c.env, run.id, artifact),
+        })
+        .catch((error) =>
+          createRunEvent(c.env, run.id, {
+            type: 'sandbox_destroy_failed',
+            message: error instanceof Error ? error.message : 'Sandbox destroy failed.',
+            metadata: { sandbox_id: run.sandbox_id, during_stale_recovery: true },
+          })
+        );
+      scheduleBackground(c, cancelPromise);
+    }
+
+    const dispatchPromise = dispatchNextQueuedRun(c.env, executor, {
+      runId: run.id,
+      repoUrl: run.repo_url ?? undefined,
+      waitUntil: (promise: Promise<void>) => scheduleBackground(c, promise),
+    }).catch((error) =>
+      createRunEvent(c.env, run.id, {
+        type: 'queue_dispatch_failed',
+        message: error instanceof Error ? error.message : 'Droid queue dispatch failed.',
+        metadata: { run_id: run.id, during_stale_recovery: true },
+      })
+    );
+    if (incoming?.wait_for_dispatch === true) {
+      await dispatchPromise;
+    } else {
+      scheduleBackground(c, dispatchPromise);
+    }
+
+    const updatedRun = await getRun(c.env, run.id);
+    return c.json({ data: updatedRun ?? run, marked_stale: true });
+  });
+
   app.post('/v0/runs/:id/reconcile', async (c) => {
     const run = await getRun(c.env, c.req.param('id'));
     if (!run) return c.json({ error: 'Run not found' }, 404);
@@ -454,10 +544,26 @@ async function getLatestRunActivity(
   return latest ? { created_at: latest.created_at, source: latest.source } : null;
 }
 
+async function getLatestRunActivityWithStart(
+  env: Env,
+  run: { id: string; started_at: string | null }
+): Promise<{ created_at: string; source: 'd1' | 'run_room' | 'started_at' } | null> {
+  const activity = await getLatestRunActivity(env, run.id);
+  if (activity) return activity;
+  return run.started_at ? { created_at: run.started_at, source: 'started_at' } : null;
+}
+
 function isStaleEvent(createdAt: string, thresholdMs: number): boolean {
   const parsed = parseRunTimestamp(createdAt);
   if (!Number.isFinite(parsed)) return false;
   return Date.now() - parsed >= thresholdMs;
+}
+
+function durationSince(createdAt: string | null): number {
+  if (!createdAt) return 0;
+  const parsed = parseRunTimestamp(createdAt);
+  if (!Number.isFinite(parsed)) return 0;
+  return Math.max(Date.now() - parsed, 0);
 }
 
 function parseRunTimestamp(value: string): number {


### PR DESCRIPTION
## Summary
- add an authenticated Droid endpoint to mark stale running runs failed after no recent activity
- dispatch the next queued same-repo/project run after stale recovery releases the queue
- expose the action through the local Cockpit Droid dialog

## Tests
- pnpm -F @saas-maker/droid typecheck
- pnpm vitest run tests/droid/runs.test.ts tests/droid/patch.test.ts
- pnpm build:cockpit
- pnpm test
- git diff --check