### PR TITLE
Fix task status updates

### DIFF
--- a/tests/api/tasks.test.ts
+++ b/tests/api/tasks.test.ts
@@ -297,6 +297,20 @@ describe('Tasks API', () => {
     }));
   });
 
+  it('PATCH /v1/tasks/:id persists status changes', async () => {
+    const res = await request('/v1/tasks/task-1', {
+      method: 'PATCH',
+      headers: { Authorization: 'Bearer test-session', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'done' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockDb.updateTask).toHaveBeenCalledWith('task-1', 'user-1', expect.objectContaining({
+      status: 'done',
+    }));
+    await expect(res.json()).resolves.toMatchObject({ data: { status: 'done' } });
+  });
+
   it('PATCH /v1/tasks/:id stores task PR lifecycle metadata', async () => {
     const res = await request('/v1/tasks/task-1', {
       method: 'PATCH',

--- a/workers/api/src/routes/tasks.ts
+++ b/workers/api/src/routes/tasks.ts
@@ -63,6 +63,7 @@ function enumValue<T extends string>(value: unknown, allowed: readonly T[]): T |
 
 const PR_STATUSES = ['none', 'draft', 'open', 'merged', 'closed'] as const;
 const DEPLOYMENT_STATUSES = ['none', 'pending', 'success', 'failed'] as const;
+const TASK_STATUSES = ['todo', 'in_progress', 'done'] as const;
 const COMMENT_AUTHOR_TYPES = ['user', 'agent'] as const;
 
 function normalizeBlockedDeployment(input: {
@@ -175,6 +176,7 @@ tasks.patch('/:id', requireSession, async (c) => {
   });
   const updates: Record<string, unknown> = {
     ...rest,
+    status: enumValue(body.status, TASK_STATUSES),
     branch_name: optionalString(body.branch_name),
     pr_url: optionalString(body.pr_url),
     pr_status: enumValue(body.pr_status, PR_STATUSES),


### PR DESCRIPTION
## Summary\n- Persist  in  instead of only logging it\n- Add a regression test covering the persisted response\n\n## Check\n- pnpm vitest run tests/api/tasks.test.ts