### PR TITLE
feat(projects): add git_url + cli auth source label

### DIFF
--- a/apps/cockpit/src/app/cli/auth/cli-auth-approval.tsx
+++ b/apps/cockpit/src/app/cli/auth/cli-auth-approval.tsx
@@ -14,12 +14,25 @@ import { apiFetchClient, getClientToken } from "@/lib/api-client";
 
 interface Props {
   code?: string;
+  source?: string;
   userEmail: string;
 }
 
-export function CliAuthApproval({ code, userEmail }: Props) {
+const SOURCE_LABELS: Record<string, { title: string; description: string }> = {
+  codevetter: {
+    title: "Authorize CodeVetter",
+    description: "CodeVetter Desktop is requesting access to your SaaS Maker account.",
+  },
+};
+
+export function CliAuthApproval({ code, source, userEmail }: Props) {
   const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
   const [error, setError] = useState<string | null>(null);
+  const labels =
+    (source && SOURCE_LABELS[source]) || {
+      title: "Authorize CLI",
+      description: "The SaaS Maker CLI is requesting access to your account.",
+    };
 
   if (!code) {
     return (
@@ -69,10 +82,8 @@ export function CliAuthApproval({ code, userEmail }: Props) {
     <Card className="w-full max-w-sm">
       <CardHeader className="text-center">
         <Terminal className="mx-auto h-10 w-10 text-muted-foreground mb-2" />
-        <CardTitle>Authorize CLI</CardTitle>
-        <CardDescription>
-          The SaaS Maker CLI is requesting access to your account.
-        </CardDescription>
+        <CardTitle>{labels.title}</CardTitle>
+        <CardDescription>{labels.description}</CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
         <div className="rounded-md border px-3 py-2 text-sm">

--- a/apps/cockpit/src/app/cli/auth/page.tsx
+++ b/apps/cockpit/src/app/cli/auth/page.tsx
@@ -6,21 +6,28 @@ import { CliAuthApproval } from "./cli-auth-approval";
 export const dynamic = "force-dynamic";
 
 interface Props {
-  searchParams: Promise<{ code?: string }>;
+  searchParams: Promise<{ code?: string; source?: string }>;
 }
 
 export default async function CliAuthPage({ searchParams }: Props) {
-  const { code } = await searchParams;
+  const { code, source } = await searchParams;
   const requestHeaders = await headers();
   const session = await getDashboardSession(requestHeaders);
   if (!session?.user) {
-    const callbackUrl = code ? `/cli/auth?code=${code}` : "/cli/auth";
+    const params = new URLSearchParams();
+    if (code) params.set("code", code);
+    if (source) params.set("source", source);
+    const callbackUrl = params.toString() ? `/cli/auth?${params.toString()}` : "/cli/auth";
     redirect(`/login?callbackUrl=${encodeURIComponent(callbackUrl)}`);
   }
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-muted/40">
-      <CliAuthApproval code={code} userEmail={session.user.email ?? "Unknown"} />
+      <CliAuthApproval
+        code={code}
+        source={source}
+        userEmail={session.user.email ?? "Unknown"}
+      />
     </div>
   );
 }

--- a/apps/cockpit/src/components/create-project-dialog.tsx
+++ b/apps/cockpit/src/components/create-project-dialog.tsx
@@ -28,6 +28,7 @@ export function CreateProjectDialog() {
   const router = useRouter();
   const [open, setOpen] = useState(false);
   const [name, setName] = useState("");
+  const [gitUrl, setGitUrl] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -40,13 +41,17 @@ export function CreateProjectDialog() {
 
     try {
       const token = await getToken();
+      const trimmedGit = gitUrl.trim();
+      const payload: Record<string, string> = { name: name.trim() };
+      if (trimmedGit) payload.git_url = trimmedGit;
       const project = await apiFetch(
         "/v1/projects",
-        { method: "POST", body: JSON.stringify({ name: name.trim() }) },
+        { method: "POST", body: JSON.stringify(payload) },
         token
       );
       setOpen(false);
       setName("");
+      setGitUrl("");
       // Navigate to the new project or refresh the list
       if (project?.slug) {
         router.push(`/projects/${project.slug}`);
@@ -86,6 +91,20 @@ export function CreateProjectDialog() {
                 onChange={(e) => setName(e.target.value)}
                 required
               />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="project-git-url">
+                Git URL <span className="text-muted-foreground">(optional)</span>
+              </Label>
+              <Input
+                id="project-git-url"
+                placeholder="https://github.com/owner/repo"
+                value={gitUrl}
+                onChange={(e) => setGitUrl(e.target.value)}
+              />
+              <p className="text-xs text-muted-foreground">
+                Fleet clients (e.g. CodeVetter) use this to auto-link local repos to the right project.
+              </p>
             </div>
             {error && (
               <p className="text-sm text-destructive">{error}</p>

--- a/packages/blocks/shared-types/src/index.ts
+++ b/packages/blocks/shared-types/src/index.ts
@@ -26,6 +26,7 @@ export interface ProjectRecord {
   ai_api_key_preview?: string | null;
   readme: string | null;
   source: 'dashboard' | 'linkchat' | string;
+  git_url?: string | null;
   created_at: string;
 }
 
@@ -57,6 +58,7 @@ export interface UpvoteRecord {
 export interface CreateProjectRequest {
   name: string;
   source?: string;
+  git_url?: string;
 }
 
 export interface SubmitFeedbackRequest {

--- a/workers/api/migrations/0018_projects_git_url.sql
+++ b/workers/api/migrations/0018_projects_git_url.sql
@@ -1,0 +1,4 @@
+-- Add git_url to projects so fleet clients (e.g. CodeVetter) can
+-- auto-detect the project a local repo belongs to without a manual mapping.
+-- Nullable; not unique (a monorepo can legitimately back multiple project rows).
+ALTER TABLE projects ADD COLUMN git_url TEXT;

--- a/workers/api/src/db.ts
+++ b/workers/api/src/db.ts
@@ -277,10 +277,11 @@ export function getDb(d1: D1Database): FeedbackDatabase {
     // --- Projects ---
     async createProject(input) {
       const source = input.source || 'dashboard';
+      const gitUrl = input.git_url ?? null;
       await d1.prepare(
-        `INSERT INTO projects (id, name, slug, api_key, owner_id, source)
-         VALUES (?, ?, ?, ?, ?, ?)`
-      ).bind(input.id, input.name, input.slug, input.api_key, input.owner_id, source).run();
+        `INSERT INTO projects (id, name, slug, api_key, owner_id, source, git_url)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`
+      ).bind(input.id, input.name, input.slug, input.api_key, input.owner_id, source, gitUrl).run();
       const row = await d1.prepare(`SELECT * FROM projects WHERE id = ?`).bind(input.id).first();
       return mapRow<ProjectRecord>(row)!;
     },
@@ -315,6 +316,7 @@ export function getDb(d1: D1Database): FeedbackDatabase {
       if (input.name !== undefined) { sets.push('name = ?'); values.push(input.name); }
       if (input.embedding_model !== undefined) { sets.push('embedding_model = ?'); values.push(input.embedding_model); }
       if (input.readme !== undefined) { sets.push('readme = ?'); values.push(input.readme); }
+      if (input.git_url !== undefined) { sets.push('git_url = ?'); values.push(input.git_url); }
 
       if (sets.length > 0) {
         const sql = `UPDATE projects SET ${sets.join(', ')} WHERE id = ?`;

--- a/workers/api/src/routes/projects.ts
+++ b/workers/api/src/routes/projects.ts
@@ -58,13 +58,15 @@ const VALID_SOURCES = ['dashboard', 'linkchat'];
 
 projects.post('/', async (c) => {
   const userId = c.get('userId')!;
-  const body = (await c.req.json()) as { name: string; source?: string };
+  const body = (await c.req.json()) as { name: string; source?: string; git_url?: string };
   if (!body.name?.trim()) return c.json({ error: 'Project name is required' }, 400);
 
   const source = body.source || 'dashboard';
   if (!VALID_SOURCES.includes(source)) {
     return c.json({ error: `Invalid source. Must be one of: ${VALID_SOURCES.join(', ')}` }, 400);
   }
+
+  const gitUrl = body.git_url?.trim() || null;
 
   const db = getDb(c.env.DB);
   const project = await db.createProject({
@@ -74,6 +76,7 @@ projects.post('/', async (c) => {
     api_key: generateApiKey(),
     owner_id: userId,
     source,
+    git_url: gitUrl,
   });
 
   capture({ distinctId: userId, event: 'project_created', properties: { project_id: project.id, project_name: project.name, source } });
@@ -96,6 +99,7 @@ projects.patch('/:id', async (c) => {
   const body = (await c.req.json()) as {
     name?: string;
     readme?: string;
+    git_url?: string | null;
   };
 
   const db = getDb(c.env.DB);
@@ -105,9 +109,13 @@ projects.patch('/:id', async (c) => {
   if (!existing) return c.json({ error: 'Project not found' }, 404);
   if (existing.owner_id !== userId) return c.json({ error: 'Forbidden' }, 403);
 
+  const gitUrl =
+    body.git_url === undefined ? undefined : (body.git_url?.trim?.() || null);
+
   const updated = await db.updateProject(projectId, {
     name: body.name,
     readme: body.readme,
+    git_url: gitUrl,
   });
   capture({ distinctId: userId, event: 'project_updated', properties: { project_id: projectId } });
   return c.json(toPublicProject(updated));

--- a/workers/api/src/schema.ts
+++ b/workers/api/src/schema.ts
@@ -21,6 +21,7 @@ export const projects = sqliteTable('projects', {
   ai_model: text('ai_model'),
   readme: text('readme'),
   source: text('source').notNull().default('dashboard'),
+  git_url: text('git_url'),
   created_at: text('created_at').notNull().default(sql`(datetime('now'))`),
 });
 


### PR DESCRIPTION
## Summary

- Adds nullable `git_url` column to `projects` so fleet clients (CodeVetter, future ones) can auto-link a local repo to the right project without a per-product mapping table.
- Cockpit Create Project dialog gains an optional Git URL field.
- `/cli/auth` accepts `?source=` so CodeVetter's sign-in flow renders "Authorize CodeVetter" instead of generic "Authorize CLI".

## Changes

- `workers/api/migrations/0018_projects_git_url.sql` — `ALTER TABLE projects ADD COLUMN git_url TEXT`
- `workers/api/src/schema.ts` — Drizzle `git_url: text('git_url')`
- `packages/blocks/shared-types/src/index.ts` — `ProjectRecord.git_url?: string | null`, `CreateProjectRequest.git_url?: string`
- `workers/api/src/db.ts` — `createProject` writes git_url; `updateProject` patches it; PATCH treats undefined as no-op, empty string as null
- `workers/api/src/routes/projects.ts` — POST + PATCH accept `git_url`
- `apps/cockpit/src/components/create-project-dialog.tsx` — optional Git URL input
- `apps/cockpit/src/app/cli/auth/page.tsx` + `cli-auth-approval.tsx` — `?source=codevetter` renders "Authorize CodeVetter"

## Migration deployment

**Manual step:** `wrangler d1 migrations apply saasmaker-db --remote` (or `--local` for dev). Migration is a pure additive `ALTER`, no backfill — existing rows surface as `git_url=null`.

## Backward compat

- Old clients that don't send `git_url` continue to work (POST treats it as optional, PATCH treats absent as no-op).
- `GET /v1/projects` adds `git_url` to response payloads; clients that ignore unknown fields are unaffected.
- No public-shape removal.

## Test plan

- [ ] Apply migration to dev D1: `wrangler d1 migrations apply saasmaker-db --local`
- [ ] Create a project in cockpit with a Git URL — verify it round-trips on the projects list
- [ ] Create a project without a Git URL — verify it works as before
- [ ] PATCH `/v1/projects/:id` with `{ "git_url": "https://github.com/..." }` — verify it persists
- [ ] PATCH `/v1/projects/:id` with `{ "git_url": "" }` — verify it clears the field
- [ ] Visit `/cli/auth?code=test&source=codevetter` — verify title reads "Authorize CodeVetter"
- [ ] Visit `/cli/auth?code=test` (no source) — verify title reads "Authorize CLI"
- [ ] CodeVetter desktop: pick a repo whose `git remote get-url origin` matches a project's `git_url` — verify `detect_project_for_repo` returns the match

🤖 Generated with [Claude Code](https://claude.com/claude-code)