### PR TITLE
Polish Droid run feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The CLI validates commands against the generated OpenAPI spec. Prefer `fnd api` 
 
 Droid is the autonomous task runner for SaaS Maker. It starts a Cloudflare Sandbox, hydrates a repo, runs a command or agent, captures logs and patches, and can raise a draft PR.
 
-See [docs/droid-roadmap.md](docs/droid-roadmap.md) for what is next before Droid should be treated as a hands-off production employee.
+See [docs/droid.md](docs/droid.md) for the quickstart and API fields, and [docs/droid-roadmap.md](docs/droid-roadmap.md) for what is next before Droid should be treated as a hands-off production employee.
 
 ## Contributing
 

--- a/apps/cockpit/src/app/api/droid/stats/route.ts
+++ b/apps/cockpit/src/app/api/droid/stats/route.ts
@@ -4,6 +4,19 @@ export async function GET(req: Request) {
   const denied = await requireDroidAccess();
   if (denied) return denied;
 
+  if (!process.env.DROID_INTERNAL_TOKEN && process.env.NODE_ENV !== "production") {
+    return Response.json({
+      data: {
+        total: 0,
+        by_status: { queued: 0, running: 0, completed: 0, failed: 0 },
+        avg_duration_ms: null,
+        stale_running: 0,
+        recent: [],
+      },
+      error: "DROID_INTERNAL_TOKEN is not configured; Droid stats are hidden in local dev.",
+    });
+  }
+
   const incoming = new URL(req.url);
   const upstream = new URL(droidApiUrl("/v0/stats"));
   for (const key of ["project_slug", "limit"]) {

--- a/apps/cockpit/src/components/tasks/DroidDialog.tsx
+++ b/apps/cockpit/src/components/tasks/DroidDialog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { Play, Square } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { AlertTriangle, CheckCircle2, Clipboard, ExternalLink, Play, Square, XCircle } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
@@ -75,6 +76,7 @@ interface DroidDialogProps {
   maxTurns: string;
   createPr: boolean;
   acceptanceCommand: string;
+  acceptanceSuggestions: string[];
   repoUrl: string;
   branch: string;
   cwd: string;
@@ -108,6 +110,7 @@ export function DroidDialog({
   maxTurns,
   createPr,
   acceptanceCommand,
+  acceptanceSuggestions,
   repoUrl,
   branch,
   cwd,
@@ -132,6 +135,8 @@ export function DroidDialog({
   onMarkStale,
   onClose,
 }: DroidDialogProps) {
+  const acceptanceWarning = createPr && !acceptanceCommand.trim();
+
   return (
     <Dialog open={!!task} onOpenChange={open => {
       if (!open) onClose();
@@ -224,6 +229,28 @@ export function DroidDialog({
                   placeholder="pnpm test"
                   className="font-mono text-xs"
                 />
+                {acceptanceSuggestions.length > 0 ? (
+                  <div className="flex flex-wrap gap-1.5">
+                    {acceptanceSuggestions.map(suggestion => (
+                      <Button
+                        key={suggestion}
+                        type="button"
+                        size="sm"
+                        variant={acceptanceCommand === suggestion ? 'secondary' : 'outline'}
+                        className="h-auto min-h-7 max-w-full justify-start px-2 py-1 font-mono text-[11px]"
+                        onClick={() => onAcceptanceCommandChange(suggestion)}
+                      >
+                        <span className="truncate">{suggestion}</span>
+                      </Button>
+                    ))}
+                  </div>
+                ) : null}
+                {acceptanceWarning ? (
+                  <div className="flex items-start gap-2 rounded-md border border-amber-500/35 bg-amber-500/10 p-2 text-xs text-amber-700 dark:text-amber-200">
+                    <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                    <span>Droid can open a PR without this, but no acceptance check will guard it.</span>
+                  </div>
+                ) : null}
                 <p className="text-xs text-muted-foreground">
                   Optional. Droid runs this in the repo before opening a draft PR.
                 </p>
@@ -279,11 +306,13 @@ export function DroidDialog({
               <DroidError error={error} />
               <DroidResult
                 run={run}
+                events={events}
                 running={running}
                 onReconcile={onReconcile}
                 onCancel={onCancel}
                 onMarkStale={onMarkStale}
               />
+              <DroidAcceptance events={events} />
               <DroidArtifacts artifacts={artifacts} />
               <DroidEvents events={events} />
             </div>
@@ -334,17 +363,20 @@ function DroidStats({ stats }: { stats: DroidRunStats | null }) {
 
 function DroidResult({
   run,
+  events,
   running,
   onReconcile,
   onCancel,
   onMarkStale,
 }: {
   run: DroidRunRow | null;
+  events: DroidRunEvent[];
   running: boolean;
   onReconcile: () => void;
   onCancel: () => void;
   onMarkStale: () => void;
 }) {
+  const finalReport = useMemo(() => getFinalReport(events), [events]);
   const reconcileLabel = run?.status === 'queued' ? 'Start queued' : 'Check run';
   const canControl = run?.status === 'queued' || run?.status === 'running';
   const canMarkStale = run?.status === 'running';
@@ -389,10 +421,73 @@ function DroidResult({
           <div><span className="text-foreground">Duration:</span> {run.duration_ms ? `${Math.round(run.duration_ms / 1000)}s` : 'pending'}</div>
           {run.summary ? <p className="pt-1 text-sm text-foreground">{run.summary}</p> : null}
           {run.error_message ? <p className="pt-1 text-sm text-red-500">{run.error_message}</p> : null}
+          {finalReport ? (
+            <div className="mt-2 space-y-2 rounded-md border bg-background p-2">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <span className="text-xs font-medium text-foreground">Final report</span>
+                {finalReport.prUrl ? (
+                  <a
+                    href={finalReport.prUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex items-center gap-1 text-xs font-medium text-blue-600 hover:underline dark:text-blue-300"
+                  >
+                    PR
+                    <ExternalLink className="h-3 w-3" />
+                  </a>
+                ) : null}
+              </div>
+              {finalReport.summary ? <p className="text-xs text-foreground">{finalReport.summary}</p> : null}
+              {finalReport.filesChanged.length > 0 ? (
+                <div className="text-[11px] text-muted-foreground">
+                  <span className="text-foreground">Files:</span> {finalReport.filesChanged.slice(0, 4).join(', ')}
+                  {finalReport.filesChanged.length > 4 ? ` +${finalReport.filesChanged.length - 4}` : ''}
+                </div>
+              ) : null}
+              {finalReport.checksRun.length > 0 ? (
+                <div className="text-[11px] text-muted-foreground">
+                  <span className="text-foreground">Checks:</span> {finalReport.checksRun.join(', ')}
+                </div>
+              ) : null}
+            </div>
+          ) : null}
         </div>
       ) : (
         <p className="mt-2 text-sm text-muted-foreground">Run a command to see the audit trail.</p>
       )}
+    </div>
+  );
+}
+
+function DroidAcceptance({ events }: { events: DroidRunEvent[] }) {
+  const acceptance = useMemo(() => getLatestEvent(events, ['acceptance_passed', 'acceptance_failed']), [events]);
+  if (!acceptance) return null;
+  const passed = acceptance.type === 'acceptance_passed';
+  return (
+    <div className={cn(
+      'rounded-lg border p-3',
+      passed
+        ? 'border-emerald-500/35 bg-emerald-500/10'
+        : 'border-red-500/40 bg-red-500/10'
+    )}>
+      <div className="flex items-center justify-between gap-2">
+        <h3 className="flex items-center gap-2 text-sm font-semibold text-foreground">
+          {passed ? <CheckCircle2 className="h-4 w-4 text-emerald-600 dark:text-emerald-300" /> : <XCircle className="h-4 w-4 text-red-600 dark:text-red-300" />}
+          Acceptance
+        </h3>
+        <Badge variant="outline" className={passed
+          ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200'
+          : 'border-red-500/40 bg-red-500/10 text-red-700 dark:text-red-200'
+        }>
+          {passed ? 'passed' : 'failed'}
+        </Badge>
+      </div>
+      <div className="mt-2 space-y-1 text-xs text-muted-foreground">
+        {acceptance.command ? <div className="break-all font-mono text-foreground">{acceptance.command}</div> : null}
+        {acceptance.cwd ? <div className="break-all font-mono text-[11px]">{acceptance.cwd}</div> : null}
+        {acceptance.message ? <p>{acceptance.message}</p> : null}
+        {acceptance.exit_code !== null ? <p>exit {acceptance.exit_code}</p> : null}
+      </div>
     </div>
   );
 }
@@ -426,8 +521,26 @@ function DroidArtifacts({ artifacts }: { artifacts: DroidRunArtifact[] }) {
 }
 
 function DroidEvents({ events }: { events: DroidRunEvent[] }) {
+  const [copied, setCopied] = useState(false);
+  const copyLogs = async () => {
+    try {
+      await navigator.clipboard.writeText(formatDroidEvents(events));
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1600);
+    } catch {
+      setCopied(false);
+    }
+  };
+
   return (
     <div className="max-h-[26rem] overflow-y-auto rounded-lg border bg-background p-3">
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <h3 className="text-sm font-semibold text-foreground">Events</h3>
+        <Button type="button" size="sm" variant="outline" onClick={copyLogs} disabled={events.length === 0}>
+          <Clipboard className="h-3.5 w-3.5" />
+          {copied ? 'Copied' : 'Copy'}
+        </Button>
+      </div>
       {events.length === 0 ? (
         <p className="text-sm text-muted-foreground">No Droid events yet.</p>
       ) : (
@@ -453,6 +566,47 @@ function DroidEvents({ events }: { events: DroidRunEvent[] }) {
       )}
     </div>
   );
+}
+
+function getLatestEvent(events: DroidRunEvent[], types: string[]) {
+  const allowed = new Set(types);
+  return [...events].reverse().find(event => allowed.has(event.type)) ?? null;
+}
+
+function getFinalReport(events: DroidRunEvent[]) {
+  const finalEvent = getLatestEvent(events, ['final_output']);
+  if (!finalEvent) return null;
+  const metadata = parseDroidMetadata(finalEvent.metadata);
+  return {
+    summary: stringFromUnknown(metadata.summary) || finalEvent.message || finalEvent.stdout || '',
+    prUrl: stringFromUnknown(metadata.pr_url),
+    filesChanged: stringArrayFromUnknown(metadata.files_changed),
+    checksRun: stringArrayFromUnknown(metadata.checks_run),
+  };
+}
+
+function formatDroidEvents(events: DroidRunEvent[]) {
+  return events.map(event => {
+    const lines = [
+      `[${formatRunTime(event.created_at)}] ${event.type}`,
+      event.command ? `command: ${event.command}` : '',
+      event.cwd ? `cwd: ${event.cwd}` : '',
+      event.exit_code !== null ? `exit: ${event.exit_code}` : '',
+      event.message ? `message: ${event.message}` : '',
+      event.stdout ? `stdout:\n${event.stdout}` : '',
+      event.stderr ? `stderr:\n${event.stderr}` : '',
+    ].filter(Boolean);
+    return lines.join('\n');
+  }).join('\n\n');
+}
+
+function stringArrayFromUnknown(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === 'string' && item.length > 0);
+}
+
+function stringFromUnknown(value: unknown): string {
+  return typeof value === 'string' ? value : '';
 }
 
 function formatRunTime(value: string) {

--- a/apps/cockpit/src/components/tasks/TaskBoard.tsx
+++ b/apps/cockpit/src/components/tasks/TaskBoard.tsx
@@ -190,6 +190,14 @@ const ALL_PROJECTS = '__all__';
 const UNASSIGNED_PROJECT = '__unassigned__';
 const ALL_PRIORITIES = '__all__';
 
+const DEFAULT_ACCEPTANCE_BY_PROJECT: Record<string, string[]> = {
+  'saas-maker': [
+    'pnpm --filter ./apps/cockpit typecheck',
+    'pnpm vitest run tests/droid/runs.test.ts',
+    'pnpm test',
+  ],
+};
+
 function sortTasksByPriority(tasks: TaskRow[]) {
   return [...tasks].sort((a, b) => {
     const priorityDiff = PRIORITY_RANK[a.priority] - PRIORITY_RANK[b.priority];
@@ -200,6 +208,31 @@ function sortTasksByPriority(tasks: TaskRow[]) {
 
 function taskPreview(description: string | null) {
   return description?.split(/\s+Source:\s+/)[0]?.trim() ?? '';
+}
+
+function buildDroidAcceptanceSuggestions(task: TaskRow): { explicit?: string; suggestions: string[] } {
+  const explicit = extractAcceptanceCommand(task.description);
+  const projectCommands = task.project_slug ? DEFAULT_ACCEPTANCE_BY_PROJECT[task.project_slug] ?? [] : [];
+  const suggestions = uniqueStrings([
+    explicit,
+    ...projectCommands,
+    'pnpm test',
+    'pnpm typecheck',
+  ]).slice(0, 4);
+
+  return { explicit, suggestions };
+}
+
+function extractAcceptanceCommand(description: string | null): string | undefined {
+  if (!description) return undefined;
+  const fenced = description.match(/Acceptance command:\s*`([^`]+)`/i)?.[1]?.trim();
+  if (fenced) return fenced;
+  const line = description.match(/Acceptance command:\s*([^\n]+)/i)?.[1]?.trim();
+  return line || undefined;
+}
+
+function uniqueStrings(values: Array<string | undefined>) {
+  return Array.from(new Set(values.map(value => value?.trim()).filter((value): value is string => Boolean(value))));
 }
 
 function formatRunTime(value: string) {
@@ -243,6 +276,7 @@ export function TaskBoard({
   const [droidMaxTurns, setDroidMaxTurns] = useState('25');
   const [droidCreatePr, setDroidCreatePr] = useState(true);
   const [droidAcceptanceCommand, setDroidAcceptanceCommand] = useState('');
+  const [droidAcceptanceSuggestions, setDroidAcceptanceSuggestions] = useState<string[]>([]);
   const [droidRepoUrl, setDroidRepoUrl] = useState('');
   const [droidBranch, setDroidBranch] = useState('');
   const [droidCwd, setDroidCwd] = useState('');
@@ -340,13 +374,15 @@ export function TaskBoard({
   };
 
   const openDroidRun = (task: TaskRow) => {
+    const acceptance = buildDroidAcceptanceSuggestions(task);
     setDroidTask(task);
     setDroidMode('native');
     setDroidCommand(task.project_slug ? 'pwd && ls -1' : 'pwd && echo droid-ok');
     setDroidPrompt(`Work on this task and report what you changed or found.\n\nTask: ${task.title}\n\n${task.description ?? ''}`.trim());
     setDroidMaxTurns('25');
     setDroidCreatePr(true);
-    setDroidAcceptanceCommand('');
+    setDroidAcceptanceSuggestions(acceptance.suggestions);
+    setDroidAcceptanceCommand(acceptance.explicit ?? '');
     setDroidRepoUrl(task.project_slug ? projectRepos?.[task.project_slug] ?? '' : '');
     setDroidBranch(task.branch_name ?? '');
     setDroidCwd('');
@@ -387,6 +423,7 @@ export function TaskBoard({
   }, [droidRun, loadDroidRunDetails]);
 
   const openDroidLogs = async (task: TaskRow) => {
+    const acceptance = buildDroidAcceptanceSuggestions(task);
     setLoadingDroidLogsTaskId(task.id);
     setDroidTask(task);
     setDroidMode('native');
@@ -394,7 +431,8 @@ export function TaskBoard({
     setDroidPrompt(`Work on this task and report what you changed or found.\n\nTask: ${task.title}\n\n${task.description ?? ''}`.trim());
     setDroidMaxTurns('25');
     setDroidCreatePr(true);
-    setDroidAcceptanceCommand('');
+    setDroidAcceptanceSuggestions(acceptance.suggestions);
+    setDroidAcceptanceCommand(acceptance.explicit ?? '');
     setDroidRepoUrl(task.project_slug ? projectRepos?.[task.project_slug] ?? '' : '');
     setDroidBranch(task.branch_name ?? '');
     setDroidCwd('');
@@ -1303,6 +1341,7 @@ export function TaskBoard({
         maxTurns={droidMaxTurns}
         createPr={droidCreatePr}
         acceptanceCommand={droidAcceptanceCommand}
+        acceptanceSuggestions={droidAcceptanceSuggestions}
         repoUrl={droidRepoUrl}
         branch={droidBranch}
         cwd={droidCwd}

--- a/tests/droid/runs.test.ts
+++ b/tests/droid/runs.test.ts
@@ -937,6 +937,38 @@ describe('droid runs', () => {
     expect(reconcilePayload.data.summary).toBe('Command completed with exit code 0.');
   });
 
+  it('stores the first useful failure line in failed run summaries', async () => {
+    const app = createApp({
+      async execute() {
+        return {
+          stdout: 'preflight started\n',
+          stderr: '\nError: package build failed\nmore details',
+          exitCode: 1,
+          success: false,
+        };
+      },
+    });
+    const env = createEnv();
+
+    const response = await app.request(
+      '/v0/runs',
+      {
+        method: 'POST',
+        body: JSON.stringify({ command: 'pnpm build', wait_for_completion: true }),
+        headers: {
+          Authorization: 'Bearer test-token',
+          'Content-Type': 'application/json',
+        },
+      },
+      env
+    );
+
+    expect(response.status).toBe(201);
+    const payload = (await response.json()) as { data: { status: string; summary: string } };
+    expect(payload.data.status).toBe('failed');
+    expect(payload.data.summary).toBe('Command failed with exit code 1: Error: package build failed');
+  });
+
   it('uses live run room activity to guard reconcile', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-05-14T12:00:00.000Z'));

--- a/workers/droid/src/app.ts
+++ b/workers/droid/src/app.ts
@@ -646,9 +646,7 @@ async function executeRun(
 
     const durationMs = Date.now() - input.startedAt;
     const status = result.success ? 'completed' : 'failed';
-    const summary = result.success
-      ? `Command completed with exit code ${result.exitCode}.`
-      : `Command failed with exit code ${result.exitCode}.`;
+    const summary = summarizeCommandResult(result);
     await finishRun(env, input.runId, {
       status,
       exitCode: result.exitCode,
@@ -776,6 +774,29 @@ class RunTimeoutError extends Error {
   constructor(readonly timeoutMs: number) {
     super(`Droid run timed out after ${Math.round(timeoutMs / 1000)} seconds.`);
   }
+}
+
+function summarizeCommandResult(result: CommandResult): string {
+  if (result.success) {
+    return `Command completed with exit code ${result.exitCode}.`;
+  }
+
+  const reason = firstUsefulLine(result.stderr) || firstUsefulLine(result.stdout);
+  if (!reason) {
+    return `Command failed with exit code ${result.exitCode}. Inspect the Droid events for the failing command.`;
+  }
+  return `Command failed with exit code ${result.exitCode}: ${truncateSummary(reason)}`;
+}
+
+function firstUsefulLine(value: string): string {
+  return value
+    .split('\n')
+    .map((line) => line.trim())
+    .find((line) => line.length > 0) ?? '';
+}
+
+function truncateSummary(value: string): string {
+  return value.length > 220 ? `${value.slice(0, 217)}...` : value;
 }
 
 async function handleRunTimeout(


### PR DESCRIPTION
## Summary
- surface Droid acceptance status, final reports, PR links, and copyable event logs in Cockpit
- suggest acceptance commands from task/project context and warn before PR runs without one
- improve failed Droid run summaries and make local stats fallback non-fatal

## Tests
- pnpm --filter ./apps/cockpit typecheck
- pnpm vitest run tests/droid/runs.test.ts tests/droid/acceptance.test.ts tests/droid/pr-gate.test.ts
- pnpm test
- pnpm lint
- local browser smoke on http://localhost:3001/tasks