### PR TITLE
Fleet hub: events sink + task queue + worker SDK

### DIFF
--- a/apps/docs/public/openapi.json
+++ b/apps/docs/public/openapi.json
@@ -264,6 +264,30 @@
         }
       }
     },
+    "/v1/events": {
+      "get": {
+        "tags": [
+          "events"
+        ],
+        "summary": "GET /v1/events",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "events"
+        ],
+        "summary": "POST /v1/events",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
     "/v1/feedback": {
       "get": {
         "tags": [
@@ -1063,6 +1087,19 @@
         }
       }
     },
+    "/v1/tasks/claim": {
+      "post": {
+        "tags": [
+          "tasks"
+        ],
+        "summary": "POST /v1/tasks/claim",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
     "/v1/tasks/{id}": {
       "get": {
         "tags": [
@@ -1115,6 +1152,45 @@
           "tasks"
         ],
         "summary": "POST /v1/tasks/{id}/comments",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/v1/tasks/{id}/complete": {
+      "post": {
+        "tags": [
+          "tasks"
+        ],
+        "summary": "POST /v1/tasks/{id}/complete",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/v1/tasks/{id}/fail": {
+      "post": {
+        "tags": [
+          "tasks"
+        ],
+        "summary": "POST /v1/tasks/{id}/fail",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/v1/tasks/{id}/heartbeat": {
+      "post": {
+        "tags": [
+          "tasks"
+        ],
+        "summary": "POST /v1/tasks/{id}/heartbeat",
         "responses": {
           "200": {
             "description": "Success"

--- a/apps/docs/src/content/docs/sdk/cli.md
+++ b/apps/docs/src/content/docs/sdk/cli.md
@@ -163,6 +163,40 @@ Default marketing queue ideas to AI-generated reel/video briefs for `tiktok`,
 `instagram_reels`, or `youtube_shorts`. Avoid LinkedIn entirely. Use `x` and
 `reddit` only for non-promotional discussion prompts.
 
+### Fleet events (system-of-record)
+
+Spokes publish results and telemetry up to saas-maker via `/v1/events` — the
+append-only fleet system-of-record. Send one event or a batch (array, max 100);
+`idempotency_key` makes outbox retries safe. Only the hub reads the union.
+
+```bash
+fnd api POST /v1/events --auth session \
+  --body '{"product":"reel-pipeline","type":"reel.rendered","idempotency_key":"<uuid>","payload":{"reel_id":"r1","result_url":"https://..."}}'
+
+fnd api GET /v1/events --auth session --query product=reel-pipeline --output table
+```
+
+### Task queue (workers claim work on wake)
+
+The Symphony task board doubles as a polling work-queue. Producers enqueue tasks
+with a `capability`; workers claim by capability — claims are atomic and leased,
+so two workers never run the same task, and a worker that dies mid-task has its
+lease expire and the work reclaimed.
+
+```bash
+# Enqueue (producer)
+fnd api POST /v1/tasks --auth session --body '{"title":"Audit homepage","capability":"audit","project_slug":"linkchat"}'
+
+# Worker wake-loop: claim → do → report
+fnd api POST /v1/tasks/claim --auth session --body '{"worker":"psi-swarm@laptop","capability":"audit","lease_seconds":900}'  # 204 = empty
+fnd api POST /v1/tasks/<taskId>/complete --auth session --body '{"worker":"psi-swarm@laptop","result":"p75 LCP 1.8s"}'
+fnd api POST /v1/tasks/<taskId>/fail     --auth session --body '{"worker":"psi-swarm@laptop","error":"timeout"}'
+```
+
+The `@saas-maker/sdk` `client.worker.drain({ worker, capability, handler })` wraps
+this loop and degrades gracefully — a missing token or unreachable hub ends the
+drain quietly, so each service still works standalone.
+
 ## Fleet automation
 
 The `fnd fleet` commands operate across a fleet of repositories on disk (default: `~/Desktop/Fleet`). They are designed for the maintainer working many repos in parallel — most product users won't need them.

--- a/apps/showcase/src/pages/factory.astro
+++ b/apps/showcase/src/pages/factory.astro
@@ -13,9 +13,12 @@ const stations = [
   { id: 'reel-pipeline', role: 'Distribution',         flow: 'consume',   tag: 'renders & ships',     cap: 'render', auth: true,  note: 'worker + report' },
   { id: 'psi-swarm',     role: 'Perf Sensor',          flow: 'telemetry', tag: 'audit.completed',     cap: '—',      auth: true,  note: 'push-up' },
   { id: 'drank',         role: 'Rank Sensor',          flow: 'telemetry', tag: 'dr.snapshot',         cap: '—',      auth: true,  note: 'push-up' },
+  { id: 'starboard',       role: 'GitHub Insight',      flow: 'insight',   tag: 'reads fleet → better GitHub', cap: '—', auth: true, note: 'open' },
+  { id: 'everythingrated', role: 'GitHub Insight',      flow: 'insight',   tag: 'fleet-aware, closed',  cap: '—',      auth: true,  note: 'closed-source' },
   { id: 'free-ai',       role: 'AI Utility · Power',   flow: 'utility',   tag: 'inference grid',      cap: '—',      auth: true,  note: 'read-only' },
 ];
-const flowLabel = { produce: 'PRODUCE', consume: 'CONSUME', telemetry: 'TELEMETRY', utility: 'UTILITY' };
+const flowLabel = { produce: 'PRODUCE', consume: 'CONSUME', telemetry: 'TELEMETRY', utility: 'UTILITY', insight: 'INSIGHT' };
+const chipText = (s) => s.cap !== '—' ? `cap: ${s.cap}` : ({ telemetry: 'telemetry', insight: 'reads hub', utility: 'inference' }[s.flow] || s.flow);
 ---
 
 <Layout title="The Fleet Factory — saas-maker" description="A futuristic assembly line: every product a station, saas-maker the control tower and system-of-record. Pull task-queue + event telemetry on the Cloudflare edge.">
@@ -30,8 +33,8 @@ const flowLabel = { produce: 'PRODUCE', consume: 'CONSUME', telemetry: 'TELEMETR
         the system-of-record and the task queue. Work flows as <em>pull-claimed</em> jobs; results flow back as
         <em>telemetry</em>. Built on the Cloudflare edge.</p>
       <div class="stat-strip">
-        <div><b>8</b><span>stations linked</span></div>
-        <div><b>8/8</b><span>auth online</span></div>
+        <div><b>10</b><span>stations linked</span></div>
+        <div><b>10/10</b><span>auth online</span></div>
         <div><b>11/11</b><span>e2e transfers ✓</span></div>
         <div><b>D1</b><span>queue + ledger</span></div>
       </div>
@@ -71,7 +74,7 @@ const flowLabel = { produce: 'PRODUCE', consume: 'CONSUME', telemetry: 'TELEMETR
             <p class="st-role">{s.role}</p>
             <p class="st-tag">{s.tag}</p>
             <div class="st-foot">
-              <span class="chip">{s.cap !== '—' ? `cap: ${s.cap}` : 'telemetry'}</span>
+              <span class="chip">{chipText(s)}</span>
               <span class="chip ghost">{s.note}</span>
             </div>
             <div class="st-wire" aria-hidden="true"></div>
@@ -85,6 +88,7 @@ const flowLabel = { produce: 'PRODUCE', consume: 'CONSUME', telemetry: 'TELEMETR
       <div class="lg produce"><span></span>PRODUCE — enqueue work (capability-tagged) → the queue</div>
       <div class="lg consume"><span></span>CONSUME — a worker claims, does it, reports back (atomic lease)</div>
       <div class="lg telemetry"><span></span>TELEMETRY — push-up results to the ledger; hub never reads back</div>
+      <div class="lg insight"><span></span>INSIGHT — reads fleet data (read-down) to sharpen your GitHub presence</div>
       <div class="lg utility"><span></span>UTILITY — free-ai inference grid, drawn on by any station</div>
     </section>
 
@@ -167,14 +171,17 @@ const flowLabel = { produce: 'PRODUCE', consume: 'CONSUME', telemetry: 'TELEMETR
     /* flow accents */
     .flow-produce { border-top: 2px solid #34d399; } .flow-consume { border-top: 2px solid #fcd34d; }
     .flow-telemetry { border-top: 2px solid #67e8f9; } .flow-utility { border-top: 2px solid #e879f9; }
+    .flow-insight { border-top: 2px solid #818cf8; }
     .flow-produce .st-flow { color: #34d399; } .flow-consume .st-flow { color: #fcd34d; }
     .flow-telemetry .st-flow { color: #67e8f9; } .flow-utility .st-flow { color: #e879f9; }
+    .flow-insight .st-flow { color: #818cf8; }
 
     .legend { display: grid; gap: .55rem; max-width: 1040px; margin: 2.6rem auto 0; }
     .lg { display: flex; align-items: center; gap: .7rem; font: 600 .82rem/1.4 ui-monospace, monospace; color: #9fb6d2; }
     .lg span { width: 12px; height: 12px; border-radius: 3px; flex: none; }
     .lg.produce span { background: #34d399; } .lg.consume span { background: #fcd34d; }
     .lg.telemetry span { background: #67e8f9; } .lg.utility span { background: #e879f9; }
+    .lg.insight span { background: #818cf8; }
 
     .fab-foot { max-width: 720px; margin: 3.4rem auto 0; text-align: center; }
     .fab-foot p { color: #7da0c4; line-height: 1.6; } .fab-foot em { color: #5eead4; font-style: normal; }

--- a/apps/showcase/src/pages/factory.astro
+++ b/apps/showcase/src/pages/factory.astro
@@ -1,0 +1,187 @@
+---
+import Layout from '../layouts/Layout.astro';
+
+// The Fleet Factory — a futuristic assembly line where every product is a
+// station on the line and saas-maker is the control tower / system-of-record.
+// Data mirrors the real architecture (docs/plans/2026-06-19-fleet-*).
+
+const stations = [
+  { id: 'high-signal',   role: 'R&D · Discovery',      flow: 'produce',   tag: 'enqueues ideas',      cap: 'ideas',  auth: true,  note: 'cron → tasks' },
+  { id: 'pinpoint',      role: 'Intake · Feedback',    flow: 'produce',   tag: 'UI comment → task',   cap: 'review', auth: true,  note: 'wired' },
+  { id: 'CodeVetter',    role: 'Build · Review · Test',flow: 'consume',   tag: 'claims & works',      cap: 'review', auth: true,  note: 'desktop worker' },
+  { id: 'taste',         role: 'Quality Gate',         flow: 'consume',   tag: 'judges the output',   cap: 'judge',  auth: true,  note: 'hosted worker' },
+  { id: 'reel-pipeline', role: 'Distribution',         flow: 'consume',   tag: 'renders & ships',     cap: 'render', auth: true,  note: 'worker + report' },
+  { id: 'psi-swarm',     role: 'Perf Sensor',          flow: 'telemetry', tag: 'audit.completed',     cap: '—',      auth: true,  note: 'push-up' },
+  { id: 'drank',         role: 'Rank Sensor',          flow: 'telemetry', tag: 'dr.snapshot',         cap: '—',      auth: true,  note: 'push-up' },
+  { id: 'free-ai',       role: 'AI Utility · Power',   flow: 'utility',   tag: 'inference grid',      cap: '—',      auth: true,  note: 'read-only' },
+];
+const flowLabel = { produce: 'PRODUCE', consume: 'CONSUME', telemetry: 'TELEMETRY', utility: 'UTILITY' };
+---
+
+<Layout title="The Fleet Factory — saas-maker" description="A futuristic assembly line: every product a station, saas-maker the control tower and system-of-record. Pull task-queue + event telemetry on the Cloudflare edge.">
+  <main class="factory">
+    <div class="grid-floor" aria-hidden="true"></div>
+    <div class="scanline" aria-hidden="true"></div>
+
+    <header class="fab-hero">
+      <p class="kicker"><span class="led"></span> FOUNDRY · ASSEMBLY LINE ONLINE</p>
+      <h1>The Fleet Factory</h1>
+      <p class="sub">Every product is a station on one line. <strong>saas-maker</strong> is the control tower —
+        the system-of-record and the task queue. Work flows as <em>pull-claimed</em> jobs; results flow back as
+        <em>telemetry</em>. Built on the Cloudflare edge.</p>
+      <div class="stat-strip">
+        <div><b>8</b><span>stations linked</span></div>
+        <div><b>8/8</b><span>auth online</span></div>
+        <div><b>11/11</b><span>e2e transfers ✓</span></div>
+        <div><b>D1</b><span>queue + ledger</span></div>
+      </div>
+    </header>
+
+    <!-- The line -->
+    <section class="floor" aria-label="Assembly line">
+      <!-- Control tower -->
+      <div class="tower">
+        <div class="tower-core">
+          <span class="tower-tag">CONTROL TOWER</span>
+          <span class="tower-name">saas-maker</span>
+          <span class="tower-sub">system-of-record · task queue (D1)</span>
+          <div class="tower-rails">
+            <span class="rail rail-tasks">/v1/tasks · claim · lease</span>
+            <span class="rail rail-events">/v1/events · append-only</span>
+          </div>
+        </div>
+        <div class="tower-glow" aria-hidden="true"></div>
+      </div>
+
+      <!-- Conveyor -->
+      <div class="conveyor" aria-hidden="true">
+        <div class="belt"></div>
+        <span class="pulse p1"></span><span class="pulse p2"></span><span class="pulse p3"></span><span class="pulse p4"></span>
+      </div>
+
+      <!-- Stations -->
+      <div class="stations">
+        {stations.map((s, i) => (
+          <article class={`station flow-${s.flow}`} style={`--i:${i}`}>
+            <div class="st-head">
+              <span class={`st-led ${s.auth ? 'on' : ''}`} title="auth online"></span>
+              <span class="st-flow">{flowLabel[s.flow]}</span>
+            </div>
+            <h3 class="st-name">{s.id}</h3>
+            <p class="st-role">{s.role}</p>
+            <p class="st-tag">{s.tag}</p>
+            <div class="st-foot">
+              <span class="chip">{s.cap !== '—' ? `cap: ${s.cap}` : 'telemetry'}</span>
+              <span class="chip ghost">{s.note}</span>
+            </div>
+            <div class="st-wire" aria-hidden="true"></div>
+          </article>
+        ))}
+      </div>
+    </section>
+
+    <!-- Legend -->
+    <section class="legend">
+      <div class="lg produce"><span></span>PRODUCE — enqueue work (capability-tagged) → the queue</div>
+      <div class="lg consume"><span></span>CONSUME — a worker claims, does it, reports back (atomic lease)</div>
+      <div class="lg telemetry"><span></span>TELEMETRY — push-up results to the ledger; hub never reads back</div>
+      <div class="lg utility"><span></span>UTILITY — free-ai inference grid, drawn on by any station</div>
+    </section>
+
+    <footer class="fab-foot">
+      <p>Pull task-queue · event ledger · graceful-degrading workers — each station runs standalone and
+        <em>just works</em> the moment it connects. Cloudflare D1 + Workers + Cron, $5 tier.</p>
+      <a class="back" href="/">← back to the fleet</a>
+    </footer>
+  </main>
+
+  <style>
+    .factory { position: relative; min-height: 100vh; overflow: hidden; padding: 0 6vw 6rem;
+      background: radial-gradient(120% 80% at 50% -10%, #0b1426 0%, #05070d 55%, #03040a 100%); color: #dbeafe; }
+    .grid-floor { position: absolute; inset: 0; pointer-events: none; opacity: .35;
+      background-image: linear-gradient(#1e3a5f33 1px, transparent 1px), linear-gradient(90deg, #1e3a5f33 1px, transparent 1px);
+      background-size: 44px 44px; mask-image: radial-gradient(80% 60% at 50% 30%, #000 30%, transparent 85%); }
+    .scanline { position: absolute; inset: 0; pointer-events: none; mix-blend-mode: screen; opacity: .12;
+      background: linear-gradient(transparent 0, #22d3ee 50%, transparent 100%); height: 180px; animation: scan 7s linear infinite; }
+    @keyframes scan { 0% { transform: translateY(-200px); } 100% { transform: translateY(110vh); } }
+
+    .fab-hero { position: relative; text-align: center; padding: 7rem 0 3rem; }
+    .kicker { display: inline-flex; align-items: center; gap: .5rem; font: 600 .72rem/1 ui-monospace, monospace;
+      letter-spacing: .28em; color: #67e8f9; text-transform: uppercase; }
+    .led { width: 8px; height: 8px; border-radius: 50%; background: #34d399; box-shadow: 0 0 10px #34d399; animation: blink 1.6s ease-in-out infinite; }
+    @keyframes blink { 50% { opacity: .35; } }
+    .fab-hero h1 { font: 800 clamp(2.6rem, 7vw, 5.2rem)/1 'Inter', system-ui, sans-serif; margin: .6rem 0;
+      background: linear-gradient(180deg, #fff, #7dd3fc 70%, #38bdf8); -webkit-background-clip: text; background-clip: text; color: transparent;
+      text-shadow: 0 0 60px #0ea5e955; }
+    .sub { max-width: 60ch; margin: 0 auto; color: #93b4d8; line-height: 1.6; font-size: 1.02rem; }
+    .sub strong { color: #e0f2fe; } .sub em { color: #67e8f9; font-style: normal; }
+    .stat-strip { display: flex; flex-wrap: wrap; gap: 1.2rem; justify-content: center; margin-top: 2.2rem; }
+    .stat-strip div { display: grid; gap: .15rem; padding: .7rem 1.3rem; border: 1px solid #1e3a5f; border-radius: 12px;
+      background: #0a132473; backdrop-filter: blur(6px); }
+    .stat-strip b { font: 800 1.5rem/1 'Inter', sans-serif; color: #5eead4; }
+    .stat-strip span { font: 600 .62rem/1 ui-monospace, monospace; letter-spacing: .14em; color: #6b88aa; text-transform: uppercase; }
+
+    .floor { position: relative; max-width: 1200px; margin: 3rem auto 0; }
+    .tower { position: relative; display: flex; justify-content: center; margin-bottom: 2.4rem; }
+    .tower-core { position: relative; z-index: 2; display: grid; justify-items: center; gap: .35rem; text-align: center;
+      padding: 1.6rem 2.4rem; border-radius: 18px; border: 1px solid #34d39955;
+      background: linear-gradient(180deg, #0c1c2e, #0a1420); box-shadow: 0 0 0 1px #0ea5e933, 0 24px 60px #00111e88; }
+    .tower-tag { font: 700 .62rem/1 ui-monospace, monospace; letter-spacing: .28em; color: #34d399; }
+    .tower-name { font: 800 1.9rem/1 'Inter', sans-serif; color: #fff; }
+    .tower-sub { font: 500 .82rem/1 ui-monospace, monospace; color: #7da7cf; }
+    .tower-rails { display: flex; gap: .5rem; margin-top: .6rem; flex-wrap: wrap; justify-content: center; }
+    .rail { font: 600 .66rem/1 ui-monospace, monospace; padding: .4rem .6rem; border-radius: 7px; }
+    .rail-tasks { color: #fcd34d; background: #3b2f0a; border: 1px solid #facc1540; }
+    .rail-events { color: #67e8f9; background: #06283a; border: 1px solid #22d3ee40; }
+    .tower-glow { position: absolute; inset: -40px; background: radial-gradient(closest-side, #0ea5e944, transparent); filter: blur(20px); animation: breathe 4s ease-in-out infinite; }
+    @keyframes breathe { 50% { opacity: .55; transform: scale(1.06); } }
+
+    .conveyor { position: relative; height: 26px; border-radius: 8px; margin: 0 auto 1.8rem; max-width: 1040px; overflow: hidden;
+      border: 1px solid #1b3552; background: #060d18; }
+    .belt { position: absolute; inset: 0; background: repeating-linear-gradient(90deg, #0e2236 0 18px, #08131f 18px 36px); animation: roll 1.1s linear infinite; }
+    @keyframes roll { to { background-position: 36px 0; } }
+    .pulse { position: absolute; top: 50%; width: 9px; height: 9px; margin-top: -4.5px; border-radius: 50%; background: #5eead4;
+      box-shadow: 0 0 12px #5eead4; animation: travel 3.4s linear infinite; }
+    .p1 { animation-delay: 0s; } .p2 { animation-delay: .9s; background:#fcd34d; box-shadow:0 0 12px #fcd34d;}
+    .p3 { animation-delay: 1.8s; background:#e879f9; box-shadow:0 0 12px #e879f9;} .p4 { animation-delay: 2.6s; }
+    @keyframes travel { from { left: -2%; } to { left: 102%; } }
+
+    .stations { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1rem; }
+    .station { position: relative; padding: 1.1rem 1.1rem 1.2rem; border-radius: 14px; border: 1px solid #173050;
+      background: linear-gradient(180deg, #0a1626f2, #081019f2); backdrop-filter: blur(8px);
+      animation: rise .6s cubic-bezier(.2,.7,.2,1) backwards; animation-delay: calc(var(--i) * 70ms); transition: transform .2s, box-shadow .2s, border-color .2s; }
+    .station:hover { transform: translateY(-4px); border-color: #2dd4bf66; box-shadow: 0 18px 40px #00131f88; }
+    @keyframes rise { from { opacity: 0; transform: translateY(16px); } }
+    .st-head { display: flex; align-items: center; justify-content: space-between; }
+    .st-led { width: 9px; height: 9px; border-radius: 50%; background: #334155; }
+    .st-led.on { background: #34d399; box-shadow: 0 0 9px #34d399; }
+    .st-flow { font: 700 .58rem/1 ui-monospace, monospace; letter-spacing: .18em; color: #6b88aa; }
+    .st-name { font: 800 1.12rem/1 'Inter', sans-serif; margin: .55rem 0 .1rem; color: #f1f5f9; }
+    .st-role { font: 600 .74rem/1.2 ui-monospace, monospace; color: #7dd3fc; margin: 0 0 .5rem; }
+    .st-tag { font-size: .82rem; color: #8fa9c6; margin: 0 0 .8rem; min-height: 2.2em; }
+    .st-foot { display: flex; flex-wrap: wrap; gap: .35rem; }
+    .chip { font: 600 .62rem/1 ui-monospace, monospace; padding: .32rem .5rem; border-radius: 6px; color: #c7d2fe; background: #141d33; border: 1px solid #25324f; }
+    .chip.ghost { color: #6b88aa; background: transparent; }
+    .st-wire { position: absolute; left: 50%; top: -1.8rem; width: 2px; height: 1.8rem; transform: translateX(-50%);
+      background: linear-gradient(#5eead4, transparent); opacity: .5; }
+    /* flow accents */
+    .flow-produce { border-top: 2px solid #34d399; } .flow-consume { border-top: 2px solid #fcd34d; }
+    .flow-telemetry { border-top: 2px solid #67e8f9; } .flow-utility { border-top: 2px solid #e879f9; }
+    .flow-produce .st-flow { color: #34d399; } .flow-consume .st-flow { color: #fcd34d; }
+    .flow-telemetry .st-flow { color: #67e8f9; } .flow-utility .st-flow { color: #e879f9; }
+
+    .legend { display: grid; gap: .55rem; max-width: 1040px; margin: 2.6rem auto 0; }
+    .lg { display: flex; align-items: center; gap: .7rem; font: 600 .82rem/1.4 ui-monospace, monospace; color: #9fb6d2; }
+    .lg span { width: 12px; height: 12px; border-radius: 3px; flex: none; }
+    .lg.produce span { background: #34d399; } .lg.consume span { background: #fcd34d; }
+    .lg.telemetry span { background: #67e8f9; } .lg.utility span { background: #e879f9; }
+
+    .fab-foot { max-width: 720px; margin: 3.4rem auto 0; text-align: center; }
+    .fab-foot p { color: #7da0c4; line-height: 1.6; } .fab-foot em { color: #5eead4; font-style: normal; }
+    .back { display: inline-block; margin-top: 1.2rem; color: #67e8f9; text-decoration: none; font: 600 .9rem ui-monospace, monospace; }
+    .back:hover { text-decoration: underline; }
+
+    @media (max-width: 820px) { .stations { grid-template-columns: repeat(2, 1fr); } }
+    @media (prefers-reduced-motion: reduce) { .scanline, .belt, .pulse, .tower-glow, .led { animation: none; } }
+  </style>
+</Layout>

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -264,6 +264,30 @@
         }
       }
     },
+    "/v1/events": {
+      "get": {
+        "tags": [
+          "events"
+        ],
+        "summary": "GET /v1/events",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "events"
+        ],
+        "summary": "POST /v1/events",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
     "/v1/feedback": {
       "get": {
         "tags": [
@@ -1063,6 +1087,19 @@
         }
       }
     },
+    "/v1/tasks/claim": {
+      "post": {
+        "tags": [
+          "tasks"
+        ],
+        "summary": "POST /v1/tasks/claim",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
     "/v1/tasks/{id}": {
       "get": {
         "tags": [
@@ -1115,6 +1152,45 @@
           "tasks"
         ],
         "summary": "POST /v1/tasks/{id}/comments",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/v1/tasks/{id}/complete": {
+      "post": {
+        "tags": [
+          "tasks"
+        ],
+        "summary": "POST /v1/tasks/{id}/complete",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/v1/tasks/{id}/fail": {
+      "post": {
+        "tags": [
+          "tasks"
+        ],
+        "summary": "POST /v1/tasks/{id}/fail",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/v1/tasks/{id}/heartbeat": {
+      "post": {
+        "tags": [
+          "tasks"
+        ],
+        "summary": "POST /v1/tasks/{id}/heartbeat",
         "responses": {
           "200": {
             "description": "Success"

--- a/docs/plans/2026-06-19-fleet-events-hub-spec.md
+++ b/docs/plans/2026-06-19-fleet-events-hub-spec.md
@@ -1,0 +1,189 @@
+# Build Spec: Fleet Events Hub (system-of-record)
+
+**Date:** 2026-06-19
+**Status:** Spec / ready to build
+**Companion to:** [2026-06-19-fleet-hub-and-spoke-eval.md](./2026-06-19-fleet-hub-and-spoke-eval.md) — read that for *why*. This is the *how*.
+
+**Scope:** this spec is the **return path** — the append-only sink where results, fire-and-forget callbacks, and telemetry land, and which Cockpit reads. It is **one half** of the hub. The **outbound** half — saas-maker *calling* drank/psi-swarm/taste, *dispatching* to reel-pipeline, *pulling* high-signal — follows the typed interaction styles in the eval doc's §3 and is sketched in §8 below. The events sink is **not** how the hub invokes a capability; it's where capability *results* come to rest.
+
+The discipline still holds: saas-maker is the append-only **system-of-record**; spokes **read down** the registry; **no spoke reads another spoke**; single-writer per store; spokes that report up do so via a local **outbox** so they never block on the hub.
+
+## 1. The write surface — `POST /v1/events`
+
+### 1a. D1 table (new migration, next number in `workers/api/migrations/`)
+
+```sql
+CREATE TABLE fleet_events (
+  id              TEXT PRIMARY KEY,
+  project_id      TEXT NOT NULL REFERENCES projects(id),
+  product         TEXT NOT NULL,                 -- slug, denormalized for fast filter
+  type            TEXT NOT NULL,                 -- e.g. 'reel.rendered', 'audit.completed'
+  payload         TEXT NOT NULL,                 -- opaque JSON envelope
+  schema_version  INTEGER NOT NULL DEFAULT 1,
+  occurred_at     TEXT NOT NULL,                 -- client event time
+  received_at     TEXT NOT NULL DEFAULT (datetime('now')),
+  idempotency_key TEXT NOT NULL,
+  UNIQUE(project_id, idempotency_key)            -- makes outbox retries safe
+);
+CREATE INDEX idx_fleet_events_product_type ON fleet_events(product, type, received_at);
+```
+
+Mirror this in `workers/api/src/schema.ts` (same style as the `projects` table; `UNIQUE(project_id, idempotency_key)` mirrors the existing `UNIQUE(owner_id, slug)` on `fleet_metadata`).
+
+### 1b. Route — `workers/api/src/routes/events.ts`
+
+Mirror `routes/marketing.ts` (sub-app) and `routes/fleet-metadata.ts` (registration). Auth via the existing `requireApiKey` middleware — `X-Project-Key` header, read `c.get('projectId')`.
+
+```typescript
+const events = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+
+// WRITE — project-scoped, append-only, idempotent. Accepts one or a batch.
+events.post('/', requireApiKey, async (c) => {
+  const projectId = c.get('projectId')!;
+  const body = await c.req.json();
+  const items = Array.isArray(body) ? body : [body];
+  // validate envelope: { type, payload, idempotency_key, occurred_at }
+  // INSERT ... ON CONFLICT(project_id, idempotency_key) DO NOTHING   ← retry-safe
+  return c.json({ accepted, deduped });
+});
+
+// READ — for Cockpit/analytics only. Session/admin auth, never a spoke.
+events.get('/', requireSession, async (c) => {
+  // filters: ?product= &type= &since= &limit=  (use idx_fleet_events_product_type)
+});
+```
+
+Register in `workers/api/src/index.ts` (~line 152, beside the other `app.route(...)` calls):
+
+```typescript
+app.route('/v1/events', events);
+```
+
+**Why this is enough on the server:** the idempotent `ON CONFLICT DO NOTHING` insert means a spoke can retry the same event forever with no duplicates — so the API stays a dumb, durable sink and **all retry/buffering lives at the edge** (the outbox). No Queues/Cron/DO needed on the API for Phase 0 (none exist today, per wrangler.toml).
+
+## 2. The outbox — what buys async / no-SPOF
+
+Add an `events` service to the SDK (`packages/blocks/sdk/src/`; there is no separate analytics-sdk — this is new). Public API:
+
+```typescript
+client.events.emit({ type, payload, idempotencyKey?, occurredAt? })
+// generates idempotencyKey (uuid) + occurredAt if omitted,
+// appends to a local buffer, flushes with retry+backoff, never blocks the caller
+```
+
+The **buffer backing differs by host** — same SDK surface, different durability substrate:
+
+| Spoke | Outbox backing | Flush trigger |
+| :--- | :--- | :--- |
+| high-signal, taste, reel-pipeline (CF Workers) | row in their **own D1** `outbox` table | `ctx.waitUntil(flush())` after request; drain on next request |
+| drank (Vercel / browser) | **no per-user upload.** The existing GitHub Action that publishes the global DR snapshot also POSTs that snapshot | on each scheduled refresh |
+| CodeVetter (desktop, local SQLite) | local `outbox` table | flush opportunistically when online (emits review telemetry) |
+| psi-swarm (CLI, local SQLite) | local `outbox` table | POST after a run; drain stale rows on next invocation |
+
+Local-first is preserved everywhere: the product writes its own store, returns to the user, and the outbox flushes upward best-effort. If saas-maker is down, nothing blocks; rows drain later.
+
+## 3. The read-down surface (already exists)
+
+Spokes that need central truth read it through the existing read-only contracts — **no new work, no raw-table access**:
+
+- `GET /v1/fleet/metadata` — project registry
+- `GET /v1/standards/:type` — shared config/standards
+- `GET /v1/secrets` — scoped secrets
+
+Consume via the SDK (`SaaSMakerClient`). These are the "other services can read this project's data" half — keep them read-only.
+
+## 4. Cockpit — make the data visible
+
+A "Fleet Activity" view in `apps/cockpit` reads `GET /v1/events` and renders a cross-product timeline + per-product rollups. This is what realizes the central-data/analytics goal the user actually asked for — the moment one screen shows every product's events, the hub exists.
+
+## 5. Per-service onboarding (maps to the eval's verdict table)
+
+1. **reel-pipeline** — on render complete, `events.emit({ type: 'reel.rendered', payload })`. Already pushes up via marketing-queue PATCH; this adds it to the system-of-record. *(Phase 1 proof.)*
+2. **high-signal** — emit `signal.published` / `brief.composed`. Already a `@saas-maker/*` consumer, so the SDK is in place. *(Phase 1 proof.)*
+3. **taste** — emit `study.completed` / `arena.vote` from Pages Functions.
+4. **psi-swarm** — emit `audit.completed` with p75/p99 after a run.
+5. **CodeVetter** — emit `review.completed` telemetry (it already has Roadmap/telemetry).
+6. **drank** — GitHub Action emits `dr.snapshot`; replaces the drank→high-signal GitHub-JSON hop later.
+
+## 6. Phasing
+
+- **Phase 0:** migration + `routes/events.ts` + SDK `events.emit` + Cockpit Fleet Activity skeleton.
+- **Phase 1:** wire reel-pipeline + high-signal (the two live flows) → prove end-to-end.
+- **Phase 2:** onboard taste, psi-swarm, CodeVetter.
+- **Phase 3:** drank snapshot up; collapse the GitHub-JSON hop.
+- **Later (only if needed):** add CF Queues to the API for server-side buffering of any *pull-ETL* (saas-maker calling a spoke's API on a schedule); shared SSO/billing.
+
+## 7. Open code-level decisions
+
+- **idempotency_key source** — client-supplied uuid (simple, chosen) vs semantic hash of payload. Start with client uuid.
+- **payload validation** — keep the envelope strict (`type`, `idempotency_key`, `occurred_at`) and the `payload` opaque JSON, so the table schema never couples to product internals.
+- **retention** — events are append-only; add a rollup/prune job once volume warrants (D1 is fine at fleet scale for now).
+- **batch size cap** on `POST /v1/events` to bound a single request.
+
+## 8. The outbound half — saas-maker calls/dispatches/pulls
+
+The sink above is where results land; this is how the hub *invokes* capabilities. saas-maker needs a small **capability layer**: a registry of each spoke's endpoint + a typed client per interaction style. By style (from the eval §3 table):
+
+- **Publish-up only — drank, psi-swarm (local-only tools).** These run standalone and **push their learning up**; saas-maker never reads or calls them. No outbound capability layer, no hosted endpoint, no reachability problem — they reuse the events sink in §1. psi-swarm emits `audit.completed` after each local run (Node CLI holds an `sm_` token, local SQLite outbox for retry); drank's existing GitHub Action also POSTs `dr.snapshot` (per-user browser data stays local; only the aggregate goes up).
+- **Fire-and-forget — reel-pipeline.** Already built: saas-maker enqueues in the marketing queue, reel-pipeline pulls + renders + PATCHes the result back. Fold that result into `/v1/events` so it also lands in the system-of-record.
+- **Job + result — taste, CodeVetter.** saas-maker creates a job, the spoke runs it, the result returns. taste is hub-callable (create study → poll/callback for verdict). **CodeVetter is a desktop runner that reuses the existing Symphony `tasks` API — no new jobs table.** It mirrors the *Symphony CLI* runner loop (not Droid, which is push-based):
+  1. Auth once via CLI device flow (`POST /v1/cli-auth/code` → approve → poll for an `sm_*` token); use `Authorization: Bearer sm_*` thereafter.
+  2. `GET /v1/tasks?status=todo` to read work.
+  3. Claim, run build/review/test locally.
+  4. Report via `POST /v1/tasks/:id/comments` (`author_type:'agent'`, body = findings) + `PATCH /v1/tasks/:id` status → `done` (same as the CLI's `claim`/`done`). Optionally also `events.emit('review.completed', …)` so the outcome lands in the system-of-record.
+
+  **Two server deltas this requires** (both small, both real):
+  - **Atomic claim** — the task queue has no lock today (PATCH is unconditional). Harmless with one runner; with CodeVetter as a *second* concurrent runner, two can grab the same `todo`. Fix: conditional `UPDATE tasks SET status='in_progress' WHERE id=? AND status='todo'`, check rows-affected.
+  - **Runner routing** — `task_type` is `feature|bug|chore|docs|research|cleanup|other` (no review/build/test), there's no `assignee`/`runner` field, and `GET /v1/tasks` has no `?type=` filter. Add a runner-facing type (e.g. `review`) or a `runner` tag + filter so CodeVetter selects only its tasks.
+
+  **Separation of surfaces:** the *task* is the workflow state (read/do/update); an *event* is the analytics result (optional emit). Same action, two records, each with its own job.
+- **Task producer — pinpoint.** Local-only (CLI / daemon / Vite plugin / browser extension); already posts UI-feedback comments as tasks (`POST /v1/tasks`, Bearer `sm_`/session token). The hub never reads it. It *seeds* the same board CodeVetter *drains* — producer → hub task board → consumer, neither talking to the other. Two notes: (1) to be fully hub-centric, consumers should read from `/v1/tasks`, not pinpoint's local `.pinpoint/inbox.jsonl`; (2) pinpoint emits `task_type:'chore'` today, so it needs the runner/type tag (above) to route to the right consumer. Whoever runs the task updates its status — the hub never pulls pinpoint's local `history.jsonl`.
+- **Pull / ingest — high-signal.** A scheduled job calls high-signal's API (`/brief/daily`, `/api/mentions`, AI-awareness checks) and writes the results into the system-of-record. The API worker has **no Cron Triggers today** — run the scheduler as a GitHub Action cron, or add `[triggers] crons` to `workers/api/wrangler.toml`.
+
+So the full hub is **three surfaces**: this events sink (results in), a capability/jobs layer (work out), and the existing read-down registry (config down). Phase 0–1 only needs the sink + the two already-live flows; the capability layer grows one spoke at a time.
+
+## 9. Worker protocol & queue primitive (the core pattern)
+
+The fleet runs as a **polling work-queue on the existing Symphony `tasks` table**: every spoke is a worker that, on wake (local run / background daemon / cron), claims pending tasks it can handle, executes, and writes results back. The DB is the only coordinator. This is the single most-reused mechanism — build it once, well.
+
+**Schema deltas to `tasks`** (one migration; generalizes the CodeVetter notes in §8):
+- `runner` / `capability` tag (e.g. `review`, `audit`, `judge`, `ideas`) + a `?runner=`/`?capability=` filter on `GET /v1/tasks` — so a worker claims only its kind.
+- `claimed_by TEXT`, `lease_until TEXT` — claim ownership + visibility timeout.
+- status lifecycle: `pending → claimed → done | failed` (today's `todo/in_progress/done` maps; add `failed`).
+- a result home: reuse `task_comments` (`author_type:'agent'`) + final status, or add a `result` column.
+
+**Atomic claim** (the correctness core — concurrent wakes race):
+```sql
+UPDATE tasks SET status='claimed', claimed_by=?, lease_until=datetime('now','+15 minutes')
+WHERE id=? AND (status='pending' OR (status='claimed' AND lease_until < datetime('now')))
+RETURNING *;
+```
+Zero rows back = someone else won; the worker moves on. The `lease_until < now` clause **reclaims tasks abandoned by a worker that died mid-run** — without it the queue silently leaks work. A claim endpoint like `POST /v1/tasks/claim?capability=review` runs this and returns the claimed task (or 204).
+
+**Worker SDK / wake protocol** — the ~50-line client every spoke embeds (the only bespoke part is `handler`):
+```
+loop on wake:
+  task = POST /v1/tasks/claim?capability=<mine>     # atomic claim
+  if !task: break
+  try { result = await handler(task); report(task, 'done', result) }
+  catch (e) { report(task, 'failed', e) }            # PATCH status + comment
+  # long handlers periodically extend the lease (heartbeat)
+```
+Handlers must be **idempotent** — a task can run twice across a lease expiry.
+
+**Implemented (2026-06-19):** migration `0020_task_queue.sql` + `POST /v1/tasks/{claim,:id/complete,:id/fail,:id/heartbeat}` + `capability` on create. The wake-loop is `client.worker.drain({ worker, capability, handler })` in `@saas-maker/sdk` — and it's **graceful by design**: a missing token or unreachable hub ends the drain quietly (`hubUnavailable: true`), never throwing, so a service runs standalone and auto-drains the moment it can reach the hub (the "open services → they just work / unplug hub → still work alone" tenet). Atomic claim is a single race-safe UPDATE that also reclaims expired leases, so no reaper cron is required for correctness (a reaper is optional, only for dead-letter sweeps/metrics).
+
+**Recurring work** — a cron (GitHub Action or CF Cron Trigger; the API has none today) enqueues periodic tasks (`capability:'ideas'` daily), so when high-signal wakes it finds work waiting. Producers like pinpoint enqueue on user action.
+
+This section, not the events sink, is the heart of the architecture: **events = unsolicited telemetry pushed; tasks = assigned work pulled.** Most spokes are workers; drank-style pure telemetry stays on the events sink (§1).
+
+### 9a. Cloudflare building blocks (on the $5 Workers Paid plan)
+
+Limits verified 2026-06-19 for **Workers Paid ($5/mo)** — the plan in use:
+- **D1** (25B row-reads/mo, 50M writes/mo, 5GB) — the queue + system-of-record. Effectively unlimited at fleet scale (~9,600 reads/sec sustained) → **poll as often as you want; ignore read budget.**
+- **Workers** (10M req/mo, **CPU 30s default / up to 5min configurable**) — hosts the claim/report API + always-on workers. The free-tier 10ms cap is gone, so hosted Workers can do real compute, not just DB ops.
+- **Cron Triggers** (250/account on Paid — account-level, not per-Worker; free is 5) — three jobs: (1) enqueue recurring tasks, (2) **lease-reaper** requeuing expired-`lease_until` tasks (makes intermittent workers reliable — a slept-laptop's claim returns to the pool), (3) always-on poller (a cron-triggered Worker is an always-on drainer). Realistic need is ~5–15 against the 250 ceiling.
+
+"Pick up tasks as soon as they start" = startup-poll: a worker calls `claim` on boot and loops until empty — no special primitive, just the API + D1.
+
+**Strategic consequence of Paid:** any spoke whose job fits ≤5min CPU with no special runtime can become an *always-on cron-polled Worker* (taste agent-eval, high-signal, orchestration, the reaper) — shrinking the intermittent set to only those needing a local/desktop runtime: psi-swarm (headless Chrome → Browser Rendering to host), CodeVetter (desktop), pinpoint (local dev). Workers still have no persistent FS + a wall-clock/subrequest ceiling, so Lighthouse/repo-builds stay local or use Containers/Browser Rendering. Still **not** Queues (consumers are push-targets; offline workers can't be pushed to). DO+Alarms (SQLite or KV-backed on Paid) only for sub-minute reactivity; Workflows for the v2 orchestration DAG.

--- a/docs/plans/2026-06-19-fleet-hub-and-spoke-eval.md
+++ b/docs/plans/2026-06-19-fleet-hub-and-spoke-eval.md
@@ -1,0 +1,144 @@
+# Evaluation: saas-maker as the Fleet Hub ("everything goes through saas-maker")
+
+**Date:** 2026-06-19
+**Status:** Recommendation
+**Driver (confirmed):** Central data / analytics — saas-maker as the **system-of-record** for all products' events, results, and metrics.
+**Note:** "codewitter" is read as **CodeVetter** (Tauri desktop code-review app; today metadata-linked only).
+
+## TL;DR
+
+**Qualified yes.** The instinct is good, but there are two very different ways to build it, and only one is right for a solo fleet:
+
+- ❌ **Synchronous gateway / ESB** — spoke → saas-maker → spoke on the live request path. Single point of failure, a latency hop on every call, deploy coupling, and it *destroys* the local-first property of drank / psi-swarm / CodeVetter. Don't build this.
+- ✅ **Asynchronous publish-up hub** — spokes **push** events/data/results *up* to saas-maker; saas-maker is the system-of-record and distribution layer; spokes never call each other. This honors the exact goal ("services won't communicate with each other") **and** matches your confirmed driver (central data). It's already how `reel-pipeline ⇄ marketing-queue` works.
+
+So: keep the words, change the mechanism. Hub for **integration events and data**, not for **all runtime traffic**.
+
+## 1. Reality check on the premise
+
+The premise slightly overstates today's coupling. Across 6 services there are **three** real cross-service flows:
+
+| Flow | Mechanism today | Type |
+| :--- | :--- | :--- |
+| reel-pipeline ⇄ saas-maker marketing queue | HTTP `GET/PATCH /v1/marketing/posts` + bearer token | async pull/patch |
+| high-signal → reel-pipeline (reel briefs) | `POST /reels/signal` JSON | async push |
+| drank → high-signal (DR leaderboard) | public GitHub JSON sync | async batch |
+
+Everything else (taste, psi-swarm, CodeVetter) is an **island**. The O(N²) point-to-point mess that justifies a runtime hub **does not exist yet** — so the value here is *not* "less integration upkeep." The value is the confirmed driver: **one place that knows everything** (events, results, metrics). That goal is real and worth building toward, incrementally.
+
+Note also: high-signal already consumes `@saas-maker/*` npm packages (ai, ops, db, analytics-sdk, feedback). That is **build-time centralization** — the *good* kind of "going through saas-maker," with zero runtime coupling. It's the model to expand, not replace.
+
+## 2. The recommended shape: publish-up event hub
+
+Add one durable surface to the saas-maker API and have every product report into it.
+
+```
+spoke products ──(publish events/results, async)──▶  saas-maker
+                                                       ├─ events table (system of record)
+                                                       ├─ analytics-sdk (already exists)
+                                                       └─ cockpit dashboards / digests
+```
+
+- **New:** `POST /v1/events` (or extend `analytics-sdk`) — a generic, append-only event/result sink. `{ product, type, payload, ts }`. This becomes the single fleet data lake.
+- **Reuse:** `@saas-maker/analytics-sdk` already exists — likely 80% of the transport. Standardize the schema and point every product at it.
+- **Keep:** marketing queue and signal-brief flows as-is; they're proof the broker pattern works. Optionally re-route the high-signal→reel-pipeline brief *through* a saas-maker queue later so it too lands in the system of record.
+- **Never:** put a spoke's own internal traffic (a psi-swarm audit run, a CodeVetter review loop) on the saas-maker live path. They run locally; they **report results up** when done.
+
+## 2.1. Who owns what (ownership boundary)
+
+The central question isn't "shared DB or API" — it's **who owns which data and who may write it**. The rule:
+
+- **saas-maker owns the *shared/central* data** — project registry, config/standards, and the cross-product system-of-record. Spokes **read this down** via a read-only contract (`/v1/fleet/metadata`, `/v1/standards`, `/v1/secrets` already do this). ✅ Good centralization.
+- **Each spoke owns its *operational* data.** saas-maker does **not** reach into a spoke's raw tables.
+- **Exchange via contracts, not raw tables.** When saas-maker needs a spoke's data it **pulls through that spoke's API** (e.g. taste's `/api/studies`), not its DB. When a spoke contributes data it **pushes up**. Either direction is fine; the invariant is **single-writer per store, no shared raw tables**.
+
+Why not let saas-maker pull/write every spoke's DB directly? Two reasons:
+
+**Physics — most of the fleet has no centrally-reachable store:**
+
+| Spoke | Store | saas-maker can pull/write it? |
+| :--- | :--- | :--- |
+| drank | localStorage (no server DB) | ❌ nothing to reach |
+| psi-swarm | local SQLite `~/.psi-swarm` | ❌ on user's machine |
+| CodeVetter | local SQLite (desktop Tauri) | ❌ on user's machine |
+| reel-pipeline | no DB (state in saas-maker / local JSON) | ⚠️ nothing of its own |
+| taste | CF D1 `shiprank-db` | ⚠️ only via binding/HTTP |
+| high-signal | CF D1 | ⚠️ only via binding/HTTP |
+
+For **4 of 6**, "saas-maker writes data into the service" is impossible by design — so it can't be the foundation.
+
+**Coupling — even where possible, raw cross-DB access couples the hub to every spoke's physical schema** (every spoke migration can break the hub) and creates **dual-writers** (spoke + saas-maker writing the same tables → races, no single owner of invariants). That's the integration-DB anti-pattern with the blast radius moved to the hub.
+
+## 2.2. Sync vs async: the outbox is the real decision
+
+"Everything through a shared store" quietly re-introduces synchronous coupling unless guarded. Two senses of "sync":
+
+- **Sync state** (one consistent store, readers see writers) — fine.
+- **Sync coupling** (A can't proceed unless the hub is up) — the SPOF property we want to avoid.
+
+A naive shared DB gives the second one: a spoke writing *directly* to the central store now hard-depends on it at write time (kills local-first), and a shared DB *invites* spoke B to read spoke A's rows for live behavior (spoke-to-spoke coupling laundered through a table). 
+
+The property that buys true async is a **local outbox**: the spoke appends to its own buffer and flushes up with retry, never blocking on the hub — works whether the destination is a DB or a thin API. For the central-data goal you only ever need **write-up + hub-reads**; no spoke reads another spoke. So treat the shared store as an implementation detail *behind* the write path, never as the surface spokes integrate against.
+
+## 3. Per-service verdict: typed capabilities (the spine)
+
+These are six *different products with different purposes*, so each gets a *different interaction style* — **not** a uniform "publish up." saas-maker is the **orchestrator**; each spoke is a typed capability.
+
+| Service | Purpose | Style | Direction | Notes |
+| :--- | :--- | :--- | :--- | :--- |
+| **drank** | domain-rating snapshots | **publish-up only** | spoke → hub (hub never reads it) | pushes via its existing GitHub Action |
+| **psi-swarm** | perf-audit results (p50–p99) | **publish-up only** | spoke → hub (hub never reads it) | pushes after each local run |
+| **reel-pipeline** | render + distribute reels | **fire-and-forget** | hub → spoke (result drifts back) | already wired (marketing queue) |
+| **pinpoint** | UI feedback → tasks | **task producer (push-up)** | spoke → hub (hub never reads it) | local-only; already posts `/v1/tasks` |
+| **CodeVetter** | build / review / test | **task runner (consumer)** | spoke **pulls** tasks, pushes results | desktop; pulls, so no inbound reach needed |
+| **taste** | judge end-product quality | **job + verdict** | hub → spoke, returns verdict | hosted (CF Pages + agents) |
+| **high-signal** | ideas / mentions / does-AI-know-us | **pull / ingest** | hub ← spoke | hosted API; needs a scheduler |
+
+**Task-board pairing.** pinpoint *produces* tasks (UI feedback → `/v1/tasks`) and CodeVetter *consumes* them (build/review/test → status update). They never talk to each other — the Symphony task board is their only meeting point, which is exactly the hub-as-system-of-record pattern. This makes the **runner-routing field load-bearing**: with both producers and consumers on one board, tasks need a type/runner tag so the right consumer picks up the right work (see spec §8).
+
+**Unifying architecture: a polling task-queue where the DB is the coordinator.** The model generalizes — every spoke is a **worker** that, on wake (local run, background daemon, or schedule), claims the pending tasks it can handle, executes, and writes results back to saas-maker's DB. No spoke calls another; no hub reaches into a machine; workers *pull*. The per-style taxonomy above collapses into **two roles on one queue**: *producers* enqueue work (pinpoint, crons), *workers* drain it (CodeVetter, psi-swarm, taste, high-signal). Some are both. The one surviving distinction: **queue = assigned work pulled; events sink = unsolicited telemetry pushed** (drank's DR snapshot is nobody's task → event).
+
+DB-as-queue (D1 + tasks table) is the right choice for intermittent, heterogeneous, low-volume workers — *not* Redis/SQS/CF Queues. But three things become correctness-critical: **(1) atomic claim** (conditional `UPDATE … WHERE status='pending'`, check rows-affected — concurrent wakes race), **(2) lease / visibility timeout** (a worker dies mid-task → stuck `claimed` forever unless `lease_until` makes it reclaimable — the most-overlooked part), **(3) task typing/routing** so the right worker claims the right work. Plus idempotent handlers and recurring-task generation (crons enqueue). Highest-leverage build: a shared **worker SDK** (`claimNext(capabilities) → run → report`) embedded by every service; the only bespoke part per spoke is the handler. See spec §9.
+
+**Alternatives considered (why DB-as-queue).** The deciding constraint is that workers are *intermittent and not inbound-reachable*, which forces *pull* and rules out every push design. A **broker** (CF Queues / SQS / Redis+BullMQ) gives lease/retry/DLQ free, but offline workers can't be push-consumers (they'd poll it anyway), so it only adds a second source of truth + infra to buy machinery we can hand-roll in ~a day on the table we already own. **Durable Objects** = a fancier endpoint workers still poll. **Event-sourcing/Kafka** = overkill, still needs a claim mechanism on top. **Webhooks/push** = needs inbound reachability we don't have. **Git-as-queue** = fine for one-way data sync (drank), bad for concurrent claim/status. Two places something else *does* win: don't force telemetry into the queue (that's the events sink, §1); and multi-step orchestration (the v2 idea→build→review→judge→distribute DAG) wants a **durable workflow engine (CF Workflows / Inngest) layered on top** of the queue, never hand-rolled on it. Simple ordering meanwhile fits a `depends_on` check on the existing `tasks.dependencies` field. Net: queue now, workflow engine later, broker never.
+
+**v1 scope (now): everything is push-up or pull-task; local-only is fine.** A lot of these stay local-only for now, so v1 is the queue + workers polling on wake, plus the events sink for non-task telemetry. saas-maker is a **system-of-record + work queue**, not yet a *driving* orchestrator. Tradeoff to accept knowingly: an observe-only, pull-only hub's data is only as fresh as each spoke's last wake — so don't build anything that *depends* on a spoke's data being current until that spoke runs as a hosted/background worker. All of it is forward-compatible: hosting a worker later (so it polls continuously) is additive, no rework.
+
+This does **not** reverse §2.2's SPOF warning: there the risk was a *local-first product depending on the hub*; here, push-up is fire-and-forget through an outbox, so spokes still work standalone.
+
+**Design tenet: the hub is optional.** Every service must (a) work fully standalone with no saas-maker, and (b) "just work" — auto-drain its queue, publish its results — the moment it's started with a token and can reach the hub. The hub is never a hard dependency. Operationally this means: a service only engages the hub when a token is configured, and the worker loop swallows hub/network errors (the SDK's `client.worker.drain()` ends quietly with `hubUnavailable: true` rather than throwing). Open services → connect → they all just work; unplug the hub → each keeps working alone.
+
+**Reachability invariant (the simplification).** The local-only tools — **psi-swarm** (localhost CLI), **drank** (browser/Vercel), and **pinpoint** (CLI/daemon/extension) — are **push-only: they emit up (events or tasks), and saas-maker never reads or calls them.** This dissolves the old "a cloud Worker can't reach into your laptop" problem — there's nothing to reach into; work flows outward. (Explicitly rejected: having the hub pull pinpoint's local `history.jsonl` off the machine — that would violate this invariant. Instead, whoever *runs* a pinpoint-seeded task updates its status in the hub.) **CodeVetter** is also local (desktop) but *pulls* tasks, so it too needs no inbound reachability. Net: **nothing requires the hub to reach into a local machine.** The hub only ever *calls* hosted spokes (taste, reel-pipeline dispatch, high-signal pull); every local/desktop spoke either pushes up or pulls down. psi-swarm and drank reuse the Phase 0 events sink as-is; pinpoint already posts to the task board — no new infra for any of the three.
+
+## 4. Why this is a good idea (in this form)
+
+- **Honors the goal literally:** spokes stop talking to each other; saas-maker becomes the one that knows everything.
+- **No SPOF for the products:** publishing is fire-and-forget/async; if saas-maker is down, the product still works and buffers/retries. A sync gateway would take every product down with it.
+- **Matches the confirmed driver:** a single events table *is* the central-data/analytics outcome you asked for.
+- **Cheap:** mostly reuses `analytics-sdk` + one endpoint. No service mesh, no queues-everywhere, no per-product rewrite.
+- **Incremental & reversible:** each product opts in independently; nothing forces a big-bang migration.
+
+## 5. Why the literal "all communication through saas-maker" would be a bad idea
+
+- **Distributed monolith:** routing live traffic through one service couples every product's deploys to the hub's. A solo dev pays org-scale ESB overhead with no org-scale governance need.
+- **Kills local-first:** drank (browser), psi-swarm (local CLI), CodeVetter (offline Tauri) derive their main value from needing *nothing else*. A runtime hub makes them require a network round-trip and an uptime dependency.
+- **Latency + failure surface** on every call, for integrations that are inherently batch/async anyway.
+- **Solves a problem you don't have:** the integration count is 3, not 30. Hub-for-maintenance is premature.
+
+## 6. Phased plan
+
+1. **Phase 0 — Schema (small):** define the fleet event contract `{ product, type, payload, ts, idempotency_key }`; add `POST /v1/events` + an `events` D1 table; confirm `analytics-sdk` can carry it.
+2. **Phase 1 — Prove with the two live flows:** route reel-pipeline render results and high-signal brief emissions into `/v1/events`. Surface them in a Cockpit "Fleet Activity" view. (Validates the system-of-record claim end-to-end.)
+3. **Phase 2 — Onboard reporters:** taste (study/arena results), psi-swarm (audit percentiles), CodeVetter (review telemetry) publish up. Each is a few lines via the SDK.
+4. **Phase 3 — Collapse the odd hop:** replace drank→high-signal GitHub-JSON sync with publish-up so drank's snapshot lives in saas-maker too. Optionally re-home the high-signal→reel-pipeline brief through a saas-maker queue.
+5. **Phase 4 (only if a real need appears):** shared identity/SSO and a unified paywall — defer until a product actually needs cross-product accounts. Not required for the data goal.
+
+**Explicitly out of scope:** a synchronous request gateway, Durable-Object service mesh, or routing any product's internal traffic through saas-maker.
+
+**Concrete build spec:** see [2026-06-19-fleet-events-hub-spec.md](./2026-06-19-fleet-events-hub-spec.md) for the D1 table, `POST /v1/events` route, the outbox, and per-service onboarding steps.
+
+## 7. Open questions
+
+- Event schema granularity — one generic `events` sink vs. a few typed streams (marketing / signals / audits / reviews)? Start generic, split if query patterns demand.
+- Does the `events` store need to be queryable analytics (ClickHouse-ish) or is D1 + periodic rollups enough? D1 is almost certainly enough at fleet scale.
+- Backpressure / retry on the publish path so a hub outage never blocks a product.

--- a/packages/blocks/sdk/src/client.ts
+++ b/packages/blocks/sdk/src/client.ts
@@ -7,6 +7,8 @@ import { AIService } from './services/ai';
 import { RoadmapService } from './services/roadmap';
 import { ProjectService } from './services/projects';
 import { KnowledgeService } from './services/knowledge';
+import { EventsService } from './services/events';
+import { WorkerService } from './services/worker';
 
 export interface SaaSMakerConfig {
   apiKey?: string;
@@ -23,6 +25,8 @@ export class SaaSMakerClient {
   readonly roadmap: RoadmapService;
   readonly projects: ProjectService;
   readonly knowledge: KnowledgeService;
+  readonly events: EventsService;
+  readonly worker: WorkerService;
 
   constructor(config: SaaSMakerConfig) {
     if (!config.apiKey && !config.sessionToken) {
@@ -43,5 +47,7 @@ export class SaaSMakerClient {
     this.roadmap = new RoadmapService(http);
     this.projects = new ProjectService(http);
     this.knowledge = new KnowledgeService(http);
+    this.events = new EventsService(http);
+    this.worker = new WorkerService(http);
   }
 }

--- a/packages/blocks/sdk/src/index.ts
+++ b/packages/blocks/sdk/src/index.ts
@@ -17,3 +17,5 @@ export type {
 export type { RoadmapItem, RoadmapListResponse } from './services/roadmap';
 export type { ProjectReadmeResponse } from './services/projects';
 export type { KnowledgeService } from './services/knowledge';
+export type { FleetEventInput, EmitResponse } from './services/events';
+export type { FleetTask, DrainOptions, DrainResult } from './services/worker';

--- a/packages/blocks/sdk/src/services/events.ts
+++ b/packages/blocks/sdk/src/services/events.ts
@@ -1,0 +1,74 @@
+import { HttpClient } from '../http';
+
+// ---- Types ----
+
+export interface FleetEventInput {
+  /** Which spoke emitted this, e.g. 'reel-pipeline'. */
+  product: string;
+  /** Event type, e.g. 'reel.rendered', 'audit.completed'. */
+  type: string;
+  /** Opaque JSON payload — never coupled to the server table shape. */
+  payload?: Record<string, unknown>;
+  /** Optional fleet-project linkage. */
+  projectSlug?: string;
+  /** Dedupe key for safe outbox retries. Auto-generated if omitted. */
+  idempotencyKey?: string;
+  /** Client event time (ISO). Defaults to now. */
+  occurredAt?: string;
+}
+
+export interface EmitResponse {
+  accepted: number;
+  deduped: number;
+  received: number;
+}
+
+interface WireEvent {
+  product: string;
+  type: string;
+  payload: Record<string, unknown>;
+  project_slug?: string;
+  schema_version: number;
+  idempotency_key: string;
+  occurred_at: string;
+}
+
+function toWire(input: FleetEventInput): WireEvent {
+  return {
+    product: input.product,
+    type: input.type,
+    payload: input.payload ?? {},
+    project_slug: input.projectSlug,
+    schema_version: 1,
+    idempotency_key: input.idempotencyKey ?? crypto.randomUUID(),
+    occurred_at: input.occurredAt ?? new Date().toISOString(),
+  };
+}
+
+// ---- Service ----
+
+/**
+ * Publish-up events to the fleet system-of-record (POST /v1/events).
+ *
+ * This is the transport primitive. A *durable* outbox (local buffer + retry so
+ * the caller never blocks on the hub) is host-specific — back it with the
+ * spoke's own store (D1 row / local SQLite / a scheduled job) and call emit()
+ * on flush. The client-supplied idempotency key makes retries safe.
+ */
+export class EventsService {
+  constructor(private http: HttpClient) {}
+
+  /** Emit a single event. Uses the session/Bearer token. */
+  emit(event: FleetEventInput): Promise<EmitResponse> {
+    return this.http.request<EmitResponse>('POST', '/v1/events', toWire(event), {
+      auth: 'session',
+    });
+  }
+
+  /** Emit a batch of events in one request (max 100). */
+  emitBatch(events: FleetEventInput[]): Promise<EmitResponse> {
+    return this.http.request<EmitResponse>('POST', '/v1/events', events.map(toWire), {
+      auth: 'session',
+    });
+  }
+}

--- a/packages/blocks/sdk/src/services/worker.ts
+++ b/packages/blocks/sdk/src/services/worker.ts
@@ -1,0 +1,116 @@
+import { HttpClient } from '../http';
+
+// ---- Types ----
+
+export interface FleetTask {
+  id: string;
+  title: string;
+  description: string | null;
+  capability: string | null;
+  project_slug: string | null;
+  status: string;
+  priority: string;
+  task_type: string;
+  attempts: number;
+  [key: string]: unknown;
+}
+
+export interface DrainOptions {
+  /** Worker identity, e.g. 'psi-swarm@laptop'. Owns the lease. */
+  worker: string;
+  /** Only claim tasks of this capability (omit to claim any). */
+  capability?: string;
+  /** Lease seconds per task (30–3600, default 900). */
+  leaseSeconds?: number;
+  /** Stop after this many tasks (default: drain until empty). */
+  maxTasks?: number;
+  /** Does the work. Return a string to attach as the result comment. Throw to fail the task. */
+  handler: (task: FleetTask) => Promise<string | void> | string | void;
+}
+
+export interface DrainResult {
+  completed: number;
+  failed: number;
+  /** True if the loop stopped because the hub was unreachable (not because the queue was empty). */
+  hubUnavailable: boolean;
+}
+
+// ---- Service ----
+
+/**
+ * Fleet worker client — the wake-loop every spoke embeds. On wake, `drain()`
+ * claims pending tasks for a capability, runs the handler, and reports back.
+ *
+ * Designed to be OPTIONAL: a service constructs this only when a saas-maker token
+ * is configured, and `drain()` never throws on hub/network errors — it just stops
+ * and reports `hubUnavailable`. So a service works standalone, and "just works"
+ * (drains the queue) the moment it can reach the hub. The hub is never a hard
+ * dependency.
+ */
+export class WorkerService {
+  constructor(private http: HttpClient) {}
+
+  /** Atomically claim the next runnable task, or null if the queue is empty. */
+  async claim(opts: { worker: string; capability?: string; leaseSeconds?: number }): Promise<FleetTask | null> {
+    const res = await this.http.requestRaw(
+      'POST',
+      '/v1/tasks/claim',
+      { worker: opts.worker, capability: opts.capability, lease_seconds: opts.leaseSeconds },
+      { auth: 'session' },
+    );
+    if (res.status === 204) return null;
+    return ((await res.json()) as { data: FleetTask }).data;
+  }
+
+  /** Extend the lease on an in-flight task (call periodically from long handlers). */
+  heartbeat(id: string, worker: string, leaseSeconds?: number): Promise<{ ok: true }> {
+    return this.http.request('POST', `/v1/tasks/${encodeURIComponent(id)}/heartbeat`, { worker, lease_seconds: leaseSeconds }, { auth: 'session' });
+  }
+
+  /** Mark a claimed task done; optional `result` is stored as an agent comment. */
+  complete(id: string, worker: string, result?: string): Promise<{ data: FleetTask }> {
+    return this.http.request('POST', `/v1/tasks/${encodeURIComponent(id)}/complete`, { worker, result }, { auth: 'session' });
+  }
+
+  /** Report failure; the hub requeues (under max_attempts) or dead-letters. */
+  fail(id: string, worker: string, error?: string, maxAttempts?: number): Promise<{ data: FleetTask; outcome: { dead_letter: boolean; requeued: boolean; attempts: number } }> {
+    return this.http.request('POST', `/v1/tasks/${encodeURIComponent(id)}/fail`, { worker, error, max_attempts: maxAttempts }, { auth: 'session' });
+  }
+
+  /**
+   * The wake-loop: claim → handle → complete/fail, until the queue is empty,
+   * `maxTasks` is reached, or the hub becomes unreachable. Never throws — a hub
+   * outage simply ends the drain with `hubUnavailable: true`, so the calling
+   * service keeps running standalone.
+   */
+  async drain(opts: DrainOptions): Promise<DrainResult> {
+    const max = opts.maxTasks ?? Number.POSITIVE_INFINITY;
+    let completed = 0;
+    let failed = 0;
+
+    while (completed + failed < max) {
+      let task: FleetTask | null;
+      try {
+        task = await this.claim({ worker: opts.worker, capability: opts.capability, leaseSeconds: opts.leaseSeconds });
+      } catch {
+        return { completed, failed, hubUnavailable: true }; // hub down → stop quietly, service lives on
+      }
+      if (!task) break; // queue empty
+
+      try {
+        const result = await opts.handler(task);
+        await this.complete(task.id, opts.worker, typeof result === 'string' ? result : undefined);
+        completed++;
+      } catch (err) {
+        failed++;
+        try {
+          await this.fail(task.id, opts.worker, err instanceof Error ? err.message : String(err));
+        } catch {
+          // lease already lost/reclaimed, or hub down — leave it for the next wake/reaper
+        }
+      }
+    }
+
+    return { completed, failed, hubUnavailable: false };
+  }
+}

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -117,6 +117,22 @@ fnd api PATCH /v1/marketing/posts/<postId> --auth session \
 # Marketing tasks should default to AI-generated reel/video briefs for TikTok,
 # Instagram Reels, or YouTube Shorts. Avoid LinkedIn entirely.
 
+# Fleet events: spokes publish results/telemetry up to the system-of-record.
+# One event or a batch (array, max 100). idempotency_key dedupes retries.
+fnd api POST /v1/events --auth session \
+  --body '{"product":"reel-pipeline","type":"reel.rendered","idempotency_key":"<uuid>","payload":{"reel_id":"r1","result_url":"https://..."}}'
+fnd api GET /v1/events --auth session --query product=reel-pipeline --output table
+
+# Task queue: a worker claims pending work on wake, does it, reports back.
+# Producers enqueue with a capability; workers claim by capability (atomic + leased).
+fnd api POST /v1/tasks --auth session \
+  --body '{"title":"Review PR #12","capability":"review","project_slug":"linkchat"}'
+fnd api POST /v1/tasks/claim --auth session \
+  --body '{"worker":"codevetter@laptop","capability":"review","lease_seconds":900}'   # 204 if queue empty
+fnd api POST /v1/tasks/<taskId>/heartbeat --auth session --body '{"worker":"codevetter@laptop"}'  # extend lease
+fnd api POST /v1/tasks/<taskId>/complete  --auth session --body '{"worker":"codevetter@laptop","result":"LGTM"}'
+fnd api POST /v1/tasks/<taskId>/fail      --auth session --body '{"worker":"codevetter@laptop","error":"build failed"}'  # requeues or dead-letters
+
 # Project-auth route: list feedback
 fnd api GET /v1/feedback --auth project --query type=feature --output table
 

--- a/packages/cli/src/openapi.json
+++ b/packages/cli/src/openapi.json
@@ -264,6 +264,30 @@
         }
       }
     },
+    "/v1/events": {
+      "get": {
+        "tags": [
+          "events"
+        ],
+        "summary": "GET /v1/events",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "events"
+        ],
+        "summary": "POST /v1/events",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
     "/v1/feedback": {
       "get": {
         "tags": [
@@ -1063,6 +1087,19 @@
         }
       }
     },
+    "/v1/tasks/claim": {
+      "post": {
+        "tags": [
+          "tasks"
+        ],
+        "summary": "POST /v1/tasks/claim",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
     "/v1/tasks/{id}": {
       "get": {
         "tags": [
@@ -1115,6 +1152,45 @@
           "tasks"
         ],
         "summary": "POST /v1/tasks/{id}/comments",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/v1/tasks/{id}/complete": {
+      "post": {
+        "tags": [
+          "tasks"
+        ],
+        "summary": "POST /v1/tasks/{id}/complete",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/v1/tasks/{id}/fail": {
+      "post": {
+        "tags": [
+          "tasks"
+        ],
+        "summary": "POST /v1/tasks/{id}/fail",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/v1/tasks/{id}/heartbeat": {
+      "post": {
+        "tags": [
+          "tasks"
+        ],
+        "summary": "POST /v1/tasks/{id}/heartbeat",
         "responses": {
           "200": {
             "description": "Success"

--- a/scripts/e2e-fleet-local.mjs
+++ b/scripts/e2e-fleet-local.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * End-to-end fleet harness against a LOCAL worker + real local D1.
+ * Proves auth + every transfer (events, task claim/complete/fail) for real —
+ * exactly the behaviors unit tests (mocked DB) can't cover.
+ *
+ * Setup (no prod, no deploy):
+ *   cd workers/api
+ *   npx wrangler d1 migrations apply saasmaker-db --local
+ *   npx wrangler dev --port 8787 --var LOCAL_AUTH_BYPASS:true --var CORS_ORIGIN:"*" --var APP_BASE_URL:"http://localhost:3000"
+ *   node ../../scripts/e2e-fleet-local.mjs
+ */
+const BASE = process.env.BASE || "http://localhost:8787";
+const TOKEN = process.env.TOKEN || "local-dev-session"; // LOCAL_AUTH_BYPASS default
+const H = { "Content-Type": "application/json", Authorization: `Bearer ${TOKEN}` };
+
+let pass = 0, fail = 0;
+function check(name, cond, detail = "") {
+  if (cond) { pass++; console.log(`  ✓ ${name}`); }
+  else { fail++; console.log(`  ✗ ${name}  ${detail}`); }
+}
+async function api(method, path, body) {
+  const res = await fetch(`${BASE}${path}`, { method, headers: H, body: body ? JSON.stringify(body) : undefined });
+  const text = await res.text();
+  let json; try { json = JSON.parse(text); } catch { json = text; }
+  return { status: res.status, json };
+}
+
+console.log("\n=== 1. AUTH ===");
+const me = await api("GET", "/v1/projects");
+check("GET /v1/projects authenticates (local bypass token)", me.status === 200, `status ${me.status}`);
+
+console.log("\n=== 2. EVENTS (push + real idempotent dedup) ===");
+const idem = `e2e-${Date.now()}`;
+const ev1 = await api("POST", "/v1/events", { product: "psi-swarm", type: "audit.completed", idempotency_key: idem, payload: { p75: 1800 } });
+check("emit event → accepted=1", ev1.status === 201 && ev1.json.accepted === 1, JSON.stringify(ev1.json));
+const ev2 = await api("POST", "/v1/events", { product: "psi-swarm", type: "audit.completed", idempotency_key: idem, payload: { p75: 1800 } });
+check("re-emit same idempotency_key → deduped=1 (real D1 ON CONFLICT)", ev2.status === 201 && ev2.json.deduped === 1, JSON.stringify(ev2.json));
+const evList = await api("GET", "/v1/events?product=psi-swarm&type=audit.completed");
+check("event readable back via GET", evList.status === 200 && evList.json.data.some((e) => e.idempotency_key === idem));
+
+console.log("\n=== 3. TASK QUEUE (produce → claim → complete) ===");
+const created = await api("POST", "/v1/tasks", { title: "Audit homepage", capability: "audit", project_slug: "linkchat" });
+check("produce task with capability", created.status === 201 && created.json.data.capability === "audit", JSON.stringify(created.json).slice(0, 160));
+const taskId = created.json?.data?.id;
+const claim1 = await api("POST", "/v1/tasks/claim", { worker: "psi-swarm@e2e", capability: "audit" });
+check("worker claims it (status→in_progress, leased)", claim1.status === 200 && claim1.json.data.id === taskId && claim1.json.data.status === "in_progress", JSON.stringify(claim1.json).slice(0, 160));
+const claim2 = await api("POST", "/v1/tasks/claim", { worker: "other@e2e", capability: "audit" });
+check("second claim → 204 (no longer pending — atomic)", claim2.status === 204, `status ${claim2.status}`);
+const done = await api("POST", `/v1/tasks/${taskId}/complete`, { worker: "psi-swarm@e2e", result: "p75 LCP 1.8s" });
+check("complete by lease holder → status done", done.status === 200 && done.json.data.status === "done", JSON.stringify(done.json).slice(0, 160));
+const wrongComplete = await api("POST", `/v1/tasks/${taskId}/complete`, { worker: "imposter@e2e" });
+check("complete by non-holder → 409", wrongComplete.status === 409, `status ${wrongComplete.status}`);
+
+console.log("\n=== 4. FAIL → REQUEUE → reclaim ===");
+const t2 = await api("POST", "/v1/tasks", { title: "Flaky audit", capability: "audit" });
+const t2id = t2.json.data.id;
+await api("POST", "/v1/tasks/claim", { worker: "w@e2e", capability: "audit" });
+const failed = await api("POST", `/v1/tasks/${t2id}/fail`, { worker: "w@e2e", error: "timeout", max_attempts: 5 });
+check("fail under max_attempts → requeued", failed.status === 200 && failed.json.outcome.requeued === true, JSON.stringify(failed.json).slice(0, 160));
+const reclaim = await api("POST", "/v1/tasks/claim", { worker: "w2@e2e", capability: "audit" });
+check("requeued task is reclaimable by another worker", reclaim.status === 200 && reclaim.json.data.id === t2id, JSON.stringify(reclaim.json).slice(0, 120));
+
+console.log(`\n=== RESULT: ${pass} passed, ${fail} failed ===`);
+process.exit(fail === 0 ? 0 : 1);

--- a/tests/api/events.test.ts
+++ b/tests/api/events.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from 'vitest';
+
+type MockContext = {
+  set: (key: string, value: unknown) => void;
+};
+
+vi.mock('../../workers/api/src/middleware/auth', () => ({
+  requireSession: async (c: MockContext, next: () => Promise<void>) => {
+    c.set('userId', 'user-1');
+    await next();
+  },
+  requireApiKey: async (_c: MockContext, next: () => Promise<void>) => {
+    await next();
+  },
+  requireApiKeyOrSession: async (c: MockContext, next: () => Promise<void>) => {
+    c.set('userId', 'user-1');
+    await next();
+  },
+  resolveBearerUserId: vi.fn().mockResolvedValue('user-1'),
+}));
+
+vi.mock('@saas-maker/ops', () => ({
+  capture: vi.fn(),
+}));
+
+import { request } from './helpers';
+
+// Mock D1 that honours the (owner_id, idempotency_key) uniqueness so we can
+// assert idempotent batch inserts return the right accepted/deduped counts.
+function createMockD1() {
+  const rows: Record<string, unknown>[] = [];
+  const seen = new Set<string>();
+  function makeStatement(sql: string, values: unknown[]) {
+    return {
+      sql,
+      values,
+      run: async () => execInsert(sql, values),
+      first: async () => rows.find((r) => r.id === values[0]) ?? null,
+      all: async () => ({
+        results: rows.filter((r) => r.owner_id === values[0]),
+      }),
+    };
+  }
+  function execInsert(sql: string, values: unknown[]) {
+    if (sql.includes('INSERT INTO fleet_events')) {
+      const key = `${values[1]}::${values[7]}`; // owner_id::idempotency_key
+      if (seen.has(key)) return { meta: { changes: 0 } };
+      seen.add(key);
+      rows.push({ id: values[0], owner_id: values[1], product: values[2], type: values[4] });
+      return { meta: { changes: 1 } };
+    }
+    return { meta: { changes: 0 } };
+  }
+  return {
+    prepare: (sql: string) => ({ bind: (...values: unknown[]) => makeStatement(sql, values) }),
+    batch: async (statements: Array<{ sql: string; values: unknown[] }>) =>
+      Promise.all(statements.map((s) => execInsert(s.sql, s.values))),
+  };
+}
+
+describe('fleet events API', () => {
+  it('accepts a single event and reports accepted=1', async () => {
+    const res = await request('/v1/events', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ product: 'reel-pipeline', type: 'reel.rendered', payload: { reel_id: 'r1' } }),
+    }, { DB: createMockD1() });
+
+    expect(res.status).toBe(201);
+    expect(await res.json()).toMatchObject({ accepted: 1, deduped: 0, received: 1 });
+  });
+
+  it('rejects an event missing required fields', async () => {
+    const res = await request('/v1/events', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ type: 'reel.rendered' }),
+    }, { DB: createMockD1() });
+
+    expect(res.status).toBe(400);
+    expect((await res.json() as { error: string }).error).toContain('product is required');
+  });
+
+  it('dedupes a repeated idempotency_key within a batch', async () => {
+    const db = createMockD1();
+    const event = { product: 'psi-swarm', type: 'audit.completed', idempotency_key: 'dup-1', payload: {} };
+    const res = await request('/v1/events', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify([event, event]),
+    }, { DB: db });
+
+    expect(res.status).toBe(201);
+    expect(await res.json()).toMatchObject({ accepted: 1, deduped: 1, received: 2 });
+  });
+
+  it('rejects an over-sized batch', async () => {
+    const events = Array.from({ length: 101 }, (_, i) => ({ product: 'p', type: 't', idempotency_key: `k${i}` }));
+    const res = await request('/v1/events', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(events),
+    }, { DB: createMockD1() });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('lists events for the owner', async () => {
+    const db = createMockD1();
+    await request('/v1/events', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ product: 'taste', type: 'study.completed', idempotency_key: 'a1' }),
+    }, { DB: db });
+
+    const res = await request('/v1/events?product=taste', { method: 'GET' }, { DB: db });
+    expect(res.status).toBe(200);
+    const payload = await res.json() as { data: unknown[] };
+    expect(Array.isArray(payload.data)).toBe(true);
+    expect(payload.data.length).toBe(1);
+  });
+});

--- a/tests/api/task-queue.test.ts
+++ b/tests/api/task-queue.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockDb = vi.hoisted(() => ({
+  claimNextTask: vi.fn(),
+  completeTask: vi.fn(),
+  failTask: vi.fn(),
+  heartbeatTask: vi.fn(),
+  getTask: vi.fn(),
+  createTaskComment: vi.fn(),
+  createSymphonyAuditEvent: vi.fn(),
+}));
+
+type MockContext = {
+  get: (key: string) => unknown;
+  set: (key: string, value: unknown) => void;
+};
+
+vi.mock('../../workers/api/src/db', () => ({ getDb: () => mockDb }));
+
+vi.mock('../../workers/api/src/middleware/auth', () => ({
+  requireSession: async (c: MockContext, next: () => Promise<void>) => {
+    c.set('userId', 'user-1');
+    await next();
+  },
+  requireApiKey: async (_c: MockContext, next: () => Promise<void>) => { await next(); },
+  requireApiKeyOrSession: async (c: MockContext, next: () => Promise<void>) => { c.set('userId', 'user-1'); await next(); },
+  resolveBearerUserId: vi.fn().mockResolvedValue('user-1'),
+}));
+
+vi.mock('@saas-maker/ops', () => ({ configurePostHog: vi.fn(), capture: vi.fn(), flushPostHog: vi.fn() }));
+
+import { request } from './helpers';
+
+beforeEach(() => {
+  Object.values(mockDb).forEach((fn) => fn.mockReset());
+  mockDb.createSymphonyAuditEvent.mockResolvedValue(undefined);
+  mockDb.getTask.mockImplementation(async (id: string) => ({ id, status: 'done' }));
+});
+
+describe('task-queue worker endpoints', () => {
+  it('claims the next task for a capability', async () => {
+    mockDb.claimNextTask.mockResolvedValue({ id: 't1', capability: 'review', status: 'in_progress' });
+    const res = await request('/v1/tasks/claim', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ worker: 'codevetter@host', capability: 'review' }),
+    }, { DB: {} });
+    expect(res.status).toBe(200);
+    expect((await res.json() as { data: { id: string } }).data.id).toBe('t1');
+    expect(mockDb.claimNextTask).toHaveBeenCalledWith('user-1', expect.objectContaining({ worker: 'codevetter@host', capability: 'review' }));
+  });
+
+  it('returns 204 when the queue is empty', async () => {
+    mockDb.claimNextTask.mockResolvedValue(null);
+    const res = await request('/v1/tasks/claim', {
+      method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ worker: 'w1' }),
+    }, { DB: {} });
+    expect(res.status).toBe(204);
+  });
+
+  it('requires a worker id to claim', async () => {
+    const res = await request('/v1/tasks/claim', {
+      method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ capability: 'review' }),
+    }, { DB: {} });
+    expect(res.status).toBe(400);
+  });
+
+  it('clamps lease_seconds into range', async () => {
+    mockDb.claimNextTask.mockResolvedValue({ id: 't1' });
+    await request('/v1/tasks/claim', {
+      method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ worker: 'w1', lease_seconds: 999999 }),
+    }, { DB: {} });
+    expect(mockDb.claimNextTask).toHaveBeenCalledWith('user-1', expect.objectContaining({ leaseSeconds: 3600 }));
+  });
+
+  it('completes a task held by the worker', async () => {
+    mockDb.completeTask.mockResolvedValue(true);
+    const res = await request('/v1/tasks/t1/complete', {
+      method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ worker: 'w1', result: 'looks good' }),
+    }, { DB: {} });
+    expect(res.status).toBe(200);
+    expect(mockDb.createTaskComment).toHaveBeenCalledWith('user-1', 't1', expect.objectContaining({ author_type: 'agent', body: 'looks good' }));
+  });
+
+  it('409s completing a task not held by the worker', async () => {
+    mockDb.completeTask.mockResolvedValue(false);
+    const res = await request('/v1/tasks/t1/complete', {
+      method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ worker: 'w1' }),
+    }, { DB: {} });
+    expect(res.status).toBe(409);
+  });
+
+  it('requeues on fail under max attempts, dead-letters past it', async () => {
+    mockDb.failTask.mockResolvedValueOnce({ dead_letter: false, requeued: true, attempts: 1 });
+    let res = await request('/v1/tasks/t1/fail', {
+      method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ worker: 'w1', error: 'boom' }),
+    }, { DB: {} });
+    expect(res.status).toBe(200);
+    expect((await res.json() as { outcome: { requeued: boolean } }).outcome.requeued).toBe(true);
+
+    mockDb.failTask.mockResolvedValueOnce({ dead_letter: true, requeued: false, attempts: 3 });
+    res = await request('/v1/tasks/t1/fail', {
+      method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ worker: 'w1', error: 'boom' }),
+    }, { DB: {} });
+    expect((await res.json() as { outcome: { dead_letter: boolean } }).outcome.dead_letter).toBe(true);
+  });
+
+  it('extends the lease on heartbeat', async () => {
+    mockDb.heartbeatTask.mockResolvedValue(true);
+    const res = await request('/v1/tasks/t1/heartbeat', {
+      method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ worker: 'w1' }),
+    }, { DB: {} });
+    expect(res.status).toBe(200);
+  });
+});

--- a/workers/api/migrations/0019_fleet_events.sql
+++ b/workers/api/migrations/0019_fleet_events.sql
@@ -1,0 +1,19 @@
+-- Fleet events: append-only system-of-record where spokes publish results/telemetry up.
+-- Single-writer-per-product by convention; only the hub (Cockpit) reads the union.
+-- See docs/plans/2026-06-19-fleet-events-hub-spec.md
+CREATE TABLE IF NOT EXISTS fleet_events (
+  id TEXT PRIMARY KEY,
+  owner_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  product TEXT NOT NULL,                          -- which spoke emitted it, e.g. 'reel-pipeline'
+  project_slug TEXT,                              -- optional fleet-project linkage
+  type TEXT NOT NULL,                             -- e.g. 'reel.rendered', 'audit.completed'
+  payload TEXT NOT NULL DEFAULT '{}',             -- opaque JSON envelope; never coupled to the table
+  schema_version INTEGER NOT NULL DEFAULT 1,
+  idempotency_key TEXT NOT NULL,                  -- client-supplied; makes outbox retries safe
+  occurred_at TEXT,                              -- client event time (optional)
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(owner_id, idempotency_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_fleet_events_owner_product_type ON fleet_events(owner_id, product, type, created_at);
+CREATE INDEX IF NOT EXISTS idx_fleet_events_owner_created ON fleet_events(owner_id, created_at);

--- a/workers/api/migrations/0020_task_queue.sql
+++ b/workers/api/migrations/0020_task_queue.sql
@@ -1,0 +1,14 @@
+-- Task-queue primitive: turn the Symphony tasks table into a polling work-queue
+-- that heterogeneous workers (local or cron-deployed) claim from on wake.
+-- See docs/plans/2026-06-19-fleet-events-hub-spec.md §9.
+-- Status stays 'todo'/'in_progress'/'done' (no CHECK rebuild): pending = todo + claimed_by IS NULL,
+-- claimed = in_progress + claimed_by + lease_until, done = done, dead = dead_letter = 1.
+ALTER TABLE tasks ADD COLUMN capability TEXT;            -- which worker type handles it (review/audit/judge/ideas/...)
+ALTER TABLE tasks ADD COLUMN claimed_by TEXT;            -- worker id holding the lease
+ALTER TABLE tasks ADD COLUMN lease_until TEXT;           -- lease expiry; expired claims are reclaimable
+ALTER TABLE tasks ADD COLUMN attempts INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE tasks ADD COLUMN last_error TEXT;
+ALTER TABLE tasks ADD COLUMN dead_letter INTEGER NOT NULL DEFAULT 0;
+
+-- Claimability lookup: filter by capability + status, skip dead-lettered.
+CREATE INDEX IF NOT EXISTS idx_tasks_claimable ON tasks(owner_id, capability, status, dead_letter, lease_until);

--- a/workers/api/src/db.ts
+++ b/workers/api/src/db.ts
@@ -54,6 +54,12 @@ export interface TaskRow {
   deployment_status: 'none' | 'pending' | 'success' | 'failed';
   blocked_on_user: boolean;
   has_changelog: boolean;
+  capability: string | null;
+  claimed_by: string | null;
+  lease_until: string | null;
+  attempts: number;
+  last_error: string | null;
+  dead_letter: boolean;
   created_at: string; updated_at: string;
 }
 
@@ -115,6 +121,7 @@ function hydrateTaskRow(row: Record<string, unknown> | null | undefined): TaskRo
     dependencies: parseTaskDependencies(row.dependencies),
     blocked_on_user: row.blocked_on_user === true || row.blocked_on_user === 1,
     has_changelog: row.has_changelog === true || row.has_changelog === 1,
+    dead_letter: row.dead_letter === true || row.dead_letter === 1,
   } as TaskRow;
 }
 
@@ -1261,7 +1268,7 @@ export function getDb(d1: D1Database): FeedbackDatabase {
     },
 
     // --- Tasks ---
-    async createTask(ownerId: string, input: { title: string; description?: string; project_slug?: string; priority?: string; task_type?: string; size?: string; dependencies?: string[]; branch_name?: string | null; pr_url?: string | null; pr_status?: string; commit_sha?: string | null; deployment_url?: string | null; deployment_status?: string; blocked_on_user?: boolean }): Promise<TaskRow> {
+    async createTask(ownerId: string, input: { title: string; description?: string; project_slug?: string; priority?: string; task_type?: string; size?: string; dependencies?: string[]; branch_name?: string | null; pr_url?: string | null; pr_status?: string; commit_sha?: string | null; deployment_url?: string | null; deployment_status?: string; blocked_on_user?: boolean; capability?: string | null }): Promise<TaskRow> {
       const id = crypto.randomUUID();
       const priority = input.priority ?? 'medium';
       const taskType = input.task_type ?? 'feature';
@@ -1270,9 +1277,9 @@ export function getDb(d1: D1Database): FeedbackDatabase {
       await d1.prepare(
         `INSERT INTO tasks (
           id, owner_id, project_slug, title, description, priority, task_type, size, dependencies,
-          branch_name, pr_url, pr_status, commit_sha, deployment_url, deployment_status, blocked_on_user
+          branch_name, pr_url, pr_status, commit_sha, deployment_url, deployment_status, blocked_on_user, capability
         )
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
       ).bind(
         id,
         ownerId,
@@ -1290,6 +1297,7 @@ export function getDb(d1: D1Database): FeedbackDatabase {
         input.deployment_url ?? null,
         input.deployment_status ?? 'none',
         input.blocked_on_user ? 1 : 0,
+        input.capability ?? null,
       ).run();
       const row = await d1.prepare(`SELECT t.*, CASE WHEN EXISTS(SELECT 1 FROM changelog_entries ce WHERE ce.task_id = t.id LIMIT 1) THEN 1 ELSE 0 END AS has_changelog FROM tasks t WHERE t.id = ?`).bind(id).first();
       return hydrateTaskRow(row as Record<string, unknown> | null) as TaskRow;
@@ -1354,6 +1362,71 @@ export function getDb(d1: D1Database): FeedbackDatabase {
       const { meta } = await d1.prepare(
         `DELETE FROM tasks WHERE id = ? AND owner_id = ?`
       ).bind(id, ownerId).run();
+      return (meta.changes ?? 0) > 0;
+    },
+
+    // --- Task-queue primitive (workers claim/complete/fail/heartbeat) ---
+
+    // Atomically claim the next runnable task for a capability. The single UPDATE
+    // is race-safe (D1 serializes writes); expired leases are reclaimed in the same
+    // query, so no separate reaper is needed for correctness. Returns null if none.
+    async claimNextTask(ownerId: string, input: { worker: string; capability?: string | null; leaseSeconds?: number }): Promise<TaskRow | null> {
+      const capability = input.capability ?? null;
+      const leaseMod = `+${input.leaseSeconds ?? 900} seconds`;
+      const { results } = await d1.prepare(
+        `UPDATE tasks
+            SET status = 'in_progress', claimed_by = ?, lease_until = datetime('now', ?),
+                attempts = attempts + 1, updated_at = datetime('now')
+          WHERE id = (
+            SELECT id FROM tasks
+             WHERE owner_id = ? AND dead_letter = 0
+               AND (? IS NULL OR capability = ?)
+               AND (status = 'todo' OR (status = 'in_progress' AND lease_until IS NOT NULL AND lease_until < datetime('now')))
+             ORDER BY CASE priority WHEN 'high' THEN 0 WHEN 'medium' THEN 1 ELSE 2 END, created_at ASC
+             LIMIT 1
+          )
+            AND (status = 'todo' OR (status = 'in_progress' AND lease_until < datetime('now')))
+          RETURNING id`
+      ).bind(input.worker, leaseMod, ownerId, capability, capability).all();
+      const claimedId = (results?.[0] as { id?: string } | undefined)?.id;
+      if (!claimedId) return null;
+      const row = await d1.prepare(`SELECT t.*, CASE WHEN EXISTS(SELECT 1 FROM changelog_entries ce WHERE ce.task_id = t.id LIMIT 1) THEN 1 ELSE 0 END AS has_changelog FROM tasks t WHERE t.id = ?`).bind(claimedId).first();
+      return hydrateTaskRow(row as Record<string, unknown> | null);
+    },
+
+    // Mark done — only the lease holder may complete.
+    async completeTask(id: string, ownerId: string, worker: string): Promise<boolean> {
+      const { meta } = await d1.prepare(
+        `UPDATE tasks SET status = 'done', lease_until = NULL, updated_at = datetime('now')
+          WHERE id = ? AND owner_id = ? AND claimed_by = ?`
+      ).bind(id, ownerId, worker).run();
+      return (meta.changes ?? 0) > 0;
+    },
+
+    // Fail — requeue (back to 'todo') if under maxAttempts, else dead-letter. Lease holder only.
+    async failTask(id: string, ownerId: string, input: { worker: string; error?: string | null; maxAttempts?: number }): Promise<{ dead_letter: boolean; attempts: number; requeued: boolean } | null> {
+      const maxAttempts = input.maxAttempts ?? 3;
+      const { results } = await d1.prepare(
+        `UPDATE tasks
+            SET dead_letter = CASE WHEN attempts >= ? THEN 1 ELSE 0 END,
+                status = CASE WHEN attempts >= ? THEN status ELSE 'todo' END,
+                claimed_by = NULL, lease_until = NULL, last_error = ?, updated_at = datetime('now')
+          WHERE id = ? AND owner_id = ? AND claimed_by = ?
+          RETURNING dead_letter, attempts`
+      ).bind(maxAttempts, maxAttempts, input.error ?? null, id, ownerId, input.worker).all();
+      const row = results?.[0] as { dead_letter?: number; attempts?: number } | undefined;
+      if (!row) return null;
+      const dead = row.dead_letter === 1;
+      return { dead_letter: dead, attempts: row.attempts ?? 0, requeued: !dead };
+    },
+
+    // Extend the lease on an in-flight task (heartbeat from a long-running handler). Lease holder only.
+    async heartbeatTask(id: string, ownerId: string, worker: string, leaseSeconds?: number): Promise<boolean> {
+      const leaseMod = `+${leaseSeconds ?? 900} seconds`;
+      const { meta } = await d1.prepare(
+        `UPDATE tasks SET lease_until = datetime('now', ?), updated_at = datetime('now')
+          WHERE id = ? AND owner_id = ? AND claimed_by = ? AND status = 'in_progress'`
+      ).bind(leaseMod, id, ownerId, worker).run();
       return (meta.changes ?? 0) > 0;
     },
 

--- a/workers/api/src/index.ts
+++ b/workers/api/src/index.ts
@@ -22,6 +22,7 @@ import { taskWorkflows } from './routes/task-workflows';
 import { symphony } from './routes/symphony';
 import { knowledge } from './routes/knowledge';
 import { marketing } from './routes/marketing';
+import { events } from './routes/events';
 import { test as testRoutes } from './routes/test';
 import { requireApiKey } from './middleware/auth';
 import { rateLimit } from './middleware/rate-limit';
@@ -151,6 +152,7 @@ app.route('/v1/task-workflows', taskWorkflows);
 app.route('/v1/symphony', symphony);
 app.route('/v1/knowledge', knowledge);
 app.route('/v1/marketing', marketing);
+app.route('/v1/events', events);
 app.route('/v1/test', testRoutes);
 
 export default app;

--- a/workers/api/src/routes/events.ts
+++ b/workers/api/src/routes/events.ts
@@ -1,0 +1,141 @@
+import { Hono } from 'hono';
+import { Bindings, Variables } from '../types';
+import { requireSession } from '../middleware/auth';
+
+// Fleet events: the append-only return path where spokes publish results/telemetry
+// up to saas-maker (the system-of-record). Spokes authenticate with the same
+// Bearer token they already use (session or sm_ CLI token); owner_id scopes tenancy.
+// See docs/plans/2026-06-19-fleet-events-hub-spec.md
+
+const events = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+
+const MAX_BATCH = 100;
+
+function cleanString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+interface NormalizedEvent {
+  product: string;
+  type: string;
+  project_slug: string | null;
+  payload: string;
+  schema_version: number;
+  idempotency_key: string;
+  occurred_at: string | null;
+}
+
+/** Validate + normalize one inbound event. Returns an error string or the row. */
+function normalizeEvent(raw: unknown): { error: string } | NormalizedEvent {
+  if (!raw || typeof raw !== 'object') return { error: 'event must be an object' };
+  const input = raw as Record<string, unknown>;
+
+  const product = cleanString(input.product);
+  if (!product) return { error: 'product is required' };
+  const type = cleanString(input.type);
+  if (!type) return { error: 'type is required' };
+
+  // payload stays opaque JSON — stringify whatever object was sent.
+  let payload = '{}';
+  if (input.payload !== undefined && input.payload !== null) {
+    if (typeof input.payload !== 'object') return { error: 'payload must be an object' };
+    payload = JSON.stringify(input.payload);
+  }
+
+  const schemaVersionRaw = input.schema_version;
+  const schema_version =
+    typeof schemaVersionRaw === 'number' && Number.isFinite(schemaVersionRaw)
+      ? Math.trunc(schemaVersionRaw)
+      : 1;
+
+  return {
+    product,
+    type,
+    project_slug: cleanString(input.project_slug),
+    payload,
+    schema_version,
+    // Client-supplied idempotency key dedupes outbox retries; fall back to a uuid
+    // (that single call is then non-idempotent, but never errors).
+    idempotency_key: cleanString(input.idempotency_key) ?? crypto.randomUUID(),
+    occurred_at: cleanString(input.occurred_at),
+  };
+}
+
+events.use('*', requireSession);
+
+// POST /v1/events — append one event or a batch. Idempotent on (owner_id, idempotency_key).
+events.post('/', async (c) => {
+  const userId = c.get('userId')!;
+  const body = await c.req.json().catch(() => null);
+  if (body === null) return c.json({ error: 'invalid JSON body' }, 400);
+
+  const rawItems = Array.isArray(body) ? body : [body];
+  if (rawItems.length === 0) return c.json({ error: 'no events provided' }, 400);
+  if (rawItems.length > MAX_BATCH) {
+    return c.json({ error: `batch too large: max ${MAX_BATCH} events per request` }, 400);
+  }
+
+  const rows: NormalizedEvent[] = [];
+  for (let i = 0; i < rawItems.length; i++) {
+    const result = normalizeEvent(rawItems[i]);
+    if ('error' in result) return c.json({ error: `event[${i}]: ${result.error}` }, 400);
+    rows.push(result);
+  }
+
+  const statements = rows.map((row) =>
+    c.env.DB.prepare(
+      `INSERT INTO fleet_events (
+        id, owner_id, product, project_slug, type, payload, schema_version, idempotency_key, occurred_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(owner_id, idempotency_key) DO NOTHING`
+    ).bind(
+      crypto.randomUUID(),
+      userId,
+      row.product,
+      row.project_slug,
+      row.type,
+      row.payload,
+      row.schema_version,
+      row.idempotency_key,
+      row.occurred_at,
+    )
+  );
+
+  const results = await c.env.DB.batch(statements);
+  const accepted = results.reduce((sum, r) => sum + (r.meta?.changes ?? 0), 0);
+  return c.json({ accepted, deduped: rows.length - accepted, received: rows.length }, 201);
+});
+
+// GET /v1/events — read the union (Cockpit/analytics only). Filters: product, type, since, limit.
+events.get('/', async (c) => {
+  const userId = c.get('userId')!;
+  const product = cleanString(c.req.query('product'));
+  const type = cleanString(c.req.query('type'));
+  const since = cleanString(c.req.query('since')); // ISO timestamp lower bound on created_at
+
+  const conditions = ['owner_id = ?'];
+  const values: unknown[] = [userId];
+  if (product) {
+    conditions.push('product = ?');
+    values.push(product);
+  }
+  if (type) {
+    conditions.push('type = ?');
+    values.push(type);
+  }
+  if (since) {
+    conditions.push('created_at >= ?');
+    values.push(since);
+  }
+
+  const limit = Math.min(Math.max(Number.parseInt(c.req.query('limit') ?? '100', 10) || 100, 1), 500);
+  values.push(limit);
+
+  const { results } = await c.env.DB.prepare(
+    `SELECT * FROM fleet_events WHERE ${conditions.join(' AND ')} ORDER BY created_at DESC LIMIT ?`
+  ).bind(...values).all();
+
+  return c.json({ data: results ?? [] });
+});
+
+export { events };

--- a/workers/api/src/routes/tasks.ts
+++ b/workers/api/src/routes/tasks.ts
@@ -66,6 +66,12 @@ const DEPLOYMENT_STATUSES = ['none', 'pending', 'success', 'failed'] as const;
 const TASK_STATUSES = ['todo', 'in_progress', 'done'] as const;
 const COMMENT_AUTHOR_TYPES = ['user', 'agent'] as const;
 
+function clampInt(value: unknown, min: number, max: number, fallback: number): number {
+  const n = typeof value === 'number' ? value : Number.parseInt(String(value ?? ''), 10);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(Math.max(Math.trunc(n), min), max);
+}
+
 function normalizeBlockedDeployment(input: {
   blocked_on_user?: boolean;
   deployment_status?: typeof DEPLOYMENT_STATUSES[number];
@@ -97,6 +103,7 @@ tasks.post('/', requireSession, async (c) => {
     deployment_url?: unknown;
     deployment_status?: unknown;
     blocked_on_user?: unknown;
+    capability?: unknown;
   };
   if (!body.title || typeof body.title !== 'string' || !body.title.trim()) {
     return c.json({ error: 'title is required' }, 400);
@@ -123,6 +130,7 @@ tasks.post('/', requireSession, async (c) => {
     deployment_url: optionalString(body.deployment_url),
     deployment_status: state.deployment_status,
     blocked_on_user: state.blocked_on_user,
+    capability: optionalString(body.capability),
   });
   await recordAudit(db, userId, {
     task_id: task.id,
@@ -145,6 +153,74 @@ tasks.post('/', requireSession, async (c) => {
   });
   capture({ distinctId: userId, event: 'task_created', properties: { task_id: task.id, priority: task.priority ?? undefined, task_type: task.task_type ?? undefined, size: task.size ?? undefined, project_id: body.project_slug ?? undefined } });
   return c.json({ data: task }, 201);
+});
+
+// POST /v1/tasks/claim — atomically claim the next runnable task for a capability.
+// The core of the polling work-queue: a worker calls this on wake and drains.
+tasks.post('/claim', requireSession, async (c) => {
+  const userId = c.get('userId')!;
+  const body = await c.req.json().catch(() => ({})) as { capability?: unknown; worker?: unknown; lease_seconds?: unknown };
+  const worker = optionalString(body.worker);
+  if (!worker) return c.json({ error: 'worker is required' }, 400);
+  const capability = optionalString(body.capability) ?? null;
+  const db = getDb(c.env.DB);
+  const task = await db.claimNextTask(userId, { worker, capability, leaseSeconds: clampInt(body.lease_seconds, 30, 3600, 900) });
+  if (!task) return c.body(null, 204);
+  await recordAudit(db, userId, {
+    task_id: task.id, action: 'task_claimed', actor_source: 'worker',
+    project_slug: task.project_slug, metadata: { worker, capability },
+  });
+  return c.json({ data: task });
+});
+
+// POST /v1/tasks/:id/heartbeat — extend the lease on an in-flight task (long handlers).
+tasks.post('/:id/heartbeat', requireSession, async (c) => {
+  const userId = c.get('userId')!;
+  const id = c.req.param('id');
+  const body = await c.req.json().catch(() => ({})) as { worker?: unknown; lease_seconds?: unknown };
+  const worker = optionalString(body.worker);
+  if (!worker) return c.json({ error: 'worker is required' }, 400);
+  const db = getDb(c.env.DB);
+  const ok = await db.heartbeatTask(id, userId, worker, clampInt(body.lease_seconds, 30, 3600, 900));
+  if (!ok) return c.json({ error: 'Task not found or lease not held by this worker' }, 409);
+  return c.json({ ok: true });
+});
+
+// POST /v1/tasks/:id/complete — mark done (lease holder only); optional result → agent comment.
+tasks.post('/:id/complete', requireSession, async (c) => {
+  const userId = c.get('userId')!;
+  const id = c.req.param('id');
+  const body = await c.req.json().catch(() => ({})) as { worker?: unknown; result?: unknown };
+  const worker = optionalString(body.worker);
+  if (!worker) return c.json({ error: 'worker is required' }, 400);
+  const db = getDb(c.env.DB);
+  const ok = await db.completeTask(id, userId, worker);
+  if (!ok) return c.json({ error: 'Task not found or not held by this worker' }, 409);
+  if (typeof body.result === 'string' && body.result.trim()) {
+    await db.createTaskComment(userId, id, { body: body.result.trim(), author_type: 'agent' });
+  }
+  await recordAudit(db, userId, { task_id: id, action: 'task_completed', actor_source: 'worker', metadata: { worker } });
+  capture({ distinctId: userId, event: 'task_completed', properties: { task_id: id } });
+  const task = await db.getTask(id, userId);
+  return c.json({ data: task });
+});
+
+// POST /v1/tasks/:id/fail — record an error; requeue if under max_attempts, else dead-letter.
+tasks.post('/:id/fail', requireSession, async (c) => {
+  const userId = c.get('userId')!;
+  const id = c.req.param('id');
+  const body = await c.req.json().catch(() => ({})) as { worker?: unknown; error?: unknown; max_attempts?: unknown };
+  const worker = optionalString(body.worker);
+  if (!worker) return c.json({ error: 'worker is required' }, 400);
+  const db = getDb(c.env.DB);
+  const outcome = await db.failTask(id, userId, { worker, error: optionalString(body.error) ?? null, maxAttempts: clampInt(body.max_attempts, 1, 20, 3) });
+  if (!outcome) return c.json({ error: 'Task not found or not held by this worker' }, 409);
+  await recordAudit(db, userId, {
+    task_id: id, action: outcome.dead_letter ? 'task_dead_lettered' : 'task_failed_requeued',
+    actor_source: 'worker', metadata: { worker, attempts: outcome.attempts },
+  });
+  const task = await db.getTask(id, userId);
+  return c.json({ data: task, outcome });
 });
 
 // PATCH /v1/tasks/:id — update task fields

--- a/workers/api/src/schema.ts
+++ b/workers/api/src/schema.ts
@@ -1,4 +1,4 @@
-import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
+import { sqliteTable, text, integer, unique } from 'drizzle-orm/sqlite-core';
 import { sql } from 'drizzle-orm';
 
 export const users = sqliteTable('users', {
@@ -197,6 +197,21 @@ export const task_workflow_artifacts = sqliteTable('task_workflow_artifacts', {
   share_token: text('share_token').notNull().unique(),
   created_at: text('created_at').notNull().default(sql`(datetime('now'))`),
 });
+
+export const fleet_events = sqliteTable('fleet_events', {
+  id: text('id').primaryKey(),
+  owner_id: text('owner_id').notNull().references(() => users.id),
+  product: text('product').notNull(),
+  project_slug: text('project_slug'),
+  type: text('type').notNull(),
+  payload: text('payload').notNull().default('{}'),
+  schema_version: integer('schema_version').notNull().default(1),
+  idempotency_key: text('idempotency_key').notNull(),
+  occurred_at: text('occurred_at'),
+  created_at: text('created_at').notNull().default(sql`(datetime('now'))`),
+}, (t) => ({
+  uniqOwnerIdempotency: unique().on(t.owner_id, t.idempotency_key),
+}));
 
 export const changelog = sqliteTable('changelog', {
   id: text('id').primaryKey(),


### PR DESCRIPTION
The hub side of the fleet architecture (control tower / system-of-record).

## What's in it
- **Events sink** — append-only `POST/GET /v1/events` (migration `0019`), idempotent on `(owner_id, idempotency_key)`.
- **Task queue** — `0020` adds `capability`/`claimed_by`/`lease_until`/`attempts`/`dead_letter` to `tasks`; `POST /v1/tasks/claim|:id/complete|:id/fail|:id/heartbeat` with **atomic claim + lease** (expired leases auto-reclaim — no reaper needed for correctness).
- **Worker SDK** — `@saas-maker/sdk` `client.worker.drain()` + `client.events.emit()`. Graceful-degrading: a missing token / unreachable hub ends quietly (`hubUnavailable`), never throws — each spoke runs standalone.
- **Local e2e harness** — `scripts/e2e-fleet-local.mjs` (+ decision docs under `docs/plans/`), and a futuristic `/factory` showcase page.

## Verification
- Unit: **37/37** (events 5 + queue 8 + existing tasks 24).
- **Local e2e vs real D1: 11/11** — auth, event idempotent dedup, produce→claim→complete→409, fail→requeue→reclaim; plus a spoke (drank) authenticating + transferring cross-service.
- API + SDK typecheck clean.

## Not in scope / follow-up
- **Migrations 0019/0020 not yet applied to prod**; nothing deployed. Apply + deploy to light up the endpoints, then wire spoke handlers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)