### PR TITLE
Add Droid handoff loop

### DIFF
--- a/apps/cockpit/src/app/api/droid/stats/route.ts
+++ b/apps/cockpit/src/app/api/droid/stats/route.ts
@@ -11,6 +11,8 @@ export async function GET(req: Request) {
         by_status: { queued: 0, running: 0, completed: 0, failed: 0 },
         avg_duration_ms: null,
         stale_running: 0,
+        idle_running: 0,
+        estimated_compute_seconds: 0,
         recent: [],
       },
       error: "DROID_INTERNAL_TOKEN is not configured; Droid stats are hidden in local dev.",

--- a/apps/cockpit/src/components/tasks/DroidDialog.tsx
+++ b/apps/cockpit/src/components/tasks/DroidDialog.tsx
@@ -63,6 +63,8 @@ export interface DroidRunStats {
   by_status: Record<DroidRunRow['status'], number>;
   avg_duration_ms: number | null;
   stale_running: number;
+  idle_running?: number;
+  estimated_compute_seconds?: number;
   recent: DroidRunRow[];
 }
 
@@ -339,6 +341,7 @@ function DroidStats({ stats }: { stats: DroidRunStats | null }) {
     ['Queued', stats.by_status.queued],
     ['Running', stats.by_status.running],
     ['Failed', stats.by_status.failed],
+    ['Idle', stats.idle_running ?? 0],
     ['Stale', stats.stale_running],
   ] as const;
   return (
@@ -349,7 +352,7 @@ function DroidStats({ stats }: { stats: DroidRunStats | null }) {
           <span className="text-xs text-muted-foreground">avg {Math.round(stats.avg_duration_ms / 1000)}s</span>
         ) : null}
       </div>
-      <div className="mt-2 grid grid-cols-5 gap-2">
+      <div className="mt-2 grid grid-cols-6 gap-2">
         {items.map(([label, value]) => (
           <div key={label} className="rounded-md border bg-background px-2 py-1.5 text-center">
             <div className="text-sm font-semibold text-foreground">{value}</div>
@@ -357,6 +360,11 @@ function DroidStats({ stats }: { stats: DroidRunStats | null }) {
           </div>
         ))}
       </div>
+      {stats.estimated_compute_seconds ? (
+        <p className="mt-2 text-[11px] text-muted-foreground">
+          approx {Math.round(stats.estimated_compute_seconds / 60)}m sandbox runtime tracked
+        </p>
+      ) : null}
     </div>
   );
 }
@@ -438,6 +446,11 @@ function DroidResult({
                 ) : null}
               </div>
               {finalReport.summary ? <p className="text-xs text-foreground">{finalReport.summary}</p> : null}
+              {finalReport.prBranch ? (
+                <div className="break-all text-[11px] text-muted-foreground">
+                  <span className="text-foreground">Branch:</span> {finalReport.prBranch}
+                </div>
+              ) : null}
               {finalReport.filesChanged.length > 0 ? (
                 <div className="text-[11px] text-muted-foreground">
                   <span className="text-foreground">Files:</span> {finalReport.filesChanged.slice(0, 4).join(', ')}
@@ -447,6 +460,11 @@ function DroidResult({
               {finalReport.checksRun.length > 0 ? (
                 <div className="text-[11px] text-muted-foreground">
                   <span className="text-foreground">Checks:</span> {finalReport.checksRun.join(', ')}
+                </div>
+              ) : null}
+              {finalReport.nextAction ? (
+                <div className="text-[11px] text-muted-foreground">
+                  <span className="text-foreground">Next:</span> {finalReport.nextAction}
                 </div>
               ) : null}
             </div>
@@ -580,6 +598,8 @@ function getFinalReport(events: DroidRunEvent[]) {
   return {
     summary: stringFromUnknown(metadata.summary) || finalEvent.message || finalEvent.stdout || '',
     prUrl: stringFromUnknown(metadata.pr_url),
+    prBranch: stringFromUnknown(metadata.pr_branch),
+    nextAction: stringFromUnknown(metadata.next_action),
     filesChanged: stringArrayFromUnknown(metadata.files_changed),
     checksRun: stringArrayFromUnknown(metadata.checks_run),
   };

--- a/apps/cockpit/src/components/tasks/TaskBoard.tsx
+++ b/apps/cockpit/src/components/tasks/TaskBoard.tsx
@@ -198,6 +198,20 @@ const DEFAULT_ACCEPTANCE_BY_PROJECT: Record<string, string[]> = {
   ],
 };
 
+function buildDroidPrompt(task: TaskRow, acceptanceCommand?: string): string {
+  return [
+    'You own this task end to end. Make the smallest complete code change, verify it, and prepare a draft PR when useful.',
+    '',
+    `Task: ${task.title}`,
+    task.description ? `\nDetails:\n${task.description}` : '',
+    acceptanceCommand ? `\nAcceptance command to run before PR:\n${acceptanceCommand}` : '',
+    '',
+    'When blocked, return a block action with the exact user question. When done, summarize changed files, checks run, risks, and next action.',
+  ]
+    .filter(Boolean)
+    .join('\n');
+}
+
 function sortTasksByPriority(tasks: TaskRow[]) {
   return [...tasks].sort((a, b) => {
     const priorityDiff = PRIORITY_RANK[a.priority] - PRIORITY_RANK[b.priority];
@@ -378,7 +392,7 @@ export function TaskBoard({
     setDroidTask(task);
     setDroidMode('native');
     setDroidCommand(task.project_slug ? 'pwd && ls -1' : 'pwd && echo droid-ok');
-    setDroidPrompt(`Work on this task and report what you changed or found.\n\nTask: ${task.title}\n\n${task.description ?? ''}`.trim());
+    setDroidPrompt(buildDroidPrompt(task, acceptance.explicit));
     setDroidMaxTurns('25');
     setDroidCreatePr(true);
     setDroidAcceptanceSuggestions(acceptance.suggestions);
@@ -428,7 +442,7 @@ export function TaskBoard({
     setDroidTask(task);
     setDroidMode('native');
     setDroidCommand(task.project_slug ? 'pwd && ls -1' : 'pwd && echo droid-ok');
-    setDroidPrompt(`Work on this task and report what you changed or found.\n\nTask: ${task.title}\n\n${task.description ?? ''}`.trim());
+    setDroidPrompt(buildDroidPrompt(task, acceptance.explicit));
     setDroidMaxTurns('25');
     setDroidCreatePr(true);
     setDroidAcceptanceSuggestions(acceptance.suggestions);

--- a/docs/droid.md
+++ b/docs/droid.md
@@ -50,4 +50,16 @@ Droid stores:
 - command, agent, queue, acceptance, PR gate, and final report events in `droid_run_events`
 - patch and acceptance references in `droid_run_artifacts`
 
-The final report event is machine-readable and includes `summary`, `files_changed`, `checks_run`, `pr_url`, `blockers`, and `risks`.
+The final report event is machine-readable and includes `summary`, `files_changed`, `checks_run`, `pr_url`, `pr_branch`, `next_action`, `blockers`, and `risks`.
+
+## Task Feedback
+
+When `DROID_SAASMAKER_TOKEN` is configured, Droid can write back to the task:
+
+- block actions add an agent comment and set `blocked_on_user`
+- final reports add a concise run summary comment
+- draft PR creation updates `pr_url`, `pr_status`, and `branch_name`
+
+## Reliability
+
+Droid exposes `POST /v0/runs/reap-stale` for cron/manual cleanup. It finds running jobs with no activity for 15 minutes, marks them failed, cancels the sandbox when possible, and releases the next queued run for that repo/project.

--- a/tests/droid/pr-gate.test.ts
+++ b/tests/droid/pr-gate.test.ts
@@ -44,12 +44,16 @@ describe('droid pr gate helpers', () => {
         filesChanged: ['apps/cockpit/a.tsx'],
         checksRun: ['git diff --check -- .'],
         prUrl: 'https://github.com/example/repo/pull/1',
+        prBranch: 'droid/run-123',
+        nextAction: 'Review the draft PR.',
       })
     ).toMatchObject({
       summary: 'Changed audit log UI.',
       files_changed: ['apps/cockpit/a.tsx'],
       checks_run: ['git diff --check -- .'],
       pr_url: 'https://github.com/example/repo/pull/1',
+      pr_branch: 'droid/run-123',
+      next_action: 'Review the draft PR.',
       blockers: [],
       risks: [],
     });

--- a/tests/droid/runs.test.ts
+++ b/tests/droid/runs.test.ts
@@ -543,6 +543,8 @@ describe('droid runs', () => {
           failed: 1,
         },
         stale_running: 1,
+        idle_running: 1,
+        estimated_compute_seconds: expect.any(Number),
         recent: expect.arrayContaining([expect.objectContaining({ project_slug: 'saas-maker' })]),
       },
     });
@@ -590,6 +592,7 @@ describe('droid runs', () => {
         data: {
           by_status: { running: 1 },
           stale_running: 0,
+          idle_running: 0,
         },
       });
     } finally {
@@ -851,6 +854,51 @@ describe('droid runs', () => {
         data: Array<{ type: string }>;
       };
       expect(firstEventsPayload.data.map((event) => event.type)).toContain('run_marked_stale');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('reaps stale running runs in batches', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-14T12:00:00.000Z'));
+    const app = createApp({
+      async execute() {
+        return new Promise(() => undefined);
+      },
+    });
+    const env = createEnv();
+    const headers = {
+      Authorization: 'Bearer test-token',
+      'Content-Type': 'application/json',
+    };
+
+    try {
+      const runResponse = await app.request(
+        '/v0/runs',
+        {
+          method: 'POST',
+          body: JSON.stringify({ project_slug: 'saas-maker', command: 'hang' }),
+          headers,
+        },
+        env
+      );
+      const runPayload = (await runResponse.json()) as { data: { id: string } };
+      const response = await app.request(
+        '/v0/runs/reap-stale',
+        {
+          method: 'POST',
+          body: JSON.stringify({ project_slug: 'saas-maker', wait_for_dispatch: true }),
+          headers,
+        },
+        env
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        data: { reaped: 1, run_ids: [runPayload.data.id] },
+      });
+      expect((env.DB as unknown as FakeD1).runs.get(runPayload.data.id)?.status).toBe('failed');
     } finally {
       vi.useRealTimers();
     }
@@ -1306,6 +1354,14 @@ class FakeStatement {
           .filter((run) => isStaleFakeRun(this.db, run)).length,
       };
     }
+    if (this.sql.includes('SELECT COALESCE(SUM(duration_ms), 0) AS total_duration_ms FROM droid_runs')) {
+      const projectSlug = this.params.length > 0 ? this.params[0] : undefined;
+      return {
+        total_duration_ms: Array.from(this.db.runs.values())
+          .filter((run) => projectSlug === undefined || run.project_slug === projectSlug)
+          .reduce((sum, run) => sum + (typeof run.duration_ms === 'number' ? run.duration_ms : 0), 0),
+      };
+    }
     if (this.sql.includes('FROM droid_run_events') && this.sql.includes("type = 'run_request'")) {
       const [runId] = this.params;
       const event = this.db.events
@@ -1356,6 +1412,22 @@ class FakeStatement {
         results: Array.from(this.db.runs.values())
           .filter((run) => run.task_id === taskId)
           .slice(0, Number(limit)),
+      };
+    }
+    if (
+      this.sql.includes('SELECT * FROM droid_runs') &&
+      this.sql.includes("status = 'running'") &&
+      this.sql.includes("'+15 minutes'")
+    ) {
+      const hasProjectFilter = this.sql.includes('project_slug = ?');
+      const projectSlug = hasProjectFilter ? this.params[0] : undefined;
+      const limit = Number(hasProjectFilter ? this.params[1] : this.params[0]);
+      return {
+        results: Array.from(this.db.runs.values())
+          .filter((run) => projectSlug === undefined || run.project_slug === projectSlug)
+          .filter((run) => run.status === 'running' && run.started_at)
+          .filter((run) => isStaleFakeRun(this.db, run))
+          .slice(0, limit),
       };
     }
     if (this.sql.includes('SELECT * FROM droid_runs WHERE project_slug = ?')) {

--- a/workers/droid/src/app.ts
+++ b/workers/droid/src/app.ts
@@ -11,6 +11,7 @@ import {
   getNextQueuedRunForQueue,
   getRun,
   getRunStats,
+  listStaleRunningRuns,
   listRunArtifacts,
   listRunEvents,
   listRuns,
@@ -25,6 +26,7 @@ import type {
   RunExecutor,
   RunMode,
   RunProvider,
+  RunRecord,
   RunRequest,
 } from './types';
 
@@ -214,6 +216,26 @@ export function createApp(executor: RunExecutor) {
     return c.json({ data: stats });
   });
 
+  app.post('/v0/runs/reap-stale', async (c) => {
+    const incoming = (await c.req.json().catch(() => null)) as {
+      project_slug?: string;
+      limit?: number;
+      wait_for_dispatch?: boolean;
+    } | null;
+    const staleRuns = await listStaleRunningRuns(c.env, {
+      projectSlug: incoming?.project_slug?.trim(),
+      limit: normalizeLimit(incoming?.limit),
+    });
+    for (const staleRun of staleRuns) {
+      await markStaleRunAndReleaseQueue(c.env, executor, staleRun, {
+        forced: false,
+        waitForDispatch: incoming?.wait_for_dispatch === true,
+        waitUntil: (promise) => scheduleBackground(c, promise),
+      });
+    }
+    return c.json({ data: { reaped: staleRuns.length, run_ids: staleRuns.map((run) => run.id) } });
+  });
+
   app.get('/v0/runs/:id/events', async (c) => {
     const run = await getRun(c.env, c.req.param('id'));
     if (!run) return c.json({ error: 'Run not found' }, 404);
@@ -321,60 +343,12 @@ export function createApp(executor: RunExecutor) {
       );
     }
 
-    await createRunEvent(c.env, run.id, {
-      type: 'run_marked_stale',
-      message: 'Droid run marked stale after no recent activity.',
-      exit_code: 124,
-      metadata: {
-        sandbox_id: run.sandbox_id,
-        latest_event_at: latestActivity?.created_at ?? null,
-        latest_event_source: latestActivity?.source ?? null,
-        forced: incoming?.force === true,
-      },
+    await markStaleRunAndReleaseQueue(c.env, executor, run, {
+      forced: incoming?.force === true,
+      latestActivity,
+      waitForDispatch: incoming?.wait_for_dispatch === true,
+      waitUntil: (promise) => scheduleBackground(c, promise),
     });
-    await finishRun(c.env, run.id, {
-      status: 'failed',
-      exitCode: 124,
-      durationMs: durationSince(run.started_at),
-      summary: 'Droid run marked stale after no recent activity.',
-      errorMessage: 'Droid run marked stale after no recent activity.',
-    });
-
-    if (executor.cancel) {
-      const cancelPromise = executor
-        .cancel({
-          env: c.env,
-          runId: run.id,
-          sandboxId: run.sandbox_id,
-          recordEvent: (event) => createRunEvent(c.env, run.id, event),
-          recordArtifact: (artifact) => createRunArtifact(c.env, run.id, artifact),
-        })
-        .catch((error) =>
-          createRunEvent(c.env, run.id, {
-            type: 'sandbox_destroy_failed',
-            message: error instanceof Error ? error.message : 'Sandbox destroy failed.',
-            metadata: { sandbox_id: run.sandbox_id, during_stale_recovery: true },
-          })
-        );
-      scheduleBackground(c, cancelPromise);
-    }
-
-    const dispatchPromise = dispatchNextQueuedRun(c.env, executor, {
-      runId: run.id,
-      repoUrl: run.repo_url ?? undefined,
-      waitUntil: (promise: Promise<void>) => scheduleBackground(c, promise),
-    }).catch((error) =>
-      createRunEvent(c.env, run.id, {
-        type: 'queue_dispatch_failed',
-        message: error instanceof Error ? error.message : 'Droid queue dispatch failed.',
-        metadata: { run_id: run.id, during_stale_recovery: true },
-      })
-    );
-    if (incoming?.wait_for_dispatch === true) {
-      await dispatchPromise;
-    } else {
-      scheduleBackground(c, dispatchPromise);
-    }
 
     const updatedRun = await getRun(c.env, run.id);
     return c.json({ data: updatedRun ?? run, marked_stale: true });
@@ -799,6 +773,73 @@ function truncateSummary(value: string): string {
   return value.length > 220 ? `${value.slice(0, 217)}...` : value;
 }
 
+async function markStaleRunAndReleaseQueue(
+  env: Env,
+  executor: RunExecutor,
+  run: RunRecord,
+  input: {
+    forced: boolean;
+    latestActivity?: { created_at?: string; source?: string } | null;
+    waitForDispatch: boolean;
+    waitUntil: (promise: Promise<void>) => void;
+  }
+): Promise<void> {
+  await createRunEvent(env, run.id, {
+    type: 'run_marked_stale',
+    message: 'Droid run marked stale after no recent activity.',
+    exit_code: 124,
+    metadata: {
+      sandbox_id: run.sandbox_id,
+      latest_event_at: input.latestActivity?.created_at ?? null,
+      latest_event_source: input.latestActivity?.source ?? null,
+      forced: input.forced,
+    },
+  });
+  await finishRun(env, run.id, {
+    status: 'failed',
+    exitCode: 124,
+    durationMs: durationSince(run.started_at),
+    summary: 'Droid run marked stale after no recent activity.',
+    errorMessage: 'Droid run marked stale after no recent activity.',
+  });
+
+  if (executor.cancel) {
+    const cancelPromise = executor
+      .cancel({
+        env,
+        runId: run.id,
+        sandboxId: run.sandbox_id,
+        recordEvent: (event) => createRunEvent(env, run.id, event),
+        recordArtifact: (artifact) => createRunArtifact(env, run.id, artifact),
+      })
+      .catch((error) =>
+        createRunEvent(env, run.id, {
+          type: 'sandbox_destroy_failed',
+          message: error instanceof Error ? error.message : 'Sandbox destroy failed.',
+          metadata: { sandbox_id: run.sandbox_id, during_stale_recovery: true },
+        })
+      );
+    input.waitUntil(cancelPromise);
+  }
+
+  const dispatchPromise = dispatchNextQueuedRun(env, executor, {
+    runId: run.id,
+    repoUrl: run.repo_url ?? undefined,
+    waitUntil: input.waitUntil,
+  }).catch((error) =>
+    createRunEvent(env, run.id, {
+      type: 'queue_dispatch_failed',
+      message: error instanceof Error ? error.message : 'Droid queue dispatch failed.',
+      metadata: { run_id: run.id, during_stale_recovery: true },
+    })
+  );
+  if (input.waitForDispatch) {
+    await dispatchPromise;
+  } else {
+    input.waitUntil(dispatchPromise);
+  }
+}
+
 async function handleRunTimeout(
   env: Env,
   executor: RunExecutor,
@@ -1024,7 +1065,8 @@ function normalizeAcceptanceTimeoutSeconds(value: unknown): number | undefined {
 }
 
 function normalizeLimit(value: unknown): number | undefined {
-  if (typeof value !== 'string' || !value.trim()) return undefined;
+  if (typeof value !== 'string' && typeof value !== 'number') return undefined;
+  if (typeof value === 'string' && !value.trim()) return undefined;
   const parsed = Number(value);
   if (!Number.isInteger(parsed)) return undefined;
   if (parsed < 1) return 1;

--- a/workers/droid/src/db.ts
+++ b/workers/droid/src/db.ts
@@ -138,6 +138,24 @@ export async function getRunStats(env: Env, input: { projectSlug?: string; limit
   const staleRow = await env.DB.prepare(
     `SELECT COUNT(*) AS count FROM droid_runs ${staleWhere}`
   ).bind(...(input.projectSlug ? [input.projectSlug] : [])).first<{ count: number }>();
+  const idleWhere = input.projectSlug
+    ? `WHERE project_slug = ? AND status = 'running' AND started_at IS NOT NULL
+       AND datetime(
+         COALESCE((SELECT MAX(created_at) FROM droid_run_events WHERE run_id = droid_runs.id), started_at),
+         '+6 minutes'
+       ) < datetime('now')`
+    : `WHERE status = 'running' AND started_at IS NOT NULL
+       AND datetime(
+         COALESCE((SELECT MAX(created_at) FROM droid_run_events WHERE run_id = droid_runs.id), started_at),
+         '+6 minutes'
+       ) < datetime('now')`;
+  const idleRow = await env.DB.prepare(
+    `SELECT COUNT(*) AS count FROM droid_runs ${idleWhere}`
+  ).bind(...(input.projectSlug ? [input.projectSlug] : [])).first<{ count: number }>();
+  const durationWhere = input.projectSlug ? 'WHERE project_slug = ?' : '';
+  const durationRow = await env.DB.prepare(
+    `SELECT COALESCE(SUM(duration_ms), 0) AS total_duration_ms FROM droid_runs ${durationWhere}`
+  ).bind(...(input.projectSlug ? [input.projectSlug] : [])).first<{ total_duration_ms: number }>();
   const recent = await listRuns(env, { projectSlug: input.projectSlug, limit });
 
   return {
@@ -147,8 +165,28 @@ export async function getRunStats(env: Env, input: { projectSlug?: string; limit
       ? null
       : Math.round(Number(avgRow.avg_duration_ms)),
     stale_running: Number(staleRow?.count ?? 0),
+    idle_running: Number(idleRow?.count ?? 0),
+    estimated_compute_seconds: Math.round(Number(durationRow?.total_duration_ms ?? 0) / 1000),
     recent,
   };
+}
+
+export async function listStaleRunningRuns(env: Env, input: { projectSlug?: string; limit?: number }): Promise<RunRecord[]> {
+  const limit = Math.min(Math.max(input.limit ?? 5, 1), 25);
+  const where = input.projectSlug
+    ? `project_slug = ? AND status = 'running' AND started_at IS NOT NULL`
+    : `status = 'running' AND started_at IS NOT NULL`;
+  const rows = await env.DB.prepare(
+    `SELECT * FROM droid_runs
+     WHERE ${where}
+       AND datetime(
+         COALESCE((SELECT MAX(created_at) FROM droid_run_events WHERE run_id = droid_runs.id), started_at),
+         '+15 minutes'
+       ) < datetime('now')
+     ORDER BY started_at ASC
+     LIMIT ?`
+  ).bind(...(input.projectSlug ? [input.projectSlug, limit] : [limit])).all();
+  return (rows.results ?? []) as unknown as RunRecord[];
 }
 
 export async function listRunEvents(env: Env, runId: string): Promise<RunEventRecord[]> {

--- a/workers/droid/src/executor.ts
+++ b/workers/droid/src/executor.ts
@@ -21,6 +21,9 @@ type RepoHydration = {
 type PrCreationResult = {
   created: boolean;
   url?: string;
+  branch?: string;
+  number?: number;
+  headSha?: string;
 };
 
 type NativeAgentAction =
@@ -661,23 +664,11 @@ async function markTaskBlocked(
     return false;
   }
 
-  const token = input.env.DROID_SAASMAKER_TOKEN?.trim();
-  if (!token) {
-    await input.recordEvent({
-      type: 'task_blocked_callback_skipped',
-      actor: 'droid',
-      source: 'worker',
-      message: 'DROID_SAASMAKER_TOKEN is not configured.',
-      metadata: { task_id: input.taskId, reason: action.reason, question: action.question },
-    });
+  const client = await getTaskCallbackClient(input, 'task_blocked_callback_skipped');
+  if (!client) {
     return false;
   }
 
-  const apiUrl = (input.env.SAASMAKER_API_URL?.trim() || 'https://api.sassmaker.com').replace(
-    /\/+$/,
-    ''
-  );
-  const taskPath = `/v1/tasks/${encodeURIComponent(input.taskId)}`;
   const commentBody = [
     'Droid is blocked and needs user input.',
     '',
@@ -693,36 +684,8 @@ async function markTaskBlocked(
     .join('\n');
 
   try {
-    const commentResponse = await fetch(`${apiUrl}${taskPath}/comments`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        body: commentBody,
-        author_type: 'agent',
-      }),
-    });
-    if (!commentResponse.ok) {
-      const text = await commentResponse.text();
-      throw new Error(`comment failed with HTTP ${commentResponse.status}: ${text.slice(0, 300)}`);
-    }
-
-    const patchResponse = await fetch(`${apiUrl}${taskPath}`, {
-      method: 'PATCH',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ blocked_on_user: true }),
-    });
-    if (!patchResponse.ok) {
-      const text = await patchResponse.text();
-      throw new Error(
-        `block update failed with HTTP ${patchResponse.status}: ${text.slice(0, 300)}`
-      );
-    }
+    await postTaskComment(client, commentBody);
+    await patchTask(client, { blocked_on_user: true });
 
     await input.recordEvent({
       type: 'task_blocked_callback_succeeded',
@@ -741,6 +704,65 @@ async function markTaskBlocked(
       metadata: { task_id: input.taskId, reason: action.reason, question: action.question },
     });
     return false;
+  }
+}
+
+type TaskCallbackClient = {
+  apiUrl: string;
+  token: string;
+  taskId: string;
+};
+
+async function getTaskCallbackClient(
+  input: Parameters<RunExecutor['execute']>[0],
+  skippedEventType: string
+): Promise<TaskCallbackClient | null> {
+  if (!input.taskId) return null;
+  const token = input.env.DROID_SAASMAKER_TOKEN?.trim();
+  if (!token) {
+    await input.recordEvent({
+      type: skippedEventType,
+      actor: 'droid',
+      source: 'worker',
+      message: 'DROID_SAASMAKER_TOKEN is not configured.',
+      metadata: { task_id: input.taskId },
+    });
+    return null;
+  }
+  return {
+    apiUrl: (input.env.SAASMAKER_API_URL?.trim() || 'https://api.sassmaker.com').replace(/\/+$/, ''),
+    token,
+    taskId: input.taskId,
+  };
+}
+
+async function postTaskComment(client: TaskCallbackClient, body: string): Promise<void> {
+  const response = await fetch(`${client.apiUrl}/v1/tasks/${encodeURIComponent(client.taskId)}/comments`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${client.token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ body, author_type: 'agent' }),
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`comment failed with HTTP ${response.status}: ${text.slice(0, 300)}`);
+  }
+}
+
+async function patchTask(client: TaskCallbackClient, body: Record<string, unknown>): Promise<void> {
+  const response = await fetch(`${client.apiUrl}/v1/tasks/${encodeURIComponent(client.taskId)}`, {
+    method: 'PATCH',
+    headers: {
+      Authorization: `Bearer ${client.token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`task update failed with HTTP ${response.status}: ${text.slice(0, 300)}`);
   }
 }
 
@@ -1184,7 +1206,7 @@ async function createDraftPullRequest(
         pr_number: pr.number,
       },
     });
-    return { created: true, url: pr.html_url };
+    return { created: true, url: pr.html_url, branch: branchName, number: pr.number, headSha: commit.sha };
   } catch (error) {
     await input.recordEvent({
       type: 'pr_failed',
@@ -1218,13 +1240,13 @@ async function finalizeWorkspacePatch(
   if (!input.createPr) {
     const accepted = await runConfiguredAcceptance(input, sandbox, workspace);
     if (!accepted.success) {
-      await recordStructuredFinal(input, accepted, finalEvidence, null, {
-        summary: accepted.stderr || 'Droid acceptance command failed.',
-        risks: [accepted.stderr || 'Droid acceptance command failed.'],
-      });
+    await recordStructuredFinal(input, accepted, finalEvidence, null, null, {
+      summary: accepted.stderr || 'Droid acceptance command failed.',
+      risks: [accepted.stderr || 'Droid acceptance command failed.'],
+    });
       return accepted;
     }
-    await recordStructuredFinal(input, result, finalEvidence, null);
+    await recordStructuredFinal(input, result, finalEvidence, null, null);
     return result;
   }
 
@@ -1261,7 +1283,7 @@ async function finalizeWorkspacePatch(
         files_changed: evidence.filesChanged,
       },
     });
-    await recordStructuredFinal(input, result, finalEvidence, null, { summary, risks: [summary] });
+    await recordStructuredFinal(input, result, finalEvidence, null, null, { summary, risks: [summary] });
     return {
       stdout: result.stdout,
       stderr: appendTail(result.stderr, summary),
@@ -1272,7 +1294,7 @@ async function finalizeWorkspacePatch(
 
   const review = await reviewPatchForPr(input, sandbox, workspace, patch, evidence);
   if (!review.approved) {
-    await recordStructuredFinal(input, result, finalEvidence, null, {
+    await recordStructuredFinal(input, result, finalEvidence, null, null, {
       summary: review.summary || 'Droid patch review rejected PR creation.',
       risks: review.summary ? [review.summary] : [],
     });
@@ -1307,7 +1329,7 @@ async function finalizeWorkspacePatch(
         checks_run: finalEvidence.checkCommands,
       },
     });
-    await recordStructuredFinal(input, accepted, finalEvidence, null, {
+    await recordStructuredFinal(input, accepted, finalEvidence, null, null, {
       summary,
       risks: [summary],
     });
@@ -1323,7 +1345,7 @@ async function finalizeWorkspacePatch(
   );
   if (!pr.created) {
     const summary = 'Droid could not create the requested pull request.';
-    await recordStructuredFinal(input, result, finalEvidence, null, { summary, risks: [summary] });
+    await recordStructuredFinal(input, result, finalEvidence, null, null, { summary, risks: [summary] });
     return {
       stdout: result.stdout,
       stderr: appendTail(result.stderr, summary),
@@ -1344,9 +1366,29 @@ async function finalizeWorkspacePatch(
       files_changed: evidence.filesChanged,
       checks_run: finalEvidence.checkCommands,
       pr_url: pr.url ?? null,
+      pr_branch: pr.branch ?? null,
+      pr_number: pr.number ?? null,
+      head_sha: pr.headSha ?? null,
     },
   });
-  await recordStructuredFinal(input, result, finalEvidence, pr.url ?? null);
+  await input.recordEvent({
+    type: 'pr_followup_plan',
+    actor: 'droid',
+    source: 'worker',
+    command: 'Droid PR follow-up',
+    cwd: workspace,
+    message: 'Droid opened a draft PR. If CI fails, rerun Droid on the same task with the PR context to repair the branch.',
+    metadata: {
+      pr_url: pr.url ?? null,
+      pr_branch: pr.branch ?? null,
+      pr_number: pr.number ?? null,
+      head_sha: pr.headSha ?? null,
+      next_action: 'Watch PR checks; if they fail, rerun Droid with this run id and PR URL.',
+    },
+  });
+  await recordStructuredFinal(input, result, finalEvidence, pr.url ?? null, pr.branch ?? null, {
+    nextAction: 'Review the draft PR and let Droid rerun if CI reports failures.',
+  });
   return result;
 }
 
@@ -1398,13 +1440,21 @@ async function recordStructuredFinal(
   result: CommandResult,
   evidence: PrGateEvidence,
   prUrl: string | null,
-  override: { summary?: string; blockers?: string[]; risks?: string[] } = {}
+  prBranch: string | null,
+  override: { summary?: string; blockers?: string[]; risks?: string[]; nextAction?: string } = {}
 ): Promise<void> {
   const summary =
     override.summary ??
     (result.success
       ? `Droid run completed with exit code ${result.exitCode}.`
       : `Droid run failed with exit code ${result.exitCode}.`);
+  const nextAction =
+    override.nextAction ??
+    (prUrl
+      ? 'Review the draft PR and let Droid rerun if CI reports failures.'
+      : result.success
+        ? 'Review the run output.'
+        : 'Inspect the Droid events and rerun after fixing the blocker.');
   await input.recordEvent({
     type: 'final_output',
     actor: 'droid',
@@ -1416,10 +1466,95 @@ async function recordStructuredFinal(
       filesChanged: evidence.filesChanged,
       checksRun: evidence.checkCommands,
       prUrl,
+      prBranch,
+      nextAction,
       blockers: override.blockers,
       risks: override.risks,
     }),
   });
+  await syncTaskFromFinalReport(input, {
+    summary,
+    filesChanged: evidence.filesChanged,
+    checksRun: evidence.checkCommands,
+    prUrl,
+    prBranch,
+    nextAction,
+    success: result.success,
+    exitCode: result.exitCode,
+    blockers: override.blockers ?? [],
+    risks: override.risks ?? [],
+  });
+}
+
+async function syncTaskFromFinalReport(
+  input: Parameters<RunExecutor['execute']>[0],
+  report: {
+    summary: string;
+    filesChanged: string[];
+    checksRun: string[];
+    prUrl: string | null;
+    prBranch: string | null;
+    nextAction: string;
+    success: boolean;
+    exitCode: number;
+    blockers: string[];
+    risks: string[];
+  }
+): Promise<void> {
+  const client = await getTaskCallbackClient(input, 'task_final_callback_skipped');
+  if (!client) return;
+
+  const comment = [
+    report.prUrl ? 'Droid opened a draft PR.' : report.success ? 'Droid finished the run.' : 'Droid finished with a failure.',
+    '',
+    `Summary: ${report.summary}`,
+    report.prUrl ? `PR: ${report.prUrl}` : '',
+    report.prBranch ? `Branch: ${report.prBranch}` : '',
+    report.filesChanged.length ? `Files: ${report.filesChanged.slice(0, 8).join(', ')}${report.filesChanged.length > 8 ? ` +${report.filesChanged.length - 8}` : ''}` : '',
+    report.checksRun.length ? `Checks: ${report.checksRun.join(', ')}` : '',
+    report.risks.length ? `Risks: ${report.risks.join('; ')}` : '',
+    report.blockers.length ? `Blockers: ${report.blockers.join('; ')}` : '',
+    `Exit: ${report.exitCode}`,
+    `Run: ${input.runId}`,
+    `Next: ${report.nextAction}`,
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  try {
+    await postTaskComment(client, comment);
+    if (report.prUrl) {
+      await patchTask(client, {
+        pr_url: report.prUrl,
+        pr_status: 'draft',
+        branch_name: report.prBranch,
+        blocked_on_user: false,
+      });
+    }
+    await input.recordEvent({
+      type: 'task_final_callback_succeeded',
+      actor: 'droid',
+      source: 'saas-maker-api',
+      message: 'Droid posted the final run summary back to the task.',
+      metadata: {
+        task_id: input.taskId ?? null,
+        pr_url: report.prUrl,
+        pr_branch: report.prBranch,
+      },
+    });
+  } catch (error) {
+    await input.recordEvent({
+      type: 'task_final_callback_failed',
+      actor: 'droid',
+      source: 'saas-maker-api',
+      message: error instanceof Error ? error.message : 'Failed to sync final run summary to task.',
+      metadata: {
+        task_id: input.taskId ?? null,
+        pr_url: report.prUrl,
+        pr_branch: report.prBranch,
+      },
+    });
+  }
 }
 
 async function reviewPatchForPr(

--- a/workers/droid/src/pr-gate.ts
+++ b/workers/droid/src/pr-gate.ts
@@ -44,6 +44,8 @@ export function buildFinalReport(input: {
   filesChanged: string[];
   checksRun: string[];
   prUrl?: string | null;
+  prBranch?: string | null;
+  nextAction?: string | null;
   blockers?: string[];
   risks?: string[];
 }) {
@@ -52,6 +54,8 @@ export function buildFinalReport(input: {
     files_changed: input.filesChanged,
     checks_run: input.checksRun,
     pr_url: input.prUrl ?? null,
+    pr_branch: input.prBranch ?? null,
+    next_action: input.nextAction ?? null,
     blockers: input.blockers ?? [],
     risks: input.risks ?? [],
   };

--- a/workers/droid/src/types.ts
+++ b/workers/droid/src/types.ts
@@ -88,6 +88,8 @@ export interface RunStats {
   by_status: Record<RunRecord['status'], number>;
   avg_duration_ms: number | null;
   stale_running: number;
+  idle_running: number;
+  estimated_compute_seconds: number;
   recent: RunRecord[];
 }
 


### PR DESCRIPTION
## Summary
- sync Droid final reports back into task comments and PR fields when a SaaS Maker token is configured
- keep block callbacks concise and let Droid mark tasks blocked with the exact user question
- add stale-run reaping, idle/runtime health stats, and richer final report metadata for PR branch/next action
- improve default Droid prompt ownership and document feedback/reliability behavior

## Tests
- pnpm vitest run tests/droid/runs.test.ts tests/droid/pr-gate.test.ts tests/droid/acceptance.test.ts
- pnpm -F @saas-maker/droid typecheck
- pnpm --filter ./apps/cockpit typecheck
- pnpm test
- pnpm lint
- local browser smoke on http://localhost:3001/tasks