### PR TITLE
[codex] Add Droid acceptance gate

### DIFF
--- a/apps/cockpit/src/app/api/droid/runs/route.ts
+++ b/apps/cockpit/src/app/api/droid/runs/route.ts
@@ -37,6 +37,8 @@ export async function POST(req: Request) {
     pr_title?: unknown;
     pr_body?: unknown;
     pr_base_branch?: unknown;
+    acceptance_command?: unknown;
+    acceptance_timeout_seconds?: unknown;
     repo_url?: unknown;
     branch?: unknown;
     cwd?: unknown;
@@ -74,6 +76,8 @@ export async function POST(req: Request) {
     pr_title: typeof body.pr_title === "string" && body.pr_title.trim() ? body.pr_title.trim() : undefined,
     pr_body: typeof body.pr_body === "string" && body.pr_body.trim() ? body.pr_body.trim() : undefined,
     pr_base_branch: typeof body.pr_base_branch === "string" && body.pr_base_branch.trim() ? body.pr_base_branch.trim() : undefined,
+    acceptance_command: typeof body.acceptance_command === "string" && body.acceptance_command.trim() ? body.acceptance_command.trim() : undefined,
+    acceptance_timeout_seconds: typeof body.acceptance_timeout_seconds === "number" ? body.acceptance_timeout_seconds : undefined,
     cwd: typeof body.cwd === "string" && body.cwd.trim() ? body.cwd.trim() : undefined,
     destroy_after_run: body.destroy_after_run !== false,
     wait_for_completion: body.wait_for_completion === true,

--- a/apps/cockpit/src/components/tasks/DroidDialog.tsx
+++ b/apps/cockpit/src/components/tasks/DroidDialog.tsx
@@ -74,6 +74,7 @@ interface DroidDialogProps {
   prompt: string;
   maxTurns: string;
   createPr: boolean;
+  acceptanceCommand: string;
   repoUrl: string;
   branch: string;
   cwd: string;
@@ -88,6 +89,7 @@ interface DroidDialogProps {
   onPromptChange: (value: string) => void;
   onMaxTurnsChange: (value: string) => void;
   onCreatePrChange: (value: boolean) => void;
+  onAcceptanceCommandChange: (value: string) => void;
   onRepoUrlChange: (value: string) => void;
   onBranchChange: (value: string) => void;
   onCwdChange: (value: string) => void;
@@ -105,6 +107,7 @@ export function DroidDialog({
   prompt,
   maxTurns,
   createPr,
+  acceptanceCommand,
   repoUrl,
   branch,
   cwd,
@@ -119,6 +122,7 @@ export function DroidDialog({
   onPromptChange,
   onMaxTurnsChange,
   onCreatePrChange,
+  onAcceptanceCommandChange,
   onRepoUrlChange,
   onBranchChange,
   onCwdChange,
@@ -209,6 +213,20 @@ export function DroidDialog({
                   </p>
                 </div>
                 <Switch id="droid-create-pr" checked={createPr} onCheckedChange={onCreatePrChange} />
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="droid-acceptance">Acceptance command</Label>
+                <Input
+                  id="droid-acceptance"
+                  value={acceptanceCommand}
+                  onChange={event => onAcceptanceCommandChange(event.target.value)}
+                  placeholder="pnpm test"
+                  className="font-mono text-xs"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Optional. Droid runs this in the repo before opening a draft PR.
+                </p>
               </div>
 
               <div className="grid gap-3 sm:grid-cols-2">

--- a/apps/cockpit/src/components/tasks/TaskBoard.tsx
+++ b/apps/cockpit/src/components/tasks/TaskBoard.tsx
@@ -242,6 +242,7 @@ export function TaskBoard({
   const [droidPrompt, setDroidPrompt] = useState('');
   const [droidMaxTurns, setDroidMaxTurns] = useState('25');
   const [droidCreatePr, setDroidCreatePr] = useState(true);
+  const [droidAcceptanceCommand, setDroidAcceptanceCommand] = useState('');
   const [droidRepoUrl, setDroidRepoUrl] = useState('');
   const [droidBranch, setDroidBranch] = useState('');
   const [droidCwd, setDroidCwd] = useState('');
@@ -345,6 +346,7 @@ export function TaskBoard({
     setDroidPrompt(`Work on this task and report what you changed or found.\n\nTask: ${task.title}\n\n${task.description ?? ''}`.trim());
     setDroidMaxTurns('25');
     setDroidCreatePr(true);
+    setDroidAcceptanceCommand('');
     setDroidRepoUrl(task.project_slug ? projectRepos?.[task.project_slug] ?? '' : '');
     setDroidBranch(task.branch_name ?? '');
     setDroidCwd('');
@@ -392,6 +394,7 @@ export function TaskBoard({
     setDroidPrompt(`Work on this task and report what you changed or found.\n\nTask: ${task.title}\n\n${task.description ?? ''}`.trim());
     setDroidMaxTurns('25');
     setDroidCreatePr(true);
+    setDroidAcceptanceCommand('');
     setDroidRepoUrl(task.project_slug ? projectRepos?.[task.project_slug] ?? '' : '');
     setDroidBranch(task.branch_name ?? '');
     setDroidCwd('');
@@ -710,6 +713,7 @@ export function TaskBoard({
           timeout_seconds: droidMode !== 'command' ? 900 : undefined,
           create_pr: droidCreatePr,
           pr_title: droidTask ? `Droid: ${droidTask.title}` : undefined,
+          acceptance_command: droidAcceptanceCommand.trim() || undefined,
           repo_url: droidRepoUrl.trim() || undefined,
           branch: droidBranch.trim() || undefined,
           cwd: droidCwd.trim() || undefined,
@@ -1298,6 +1302,7 @@ export function TaskBoard({
         prompt={droidPrompt}
         maxTurns={droidMaxTurns}
         createPr={droidCreatePr}
+        acceptanceCommand={droidAcceptanceCommand}
         repoUrl={droidRepoUrl}
         branch={droidBranch}
         cwd={droidCwd}
@@ -1312,6 +1317,7 @@ export function TaskBoard({
         onPromptChange={setDroidPrompt}
         onMaxTurnsChange={setDroidMaxTurns}
         onCreatePrChange={setDroidCreatePr}
+        onAcceptanceCommandChange={setDroidAcceptanceCommand}
         onRepoUrlChange={setDroidRepoUrl}
         onBranchChange={setDroidBranch}
         onCwdChange={setDroidCwd}
@@ -1326,6 +1332,7 @@ export function TaskBoard({
           setDroidPrompt('');
           setDroidMaxTurns('25');
           setDroidCreatePr(true);
+          setDroidAcceptanceCommand('');
           setDroidRepoUrl('');
           setDroidBranch('');
           setDroidCwd('');

--- a/docs/droid-roadmap.md
+++ b/docs/droid-roadmap.md
@@ -24,7 +24,7 @@ Droid is usable as an experimental v1 runner: it can start a Cloudflare Sandbox,
    - Add a compact stats endpoint for Droid health.
 
 5. Better PR quality gate
-   - Require changed-file summary, patch review result, and test command output before PR creation.
+   - Require changed-file summary, patch review result, and optional acceptance command output before PR creation.
    - Keep PRs draft by default.
    - Add a clear failure summary when no meaningful diff is produced.
 

--- a/tests/droid/acceptance.test.ts
+++ b/tests/droid/acceptance.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest';
+import { runAcceptanceCommand } from '../../workers/droid/src/acceptance';
+import type { RunArtifactInput, RunEventInput, RunExecutionInput } from '../../workers/droid/src/types';
+
+describe('droid acceptance command', () => {
+  it('records acceptance pass evidence', async () => {
+    const events: RunEventInput[] = [];
+    const artifacts: RunArtifactInput[] = [];
+    const exec = vi.fn(async () => ({ stdout: 'ok\n', stderr: '', exitCode: 0, success: true }));
+
+    const result = await runAcceptanceCommand(
+      createInput(events, artifacts),
+      { exec },
+      '/workspace/repo',
+      'pnpm test',
+      120
+    );
+
+    expect(result.passed).toBe(true);
+    expect(exec).toHaveBeenCalledWith("cd '/workspace/repo' && pnpm test", { timeout: 120000 });
+    expect(events.map((event) => event.type)).toEqual(['acceptance_start', 'acceptance_passed']);
+    expect(artifacts).toEqual([
+      expect.objectContaining({
+        type: 'acceptance',
+        name: 'Droid acceptance report',
+      }),
+    ]);
+  });
+
+  it('records acceptance failure evidence', async () => {
+    const events: RunEventInput[] = [];
+    const artifacts: RunArtifactInput[] = [];
+    const exec = vi.fn(async () => ({
+      stdout: '',
+      stderr: 'failed\n',
+      exitCode: 1,
+      success: false,
+    }));
+
+    const result = await runAcceptanceCommand(
+      createInput(events, artifacts),
+      { exec },
+      '/workspace/repo',
+      'pnpm test'
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.summary).toBe('Acceptance command failed with exit code 1.');
+    expect(events.map((event) => event.type)).toEqual(['acceptance_start', 'acceptance_failed']);
+  });
+});
+
+function createInput(
+  events: RunEventInput[],
+  artifacts: RunArtifactInput[]
+): RunExecutionInput {
+  return {
+    env: {
+      DROID_INTERNAL_TOKEN: 'test-token',
+      DB: {} as D1Database,
+      Sandbox: {} as DurableObjectNamespace,
+    },
+    runId: 'run-1',
+    sandboxId: 'droid-run-1',
+    command: 'echo ok',
+    mode: 'command',
+    createPr: false,
+    timeoutSeconds: 900,
+    destroyAfterRun: true,
+    recordEvent: async (event) => {
+      events.push(event);
+    },
+    recordArtifact: async (artifact) => {
+      artifacts.push(artifact);
+    },
+  };
+}

--- a/tests/droid/acceptance.test.ts
+++ b/tests/droid/acceptance.test.ts
@@ -48,6 +48,34 @@ describe('droid acceptance command', () => {
     expect(result.summary).toBe('Acceptance command failed with exit code 1.');
     expect(events.map((event) => event.type)).toEqual(['acceptance_start', 'acceptance_failed']);
   });
+
+  it('clamps acceptance command timeouts to the worker limits', async () => {
+    const events: RunEventInput[] = [];
+    const artifacts: RunArtifactInput[] = [];
+    const exec = vi.fn(async () => ({ stdout: 'ok\n', stderr: '', exitCode: 0, success: true }));
+
+    await runAcceptanceCommand(
+      createInput(events, artifacts),
+      { exec },
+      '/workspace/repo',
+      'echo lower',
+      5
+    );
+    await runAcceptanceCommand(
+      createInput(events, artifacts),
+      { exec },
+      '/workspace/repo',
+      'echo upper',
+      1200
+    );
+
+    expect(exec).toHaveBeenNthCalledWith(1, "cd '/workspace/repo' && echo lower", {
+      timeout: 30000,
+    });
+    expect(exec).toHaveBeenNthCalledWith(2, "cd '/workspace/repo' && echo upper", {
+      timeout: 900000,
+    });
+  });
 });
 
 function createInput(

--- a/tests/droid/runs.test.ts
+++ b/tests/droid/runs.test.ts
@@ -62,6 +62,107 @@ describe('droid runs', () => {
     await expect(response.json()).resolves.toEqual({ error: 'prompt is required' });
   });
 
+  it('validates acceptance settings before creating a ticket run', async () => {
+    const app = createApp(fakeExecutor());
+    const env = createEnv();
+    const headers = {
+      Authorization: 'Bearer test-token',
+      'Content-Type': 'application/json',
+    };
+
+    const badCommand = await app.request(
+      '/v0/runs',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          task_id: 'ticket-bad-acceptance-command',
+          command: 'echo ok',
+          acceptance_command: 123,
+        }),
+        headers,
+      },
+      env
+    );
+    expect(badCommand.status).toBe(400);
+    await expect(badCommand.json()).resolves.toEqual({
+      error: 'acceptance_command must be a string',
+    });
+
+    const badTimeout = await app.request(
+      '/v0/runs',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          task_id: 'ticket-bad-acceptance-timeout',
+          command: 'echo ok',
+          acceptance_command: 'pnpm test',
+          acceptance_timeout_seconds: 12.5,
+        }),
+        headers,
+      },
+      env
+    );
+    expect(badTimeout.status).toBe(400);
+    await expect(badTimeout.json()).resolves.toEqual({
+      error: 'acceptance_timeout_seconds must be between 30 and 900',
+    });
+    expect((env.DB as unknown as FakeD1).runs.size).toBe(0);
+  });
+
+  it('clamps ticket acceptance timeout settings into the supported range', async () => {
+    const seen: Array<{ taskId?: string; acceptanceTimeoutSeconds?: number }> = [];
+    const app = createApp({
+      async execute(input) {
+        seen.push({
+          taskId: input.taskId,
+          acceptanceTimeoutSeconds: input.acceptanceTimeoutSeconds,
+        });
+        return { stdout: 'ok\n', stderr: '', exitCode: 0, success: true };
+      },
+    });
+    const env = createEnv();
+    const headers = {
+      Authorization: 'Bearer test-token',
+      'Content-Type': 'application/json',
+    };
+
+    await app.request(
+      '/v0/runs',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          task_id: 'ticket-low-timeout',
+          command: 'echo ok',
+          acceptance_command: 'pnpm test',
+          acceptance_timeout_seconds: 5,
+          wait_for_completion: true,
+        }),
+        headers,
+      },
+      env
+    );
+    await app.request(
+      '/v0/runs',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          task_id: 'ticket-high-timeout',
+          command: 'echo ok',
+          acceptance_command: 'pnpm test',
+          acceptance_timeout_seconds: 1200,
+          wait_for_completion: true,
+        }),
+        headers,
+      },
+      env
+    );
+
+    expect(seen).toEqual([
+      { taskId: 'ticket-low-timeout', acceptanceTimeoutSeconds: 30 },
+      { taskId: 'ticket-high-timeout', acceptanceTimeoutSeconds: 900 },
+    ]);
+  });
+
   it('fails native runs before creating a run when DeepSeek is not configured', async () => {
     const app = createApp(fakeExecutor());
     const env = createEnv({ DROID_DEEPSEEK_API_KEY: undefined });
@@ -565,9 +666,11 @@ describe('droid runs', () => {
   it('auto-dequeues a queued same-repo run after the active run finishes', async () => {
     let releaseFirst: (() => void) | undefined;
     const executeCommands: string[] = [];
+    const acceptanceCommands: Array<string | undefined> = [];
     const app = createApp({
       async execute(input) {
         executeCommands.push(input.command);
+        acceptanceCommands.push(input.acceptanceCommand);
         if (input.command === 'first') {
           await new Promise<void>((resolve) => {
             releaseFirst = resolve;
@@ -603,9 +706,11 @@ describe('droid runs', () => {
       {
         method: 'POST',
         body: JSON.stringify({
+          task_id: 'ticket-queued-acceptance',
           project_slug: 'saas-maker',
           repo_url: 'https://github.com/example/repo.git',
           command: 'second',
+          acceptance_command: 'pnpm test -- ticket-queued-acceptance',
         }),
         headers,
       },
@@ -633,6 +738,7 @@ describe('droid runs', () => {
     expect(dequeuedPayload.data.status).toBe('completed');
     expect(dequeuedPayload.data.exit_code).toBe(0);
     expect(executeCommands).toEqual(['first', 'second']);
+    expect(acceptanceCommands).toEqual([undefined, 'pnpm test -- ticket-queued-acceptance']);
 
     const eventsResponse = await app.request(
       `/v0/runs/${queuedPayload.data.id}/events`,

--- a/tests/droid/runs.test.ts
+++ b/tests/droid/runs.test.ts
@@ -191,11 +191,21 @@ describe('droid runs', () => {
     expect(eventsPayload.data[3].stdout).toBe('ok\n');
   });
 
-  it('passes task metadata through to the executor', async () => {
-    const seen: Array<{ taskId?: string; projectSlug?: string }> = [];
+  it('passes task metadata and acceptance settings through to the executor', async () => {
+    const seen: Array<{
+      taskId?: string;
+      projectSlug?: string;
+      acceptanceCommand?: string;
+      acceptanceTimeoutSeconds?: number;
+    }> = [];
     const app = createApp({
       async execute(input) {
-        seen.push({ taskId: input.taskId, projectSlug: input.projectSlug });
+        seen.push({
+          taskId: input.taskId,
+          projectSlug: input.projectSlug,
+          acceptanceCommand: input.acceptanceCommand,
+          acceptanceTimeoutSeconds: input.acceptanceTimeoutSeconds,
+        });
         return { stdout: 'ok\n', stderr: '', exitCode: 0, success: true };
       },
     });
@@ -209,6 +219,8 @@ describe('droid runs', () => {
           task_id: 'task-blockable',
           project_slug: 'saas-maker',
           command: 'echo ok',
+          acceptance_command: 'pnpm test',
+          acceptance_timeout_seconds: 120,
           wait_for_completion: true,
         }),
         headers: {
@@ -220,7 +232,14 @@ describe('droid runs', () => {
     );
 
     expect(response.status).toBe(201);
-    expect(seen).toEqual([{ taskId: 'task-blockable', projectSlug: 'saas-maker' }]);
+    expect(seen).toEqual([
+      {
+        taskId: 'task-blockable',
+        projectSlug: 'saas-maker',
+        acceptanceCommand: 'pnpm test',
+        acceptanceTimeoutSeconds: 120,
+      },
+    ]);
   });
 
   it('lists run artifacts', async () => {

--- a/workers/droid/src/acceptance.ts
+++ b/workers/droid/src/acceptance.ts
@@ -1,0 +1,76 @@
+import type { CommandResult, RunExecutionInput } from './types';
+
+type SandboxLike = {
+  exec(command: string, options?: { timeout?: number }): Promise<CommandResult>;
+};
+
+export interface AcceptanceResult {
+  passed: boolean;
+  command: string;
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  summary: string;
+}
+
+export async function runAcceptanceCommand(
+  input: RunExecutionInput,
+  sandbox: SandboxLike,
+  cwd: string,
+  command: string,
+  timeoutSeconds = 300
+): Promise<AcceptanceResult> {
+  const timeoutMs = Math.min(Math.max(timeoutSeconds, 30), 900) * 1000;
+  await input.recordEvent({
+    type: 'acceptance_start',
+    actor: 'tester',
+    source: 'sandbox',
+    command,
+    cwd,
+    message: 'Running Droid acceptance command.',
+    metadata: { timeout_ms: timeoutMs },
+  });
+
+  const result = await sandbox.exec(`cd ${quote(cwd)} && ${command}`, { timeout: timeoutMs });
+  const passed = result.success;
+  const summary = passed
+    ? 'Acceptance command passed.'
+    : `Acceptance command failed with exit code ${result.exitCode}.`;
+
+  await input.recordEvent({
+    type: passed ? 'acceptance_passed' : 'acceptance_failed',
+    actor: 'tester',
+    source: 'sandbox',
+    command,
+    cwd,
+    exit_code: result.exitCode,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    message: summary,
+    metadata: { timeout_ms: timeoutMs },
+  });
+  await input.recordArtifact({
+    type: 'acceptance',
+    name: 'Droid acceptance report',
+    uri: `event://runs/${input.runId}/${passed ? 'acceptance_passed' : 'acceptance_failed'}`,
+    metadata: {
+      command,
+      cwd,
+      exit_code: result.exitCode,
+      passed,
+    },
+  });
+
+  return {
+    passed,
+    command,
+    exitCode: result.exitCode,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    summary,
+  };
+}
+
+function quote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}

--- a/workers/droid/src/app.ts
+++ b/workers/droid/src/app.ts
@@ -166,6 +166,8 @@ export function createApp(executor: RunExecutor) {
       prTitle: body?.pr_title?.trim(),
       prBody: body?.pr_body?.trim(),
       prBaseBranch: body?.pr_base_branch?.trim(),
+      acceptanceCommand: body?.acceptance_command?.trim(),
+      acceptanceTimeoutSeconds: normalizeAcceptanceTimeoutSeconds(body?.acceptance_timeout_seconds),
       cwd: body?.cwd?.trim(),
       destroyAfterRun: body?.destroy_after_run !== false,
       waitUntil: (promise: Promise<void>) => scheduleBackground(c, promise),
@@ -602,6 +604,8 @@ async function executeRun(
     prTitle?: string;
     prBody?: string;
     prBaseBranch?: string;
+    acceptanceCommand?: string;
+    acceptanceTimeoutSeconds?: number;
     cwd?: string;
     destroyAfterRun: boolean;
     reconcile?: boolean;
@@ -627,6 +631,8 @@ async function executeRun(
       prTitle: input.prTitle,
       prBody: input.prBody,
       prBaseBranch: input.prBaseBranch,
+      acceptanceCommand: input.acceptanceCommand,
+      acceptanceTimeoutSeconds: input.acceptanceTimeoutSeconds,
       cwd: input.cwd,
       destroyAfterRun: input.destroyAfterRun,
       recordEvent: (event) => createRunEvent(env, input.runId, event),
@@ -854,6 +860,8 @@ function buildRunRequestMetadata(
     pr_title: body?.pr_title ?? null,
     pr_body: body?.pr_body ?? null,
     pr_base_branch: body?.pr_base_branch ?? null,
+    acceptance_command: body?.acceptance_command ?? null,
+    acceptance_timeout_seconds: body?.acceptance_timeout_seconds ?? null,
     cwd: body?.cwd ?? null,
     destroy_after_run: body?.destroy_after_run !== false,
   };
@@ -883,6 +891,8 @@ function executionInputFromRun(
     prTitle: stringFromUnknown(request?.pr_title),
     prBody: stringFromUnknown(request?.pr_body),
     prBaseBranch: stringFromUnknown(request?.pr_base_branch),
+    acceptanceCommand: stringFromUnknown(request?.acceptance_command),
+    acceptanceTimeoutSeconds: normalizeAcceptanceTimeoutSeconds(request?.acceptance_timeout_seconds),
     cwd: stringFromUnknown(request?.cwd) ?? run.cwd ?? undefined,
     destroyAfterRun: request?.destroy_after_run !== false,
   };
@@ -933,6 +943,15 @@ function validateRunRequest(body: RunRequest | null): { ok: true } | { ok: false
   if (body.pr_base_branch !== undefined && typeof body.pr_base_branch !== 'string') {
     return { ok: false, error: 'pr_base_branch must be a string' };
   }
+  if (body.acceptance_command !== undefined && typeof body.acceptance_command !== 'string') {
+    return { ok: false, error: 'acceptance_command must be a string' };
+  }
+  if (
+    body.acceptance_timeout_seconds !== undefined &&
+    normalizeAcceptanceTimeoutSeconds(body.acceptance_timeout_seconds) === undefined
+  ) {
+    return { ok: false, error: 'acceptance_timeout_seconds must be between 30 and 900' };
+  }
   return { ok: true };
 }
 
@@ -972,6 +991,14 @@ function normalizeTimeoutSeconds(value: unknown): number | undefined {
   if (typeof value !== 'number' || !Number.isInteger(value)) return undefined;
   if (value < 60) return 60;
   if (value > 1800) return 1800;
+  return value;
+}
+
+function normalizeAcceptanceTimeoutSeconds(value: unknown): number | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'number' || !Number.isInteger(value)) return undefined;
+  if (value < 30) return 30;
+  if (value > 900) return 900;
   return value;
 }
 

--- a/workers/droid/src/executor.ts
+++ b/workers/droid/src/executor.ts
@@ -1,5 +1,6 @@
 import { getSandbox } from '@cloudflare/sandbox';
 import type { CommandResult, RunExecutor } from './types';
+import { runAcceptanceCommand } from './acceptance';
 import { captureGitPatch } from './patch';
 import { buildFinalReport, collectPrGateEvidence, type PrGateEvidence } from './pr-gate';
 import { providerContractEvent, resolveProviderContract } from './provider';
@@ -1212,9 +1213,18 @@ async function finalizeWorkspacePatch(
 ): Promise<CommandResult> {
   const patch = await captureGitPatch(input, sandbox, workspace, result);
   const evidence = collectPrGateEvidence(patch);
+  const finalEvidence = withAcceptanceCommand(evidence, input.acceptanceCommand);
 
   if (!input.createPr) {
-    await recordStructuredFinal(input, result, evidence, null);
+    const accepted = await runConfiguredAcceptance(input, sandbox, workspace);
+    if (!accepted.success) {
+      await recordStructuredFinal(input, accepted, finalEvidence, null, {
+        summary: accepted.stderr || 'Droid acceptance command failed.',
+        risks: [accepted.stderr || 'Droid acceptance command failed.'],
+      });
+      return accepted;
+    }
+    await recordStructuredFinal(input, result, finalEvidence, null);
     return result;
   }
 
@@ -1229,7 +1239,7 @@ async function finalizeWorkspacePatch(
       patch_changed: patch.changed,
       patch_bytes: patch.patchBytes,
       files_changed: evidence.filesChanged,
-      checks_run: evidence.checkCommands,
+      checks_run: finalEvidence.checkCommands,
     },
   });
 
@@ -1251,7 +1261,7 @@ async function finalizeWorkspacePatch(
         files_changed: evidence.filesChanged,
       },
     });
-    await recordStructuredFinal(input, result, evidence, null, { summary, risks: [summary] });
+    await recordStructuredFinal(input, result, finalEvidence, null, { summary, risks: [summary] });
     return {
       stdout: result.stdout,
       stderr: appendTail(result.stderr, summary),
@@ -1262,7 +1272,7 @@ async function finalizeWorkspacePatch(
 
   const review = await reviewPatchForPr(input, sandbox, workspace, patch, evidence);
   if (!review.approved) {
-    await recordStructuredFinal(input, result, evidence, null, {
+    await recordStructuredFinal(input, result, finalEvidence, null, {
       summary: review.summary || 'Droid patch review rejected PR creation.',
       risks: review.summary ? [review.summary] : [],
     });
@@ -1277,6 +1287,33 @@ async function finalizeWorkspacePatch(
     };
   }
 
+  const accepted = await runConfiguredAcceptance(input, sandbox, workspace);
+  if (!accepted.success) {
+    const summary = accepted.stderr || 'Droid acceptance command failed, so no pull request was created.';
+    await input.recordEvent({
+      type: 'pr_gate_failed',
+      actor: 'tester',
+      source: 'worker',
+      command: 'Droid acceptance gate',
+      cwd: resolveWorkspaceCwd(workspace, input.cwd),
+      exit_code: accepted.exitCode,
+      stdout: accepted.stdout,
+      stderr: accepted.stderr,
+      message: summary,
+      metadata: {
+        patch_changed: patch.changed,
+        patch_bytes: patch.patchBytes,
+        files_changed: evidence.filesChanged,
+        checks_run: finalEvidence.checkCommands,
+      },
+    });
+    await recordStructuredFinal(input, accepted, finalEvidence, null, {
+      summary,
+      risks: [summary],
+    });
+    return accepted;
+  }
+
   const pr = await createDraftPullRequestWithTimeout(
     input,
     sandbox,
@@ -1286,7 +1323,7 @@ async function finalizeWorkspacePatch(
   );
   if (!pr.created) {
     const summary = 'Droid could not create the requested pull request.';
-    await recordStructuredFinal(input, result, evidence, null, { summary, risks: [summary] });
+    await recordStructuredFinal(input, result, finalEvidence, null, { summary, risks: [summary] });
     return {
       stdout: result.stdout,
       stderr: appendTail(result.stderr, summary),
@@ -1305,12 +1342,55 @@ async function finalizeWorkspacePatch(
     metadata: {
       patch_bytes: patch.patchBytes,
       files_changed: evidence.filesChanged,
-      checks_run: evidence.checkCommands,
+      checks_run: finalEvidence.checkCommands,
       pr_url: pr.url ?? null,
     },
   });
-  await recordStructuredFinal(input, result, evidence, pr.url ?? null);
+  await recordStructuredFinal(input, result, finalEvidence, pr.url ?? null);
   return result;
+}
+
+async function runConfiguredAcceptance(
+  input: Parameters<RunExecutor['execute']>[0],
+  sandbox: Awaited<ReturnType<typeof getSandbox>>,
+  workspace: string
+): Promise<CommandResult> {
+  if (!input.acceptanceCommand) {
+    return { stdout: '', stderr: '', exitCode: 0, success: true };
+  }
+  const cwd = resolveWorkspaceCwd(workspace, input.cwd);
+  const result = await runAcceptanceCommand(
+    input,
+    sandbox,
+    cwd,
+    input.acceptanceCommand,
+    input.acceptanceTimeoutSeconds
+  );
+  if (result.passed) {
+    return {
+      stdout: result.stdout,
+      stderr: result.stderr,
+      exitCode: result.exitCode,
+      success: true,
+    };
+  }
+  return {
+    stdout: result.stdout,
+    stderr: appendTail(result.stderr, result.summary),
+    exitCode: result.exitCode || 78,
+    success: false,
+  };
+}
+
+function withAcceptanceCommand(
+  evidence: PrGateEvidence,
+  acceptanceCommand: string | undefined
+): PrGateEvidence {
+  if (!acceptanceCommand) return evidence;
+  return {
+    ...evidence,
+    checkCommands: [...evidence.checkCommands, acceptanceCommand],
+  };
 }
 
 async function recordStructuredFinal(

--- a/workers/droid/src/types.ts
+++ b/workers/droid/src/types.ts
@@ -32,6 +32,8 @@ export interface RunRequest {
   pr_title?: string;
   pr_body?: string;
   pr_base_branch?: string;
+  acceptance_command?: string;
+  acceptance_timeout_seconds?: number;
   destroy_after_run?: boolean;
   wait_for_completion?: boolean;
 }
@@ -114,6 +116,8 @@ export interface RunExecutionInput {
   prTitle?: string;
   prBody?: string;
   prBaseBranch?: string;
+  acceptanceCommand?: string;
+  acceptanceTimeoutSeconds?: number;
   cwd?: string;
   destroyAfterRun: boolean;
   recordEvent: (event: RunEventInput) => Promise<void>;


### PR DESCRIPTION
## Summary
- adds optional `acceptance_command` and timeout fields to Droid runs
- runs the acceptance command inside the sandbox before draft PR creation
- records acceptance events/artifacts and exposes the field in the local Droid dialog

## Validation
- `pnpm -F @saas-maker/droid typecheck`
- `pnpm vitest run tests/droid/acceptance.test.ts tests/droid/runs.test.ts tests/droid/pr-gate.test.ts tests/droid/patch.test.ts`
- `pnpm --filter ./apps/cockpit typecheck`
- `pnpm test`
- `pnpm --filter ./apps/cockpit build`
- `pnpm lint`

## Notes
- Local `/tasks` smoke loaded, but upstream task/project sync returned fetch failures in local dev, so no task dialog could be opened from live data.
- Existing unrelated local changes were left untouched: `scripts/fleet-audit.mjs` and `docs/task-cloud-audit.md`.
