### PR TITLE
feat(api): integrate standalone RAG service for knowledge search

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -21,18 +21,19 @@ SaaS Maker is the foundry helper for the fleet: a Cloudflare-first monorepo with
 - **CI/turbo recovery (2026-06-20):** restored missing `turbo.json`, fixed CI pnpm version conflict, removed dead `build:email` steps, and pointed root tests back at `vitest run` (320 tests). Cockpit builds via turbo dependency graph.
 - **API telemetry inlined (2026-06-20):** `workers/api/src/lib/telemetry.ts` replaces direct `@saas-maker/ops` usage in the API worker; `@saas-maker/ops` remains published for external consumers.
 - **Dead email block removed (2026-06-20):** deleted orphaned `@saas-maker/email` package and Resend notification sends from feedback/waitlist routes. Email Workers migration remains tracked separately in fleet docs.
+- **RAG service integration (2026-06-20):** knowledge routes support `RAG_BACKEND=local|dual|service`, service-backed search, dual-run comparison, and `/v1/knowledge/indexes/:id/export` for pre-embedded backfill into `rag-service`. `rag-service` is registered in fleet contracts, health checks, and secret audit.
 
 ## Planned Next
 
 1. Keep the fleet registry, README, AGENTS guidance, project status docs, helper classifications, health contracts, and public showcase synchronized as projects are added or retired.
-2. **RAG service cutover (PR #27):** wire knowledge routes to standalone `rag-service` (`RAG_BACKEND=local|dual|service`), add export/backfill endpoint, register health contracts.
-3. **Astro landing tooling (PR #28):** ship `@saas-maker/astro-landing` CLI for Beasties critical CSS + landing overlay helpers.
-4. **Fleet hub events (PR #25):** events sink + task queue + worker SDK for fleet project auth/integration.
-5. Graduate Magic Form Builder only after product ownership, storage, preview, and integration boundaries are explicit.
-6. Graduate AI Feedback Digest only after human-review, task writeback, and production AI-cost controls are explicit.
-7. Tighten Task Workflows after real use: automatic Droid result capture, richer run status/events in the panel, and clearer artifact lifecycle controls.
-8. Continue reducing stale deploy/docs references when concrete drift is found.
-9. Execute the EOY DR plan in `docs/launch-kit.md` — target DR ≥ 20 on all seven owned domains by 2026-12-31 via staggered launches, directories, and linkable assets.
+2. **Astro landing tooling (PR #28):** ship `@saas-maker/astro-landing` CLI for Beasties critical CSS + landing overlay helpers.
+3. **Fleet hub events (PR #25):** events sink + task queue + worker SDK for fleet project auth/integration.
+4. Graduate Magic Form Builder only after product ownership, storage, preview, and integration boundaries are explicit.
+5. Graduate AI Feedback Digest only after human-review, task writeback, and production AI-cost controls are explicit.
+6. Tighten Task Workflows after real use: automatic Droid result capture, richer run status/events in the panel, and clearer artifact lifecycle controls.
+7. Continue reducing stale deploy/docs references when concrete drift is found.
+8. Execute the EOY DR plan in `docs/launch-kit.md` — target DR ≥ 20 on all seven owned domains by 2026-12-31 via staggered launches, directories, and linkable assets.
+9. Complete the RAG migration cutover after backfilling existing knowledge indexes and running dual-mode recall/latency comparison against production-shaped data.
 
 ## Deferred / Parked
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Everything is hosted on Cloudflare. Each deployable ships independently via GitH
 | [`knowledgebase`](https://github.com/sarthakagrawal927/knowledge-base)      | product  | P1       | Private Agent Search for cited private project corpora.           |
 | [`open-historia`](https://github.com/sarthak-fleet/open-historia)           | product  | P1       | Interactive historical timeline and storytelling product.         |
 | [`pace`](https://github.com/sarthakagrawal927/clicky)                       | product  | P1       | Local macOS voice agent, formerly Clicky Local / Space candidate. |
+| `rag-service`                                                               | helper   | P1       | Standalone Cloudflare RAG service for fleet knowledge search.     |
 | [`reel-pipeline`](https://github.com/sarthak-fleet/reel-pipeline)           | helper   | P1       | Fleet marketing video artifact and autopost pipeline.             |
 | [`researchPapers`](https://github.com/sarthakagrawal927/researchPapers)     | product  | P1       | Academic-paper intelligence platform and dashboard.               |
 | [`resume-tailor`](https://github.com/sarthak-fleet/resume-tailor)           | product  | P1       | RolePatch resume tailoring product.                               |

--- a/apps/docs/public/openapi.json
+++ b/apps/docs/public/openapi.json
@@ -523,6 +523,19 @@
         }
       }
     },
+    "/v1/knowledge/indexes/{id}/export": {
+      "get": {
+        "tags": [
+          "knowledge"
+        ],
+        "summary": "GET /v1/knowledge/indexes/{id}/export",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
     "/v1/knowledge/indexes/{id}/search": {
       "post": {
         "tags": [

--- a/apps/docs/src/content/docs/sdk/cli.md
+++ b/apps/docs/src/content/docs/sdk/cli.md
@@ -133,6 +133,13 @@ fnd api POST /v1/ai/chat/completions --auth project \
 fnd api GET /v1/ai/usage --auth session --query project_id=<projectId> --output table
 ```
 
+### Knowledge export
+
+```bash
+fnd api GET /v1/knowledge/indexes/<indexId>/export --auth session \
+  --output json > saas-maker-knowledge-export.json
+```
+
 ### Symphony memory, audit, and run ledger
 
 ```bash

--- a/docs/cloudflare-secret-management.md
+++ b/docs/cloudflare-secret-management.md
@@ -24,6 +24,7 @@ Run:
 pnpm fleet:secret-audit
 pnpm fleet:secret-audit -- --json
 pnpm fleet:secret-audit -- --project reader --fail-on-missing
+pnpm fleet:secret-audit -- --project rag-service --fail-on-missing
 ```
 
 The audit checks:
@@ -46,6 +47,17 @@ When adding or changing a Cloudflare app:
    dashboard.
 4. Put deploy credentials in the repository's GitHub Actions secrets/variables.
 5. Run `pnpm fleet:secret-audit -- --project <slug> --fail-on-missing`.
+
+For the standalone RAG service, the expected final runtime blocker is only the
+Worker secret name:
+
+```bash
+cd ../rag-service
+pnpm exec wrangler secret put RAG_SERVICE_KEYS
+RAG_SERVICE_KEY=<service-key> pnpm run readiness:auth
+cd ../saas-maker
+pnpm fleet:secret-audit -- --project rag-service --fail-on-missing
+```
 
 Keep health contracts separate from deployment state. Health contracts describe
 what production should do; `cloudflare.targets.json` describes what Cloudflare

--- a/docs/fleet-canonical-projects.md
+++ b/docs/fleet-canonical-projects.md
@@ -25,6 +25,7 @@ Registry classification uses two separate fields:
 | `pace`               | Pace                   | Local macOS voice agent; previously discussed as Clicky Local / Space.   |
 | `psi-swarm`          | psi-swarm              | Local CLI and browser controller for repeated Lighthouse audits.         |
 | `reader`             | Reader                 | Worker frontend with Google login.                                       |
+| `rag-service`        | RAG Service            | Standalone Cloudflare Worker RAG service for fleet knowledge search.     |
 | `researchPapers`     | Research Papers        | Local academic-paper intelligence platform.                              |
 | `reel-pipeline`      | Reel Pipeline          | Artifact Worker and R2-backed video pipeline.                            |
 | `resume-tailor`      | RolePatch              | Product/domain name is RolePatch; repo slug remains `resume-tailor`.     |

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -523,6 +523,19 @@
         }
       }
     },
+    "/v1/knowledge/indexes/{id}/export": {
+      "get": {
+        "tags": [
+          "knowledge"
+        ],
+        "summary": "GET /v1/knowledge/indexes/{id}/export",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
     "/v1/knowledge/indexes/{id}/search": {
       "post": {
         "tags": [

--- a/foundry.projects.json
+++ b/foundry.projects.json
@@ -79,6 +79,14 @@
     "priority": "P1",
     "maturity": "internal-first"
   },
+  "rag-service": {
+    "desc": "Standalone Cloudflare RAG service for fleet knowledge ingestion, vector search, and SaaS Maker knowledge cutover.",
+    "url": "local:/Users/sarthak/Desktop/fleet/rag-service",
+    "tier": "helper",
+    "category": "helper",
+    "priority": "P1",
+    "maturity": "internal-first"
+  },
   "linkchat": {
     "desc": "Real-time chat application built with Next.js.",
     "url": "https://github.com/sarthak-fleet/linkchat.git",

--- a/packages/blocks/sdk/package.json
+++ b/packages/blocks/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saas-maker/sdk",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Official SDK for SaaS Maker — drop-in backend services for SaaS apps. Feedback, waitlist, testimonials, changelog, roadmap, chatbot, AI gateway, and directory.",
   "keywords": [
     "saas",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -136,6 +136,10 @@ fnd api POST /v1/ai/chat/completions --auth project \
 fnd api GET /v1/ai/usage --auth session --query project_id=<projectId> --output table
 fnd api GET /v1/ai/requests --auth session --query project_id=<projectId> --output table
 
+# Export pre-embedded knowledge chunks for RAG service backfill
+fnd api GET /v1/knowledge/indexes/<indexId>/export --auth session \
+  --output json > saas-maker-knowledge-export.json
+
 # Public roadmap items by project slug
 fnd api GET /v1/roadmap/by-project/<slug> --auth project --output table
 

--- a/packages/cli/src/openapi.json
+++ b/packages/cli/src/openapi.json
@@ -523,6 +523,19 @@
         }
       }
     },
+    "/v1/knowledge/indexes/{id}/export": {
+      "get": {
+        "tags": [
+          "knowledge"
+        ],
+        "summary": "GET /v1/knowledge/indexes/{id}/export",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
     "/v1/knowledge/indexes/{id}/search": {
       "post": {
         "tags": [

--- a/scripts/fleet-production-smoke.mjs
+++ b/scripts/fleet-production-smoke.mjs
@@ -58,6 +58,7 @@ const TARGETS = {
   ],
   'open-historia': [{ label: 'web', url: 'https://open-historia.sarthakagrawal927.workers.dev' }],
   reader: [{ label: 'web', url: 'https://reader.sarthakagrawal927.workers.dev' }],
+  'rag-service': [{ label: 'health', url: 'https://rag-service.sarthakagrawal927.workers.dev/v1/healthz' }],
   'reel-pipeline': [{ label: 'health', url: 'https://reel-pipeline-artifacts.sarthakagrawal927.workers.dev/health' }],
   'resume-tailor': [{ label: 'web', url: 'https://rolepatch.com' }],
   'saas-maker': [

--- a/scripts/lib/fleet-health-contracts.mjs
+++ b/scripts/lib/fleet-health-contracts.mjs
@@ -188,6 +188,18 @@ export const FLEET_HEALTH_CONTRACTS = {
     githubWorkflow: 'deploy.yml',
     smokeCommand: 'pnpm run fleet:prod-smoke --project reader',
   },
+  'rag-service': {
+    displayName: 'RAG Service',
+    prodUrl: 'https://rag-service.sarthakagrawal927.workers.dev',
+    expectedStatus: 200,
+    criticalRoutes: ['/v1/healthz'],
+    auth: { required: true, publicProbe: '/v1/healthz', protectedProbe: '/v1/indexes' },
+    requiredEnv: { build: [], runtime: ['RAG_SERVICE_KEYS'] },
+    deployTarget: 'Cloudflare Workers + D1 + Vectorize + R2',
+    deploySecretsRequired: false,
+    githubWorkflow: null,
+    smokeCommand: 'curl --fail https://rag-service.sarthakagrawal927.workers.dev/v1/healthz',
+  },
   researchPapers: {
     displayName: 'Research Papers',
     prodUrl: null,

--- a/scripts/lib/fleet-secret-audit.mjs
+++ b/scripts/lib/fleet-secret-audit.mjs
@@ -243,7 +243,7 @@ export function buildProjectSecretPlan(
     for (const secret of extractWorkflowSecretRequirements(project.dir, contract.githubWorkflow)) {
       addGithubRequirement(secret);
     }
-  } else if (/Cloudflare/i.test(contract?.deployTarget ?? '')) {
+  } else if (contract?.deploySecretsRequired !== false && /Cloudflare/i.test(contract?.deployTarget ?? '')) {
     for (const secret of DEFAULT_DEPLOY_SECRETS.cloudflare) addGithubRequirement(secret);
   }
 

--- a/tests/api/helpers.ts
+++ b/tests/api/helpers.ts
@@ -10,8 +10,6 @@ export function request(path: string, init?: RequestInit, env?: Record<string, u
     CORS_ORIGIN: '*',
     DATABASE_URL: 'postgresql://localhost:26257/test',
     FEEDBACK_IMAGES: {} as any,
-    RESEND_API_KEY: 'test',
-    NOTIFICATION_FROM_EMAIL: 'test@test.com',
     FREE_AI_BASE_URL: 'http://localhost:8787',
     FREE_AI_API_KEY: 'test-api-key',
     ...env,

--- a/tests/api/knowledge.test.ts
+++ b/tests/api/knowledge.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockDb = vi.hoisted(() => ({
   createIndex: vi.fn(),
@@ -12,6 +12,7 @@ const mockDb = vi.hoisted(() => ({
   createChunks: vi.fn(),
   listDocumentsByIndex: vi.fn(),
   searchChunks: vi.fn(),
+  exportKnowledgeIndex: vi.fn(),
   getProjectById: vi.fn(),
 }));
 
@@ -61,6 +62,10 @@ vi.mock('@saas-maker/ops', () => ({
 
 import { request } from './helpers';
 
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
 beforeEach(() => {
   vi.clearAllMocks();
   mockDb.getProjectById.mockResolvedValue({ id: 'proj-1', owner_id: 'user-1' });
@@ -82,7 +87,12 @@ beforeEach(() => {
       created_at: '2026-01-01T00:00:00Z',
     },
   ]);
-  mockDb.getIndexById.mockResolvedValue({ id: 'idx-1', project_id: 'proj-1', name: 'Docs' });
+  mockDb.getIndexById.mockResolvedValue({
+    id: 'idx-1',
+    project_id: 'proj-1',
+    name: 'Docs',
+    external_id: 'external-docs',
+  });
   mockDb.createDocument.mockResolvedValue({
     id: 'doc-1',
     index_id: 'idx-1',
@@ -100,6 +110,20 @@ beforeEach(() => {
       metadata: { source: 'test' },
     },
   ]);
+  mockDb.exportKnowledgeIndex.mockResolvedValue({
+    index: { id: 'idx-1', project_id: 'proj-1', name: 'Docs', external_id: 'external-docs' },
+    chunks: [
+      {
+        id: 'chunk-1',
+        document_id: 'doc-1',
+        document_content: 'hello docs',
+        content: 'hello docs',
+        embedding: '[0.1,0.2,0.3]',
+        chunk_index: 0,
+        metadata: '{"source":"test"}',
+      },
+    ],
+  });
 });
 
 describe('Knowledge Base routes require auth', () => {
@@ -174,6 +198,32 @@ describe('Knowledge Base dashboard routes', () => {
     expect(await res.json()).toMatchObject({ data: [{ id: 'idx-1', document_count: 2 }] });
     expect(mockDb.listIndexesByProject).toHaveBeenCalledWith('proj-1');
   });
+
+  it('exports pre-embedded chunks for RAG service backfill', async () => {
+    const res = await request('/v1/knowledge/indexes/idx-1/export', {
+      headers: { Authorization: 'Bearer test-session' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      index: {
+        name: 'Docs',
+        external_id: 'idx-1',
+        source_external_id: 'external-docs',
+      },
+      chunks: [
+        {
+          id: 'chunk-1',
+          document_id: 'doc-1',
+          document_content: 'hello docs',
+          content: 'hello docs',
+          embedding: [0.1, 0.2, 0.3],
+          chunk_index: 0,
+          metadata: { source: 'test' },
+        },
+      ],
+    });
+  });
 });
 
 describe('Knowledge Base document routes', () => {
@@ -203,6 +253,56 @@ describe('Knowledge Base document routes', () => {
     ]);
   });
 
+  it('mirrors dual-mode ingests to the standalone RAG service while keeping local chunks', async () => {
+    const ai = { run: vi.fn().mockResolvedValue({ data: [[0.1, 0.2, 0.3]] }) };
+    const calls: Array<{ url: string; init: RequestInit | undefined }> = [];
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+      calls.push({ url, init });
+      if (url.endsWith('/v1/indexes')) {
+        return Response.json({ data: [{ id: 'rag-idx-1', external_id: 'idx-1', name: 'Docs' }] });
+      }
+      if (url.endsWith('/v1/indexes/rag-idx-1/ingest-vectors')) {
+        return Response.json({ upserted: 1 }, { status: 201 });
+      }
+      return Response.json({ error: 'unexpected' }, { status: 500 });
+    }));
+
+    const res = await request(
+      '/v1/knowledge/indexes/idx-1/documents',
+      {
+        method: 'POST',
+        headers: { Authorization: 'Bearer test-session', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: 'hello docs', metadata: { source: 'test' } }),
+      },
+      {
+        AI: ai,
+        RAG_BACKEND: 'dual',
+        RAG_SERVICE_URL: 'https://rag.example',
+        RAG_SERVICE_KEY: 'test-rag-key',
+      },
+    );
+
+    expect(res.status).toBe(201);
+    expect(await res.json()).toMatchObject({ rag_service_synced: true });
+    expect(mockDb.createChunks).toHaveBeenCalled();
+    expect(calls.map((call) => call.url)).toEqual([
+      'https://rag.example/v1/indexes',
+      'https://rag.example/v1/indexes/rag-idx-1/ingest-vectors',
+    ]);
+    expect(JSON.parse(String(calls[1]?.init?.body))).toMatchObject({
+      chunks: [
+        {
+          document_id: 'doc-1',
+          document_content: 'hello docs',
+          content: 'hello docs',
+          embedding: [0.1, 0.2, 0.3],
+          chunk_index: 0,
+          metadata: { source: 'test' },
+        },
+      ],
+    });
+  });
+
   it('clamps semantic search top_k before querying chunks', async () => {
     const ai = { run: vi.fn().mockResolvedValue({ data: [[0.2, 0.3, 0.4]] }) };
 
@@ -219,5 +319,116 @@ describe('Knowledge Base document routes', () => {
     expect(res.status).toBe(200);
     expect(mockDb.searchChunks).toHaveBeenCalledWith('idx-1', [0.2, 0.3, 0.4], 20);
     expect(await res.json()).toMatchObject({ data: [{ document_id: 'doc-1', score: 0.91 }] });
+  });
+
+  it('uses the standalone RAG service for service-mode search', async () => {
+    const ai = { run: vi.fn().mockResolvedValue({ data: [[0.2, 0.3, 0.4]] }) };
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.endsWith('/v1/indexes') && init?.method !== 'POST') {
+        return Response.json({ data: [{ id: 'rag-idx-1', external_id: 'idx-1', name: 'Docs' }] });
+      }
+      if (url.endsWith('/v1/indexes/rag-idx-1/query')) {
+        return Response.json({
+          data: [
+            {
+              document_id: 'doc-1',
+              chunk_id: 'chunk-1',
+              chunk_content: 'remote docs',
+              score: 0.99,
+              metadata: { source: 'rag' },
+            },
+          ],
+        });
+      }
+      return Response.json({ error: 'unexpected' }, { status: 500 });
+    }));
+
+    const res = await request(
+      '/v1/knowledge/indexes/idx-1/search',
+      {
+        method: 'POST',
+        headers: { Authorization: 'Bearer test-session', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query: 'docs', top_k: 500 }),
+      },
+      {
+        AI: ai,
+        RAG_BACKEND: 'service',
+        RAG_SERVICE_URL: 'https://rag.example',
+        RAG_SERVICE_KEY: 'test-rag-key',
+      },
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('X-RAG-Backend')).toBe('service');
+    expect(ai.run).not.toHaveBeenCalled();
+    expect(mockDb.searchChunks).not.toHaveBeenCalled();
+    expect(await res.json()).toMatchObject({
+      data: [{ document_id: 'doc-1', chunk_content: 'remote docs', score: 0.99 }],
+    });
+  });
+
+  it('uses the RAG service binding before public HTTP when configured', async () => {
+    const serviceFetch = vi.fn(async (request: Request) => {
+      if (request.url.endsWith('/v1/indexes') && request.method !== 'POST') {
+        return Response.json({ data: [{ id: 'rag-idx-1', external_id: 'idx-1', name: 'Docs' }] });
+      }
+      if (request.url.endsWith('/v1/indexes/rag-idx-1/query')) {
+        return Response.json({
+          data: [
+            {
+              document_id: 'doc-1',
+              chunk_id: 'chunk-1',
+              chunk_content: 'bound service docs',
+              score: 0.99,
+              metadata: { source: 'rag' },
+            },
+          ],
+        });
+      }
+      return Response.json({ error: 'unexpected' }, { status: 500 });
+    });
+    const publicFetch = vi.fn(async () => Response.json({ error: 'public fetch should not run' }, { status: 500 }));
+    vi.stubGlobal('fetch', publicFetch);
+
+    const res = await request(
+      '/v1/knowledge/indexes/idx-1/search',
+      {
+        method: 'POST',
+        headers: { Authorization: 'Bearer test-session', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query: 'docs', top_k: 5 }),
+      },
+      {
+        RAG_BACKEND: 'service',
+        RAG_SERVICE: { fetch: serviceFetch },
+        RAG_SERVICE_KEY: 'test-rag-key',
+      },
+    );
+    const second = await request(
+      '/v1/knowledge/indexes/idx-1/search',
+      {
+        method: 'POST',
+        headers: { Authorization: 'Bearer test-session', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query: 'docs', top_k: 5 }),
+      },
+      {
+        RAG_BACKEND: 'service',
+        RAG_SERVICE: { fetch: serviceFetch },
+        RAG_SERVICE_KEY: 'test-rag-key',
+      },
+    );
+
+    expect(res.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(publicFetch).not.toHaveBeenCalled();
+    expect(serviceFetch).toHaveBeenCalledTimes(3);
+    expect(serviceFetch.mock.calls[0]?.[0].headers.get('Authorization')).toBe('Bearer test-rag-key');
+    expect(serviceFetch.mock.calls.map(([request]) => request.url)).toEqual([
+      'https://rag-service.internal/v1/indexes',
+      'https://rag-service.internal/v1/indexes/rag-idx-1/query',
+      'https://rag-service.internal/v1/indexes/rag-idx-1/query',
+    ]);
+    expect(await res.json()).toMatchObject({
+      data: [{ document_id: 'doc-1', chunk_content: 'bound service docs', score: 0.99 }],
+    });
   });
 });

--- a/tests/scripts/fleet-secret-audit.test.ts
+++ b/tests/scripts/fleet-secret-audit.test.ts
@@ -122,4 +122,34 @@ binding = "DB"
     });
     expect(plan.runtime.required).toEqual(['API_SECRET']);
   });
+
+  it('allows manual Cloudflare deploy targets to audit runtime secrets only', () => {
+    const plan = buildProjectSecretPlan(
+      { slug: 'rag-service', repo: null, dir: '/missing' },
+      {
+        deployTarget: 'Cloudflare Workers + D1 + Vectorize + R2',
+        deploySecretsRequired: false,
+        githubWorkflow: null,
+        requiredEnv: { build: [], runtime: ['RAG_SERVICE_KEYS'] },
+      },
+      {
+        'rag-service': {
+          targets: [
+            {
+              kind: 'worker',
+              name: 'rag-service',
+              requiredSecrets: ['RAG_SERVICE_KEYS'],
+            },
+          ],
+        },
+      },
+    );
+
+    expect(plan.github.required).toEqual([]);
+    expect(plan.runtime).toMatchObject({
+      provider: 'cloudflare-worker',
+      name: 'rag-service',
+      required: ['RAG_SERVICE_KEYS'],
+    });
+  });
 });

--- a/workers/api/src/db.ts
+++ b/workers/api/src/db.ts
@@ -598,6 +598,26 @@ export function getDb(d1: D1Database): FeedbackDatabase {
       return (meta.changes ?? 0) > 0;
     },
 
+    async exportKnowledgeIndex(indexId) {
+      const index = await d1.prepare(`SELECT * FROM knowledge_indexes WHERE id = ?`).bind(indexId).first();
+      if (!index) return null;
+      const { results } = await d1.prepare(
+        `SELECT
+           c.id,
+           c.document_id,
+           d.content AS document_content,
+           c.content,
+           c.embedding,
+           c.chunk_index,
+           d.metadata
+         FROM document_chunks c
+         JOIN documents d ON d.id = c.document_id
+         WHERE c.index_id = ?
+         ORDER BY c.document_id, c.chunk_index`
+      ).bind(indexId).all();
+      return { index, chunks: results };
+    },
+
     // --- Waitlist ---
     async createWaitlistEntry(input) {
       const posRow = await d1.prepare(

--- a/workers/api/src/lib/rag-service.ts
+++ b/workers/api/src/lib/rag-service.ts
@@ -1,0 +1,153 @@
+import type { Bindings } from '../types';
+
+export type RagBackend = 'local' | 'dual' | 'service';
+
+export interface RagVectorChunk {
+  id: string;
+  document_id: string;
+  document_content?: string;
+  content: string;
+  embedding: number[];
+  chunk_index: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface RagSearchResult {
+  document_id: string;
+  chunk_id?: string;
+  chunk_content: string;
+  score: number;
+  metadata: Record<string, unknown>;
+}
+
+interface RagIndexInput {
+  id: string;
+  name: string;
+}
+
+const RAG_INDEX_CACHE_TTL_MS = 300_000;
+const ragIndexCache = new Map<string, { id: string; expiresAt: number }>();
+
+function normalizeBaseUrl(value: string | undefined): string {
+  return (value || '').trim().replace(/\/+$/, '');
+}
+
+function indexCacheKey(env: Bindings, input: RagIndexInput): string {
+  const target = env.RAG_SERVICE ? 'binding:rag-service' : normalizeBaseUrl(env.RAG_SERVICE_URL);
+  return `${target}:${env.RAG_SERVICE_KEY?.trim() || ''}:${input.id}`;
+}
+
+function getCachedRagIndexId(env: Bindings, input: RagIndexInput): string | null {
+  const key = indexCacheKey(env, input);
+  const cached = ragIndexCache.get(key);
+  if (!cached) return null;
+  if (cached.expiresAt <= Date.now()) {
+    ragIndexCache.delete(key);
+    return null;
+  }
+  return cached.id;
+}
+
+function setCachedRagIndexId(env: Bindings, input: RagIndexInput, id: string): void {
+  ragIndexCache.set(indexCacheKey(env, input), { id, expiresAt: Date.now() + RAG_INDEX_CACHE_TTL_MS });
+}
+
+function deleteCachedRagIndexId(env: Bindings, input: RagIndexInput): void {
+  ragIndexCache.delete(indexCacheKey(env, input));
+}
+
+export function getRagBackend(env: Bindings): RagBackend {
+  const value = (env.RAG_BACKEND || 'local').toLowerCase();
+  return value === 'dual' || value === 'service' ? value : 'local';
+}
+
+export function isRagServiceConfigured(env: Bindings): boolean {
+  return Boolean((env.RAG_SERVICE || normalizeBaseUrl(env.RAG_SERVICE_URL)) && env.RAG_SERVICE_KEY?.trim());
+}
+
+async function requestJson<T>(
+  env: Bindings,
+  path: string,
+  init: { method?: string; body?: unknown } = {},
+): Promise<T> {
+  const baseUrl = normalizeBaseUrl(env.RAG_SERVICE_URL);
+  const key = env.RAG_SERVICE_KEY?.trim();
+  if ((!env.RAG_SERVICE && !baseUrl) || !key) throw new Error('RAG service is not configured');
+
+  const requestInit = {
+    method: init.method || 'GET',
+    headers: {
+      Authorization: `Bearer ${key}`,
+      'Content-Type': 'application/json',
+    },
+    body: init.body === undefined ? undefined : JSON.stringify(init.body),
+  };
+  const res = await (env.RAG_SERVICE
+    ? env.RAG_SERVICE.fetch(new Request(`https://rag-service.internal${path}`, requestInit))
+    : fetch(`${baseUrl}${path}`, requestInit));
+  const payload = (await res.json().catch(() => ({}))) as T & { error?: string };
+  if (!res.ok) {
+    throw new Error(payload.error || `RAG service request failed with ${res.status}`);
+  }
+  return payload;
+}
+
+export async function ensureRagIndex(env: Bindings, input: RagIndexInput): Promise<string> {
+  const cached = getCachedRagIndexId(env, input);
+  if (cached) return cached;
+
+  const listed = await requestJson<{ data?: Array<{ id: string; name: string; external_id?: string | null }> }>(
+    env,
+    '/v1/indexes',
+  );
+  const existing = (listed.data || []).find((index) => index.external_id === input.id);
+  if (existing) {
+    setCachedRagIndexId(env, input, existing.id);
+    return existing.id;
+  }
+
+  const created = await requestJson<{ id: string }>(env, '/v1/indexes', {
+    method: 'POST',
+    body: { name: input.name, external_id: input.id },
+  });
+  setCachedRagIndexId(env, input, created.id);
+  return created.id;
+}
+
+export async function ingestRagVectors(
+  env: Bindings,
+  index: RagIndexInput,
+  chunks: RagVectorChunk[],
+): Promise<number> {
+  if (chunks.length === 0) return 0;
+  const ragIndexId = await ensureRagIndex(env, index);
+  const result = await requestJson<{ upserted?: number }>(env, `/v1/indexes/${ragIndexId}/ingest-vectors`, {
+    method: 'POST',
+    body: { chunks },
+  });
+  return result.upserted || 0;
+}
+
+export async function deleteRagDocument(env: Bindings, documentId: string): Promise<void> {
+  await requestJson(env, `/v1/documents/${documentId}`, { method: 'DELETE' });
+}
+
+export async function deleteRagIndex(env: Bindings, index: RagIndexInput): Promise<void> {
+  const ragIndexId = await ensureRagIndex(env, index);
+  await requestJson(env, `/v1/indexes/${ragIndexId}`, { method: 'DELETE' });
+  deleteCachedRagIndexId(env, index);
+}
+
+export async function searchRag(
+  env: Bindings,
+  index: RagIndexInput,
+  query: string,
+  topK: number,
+): Promise<RagSearchResult[]> {
+  const ragIndexId = await ensureRagIndex(env, index);
+  const result = await requestJson<{ data?: RagSearchResult[] }>(env, `/v1/indexes/${ragIndexId}/query`, {
+    method: 'POST',
+    body: { query, top_k: topK },
+  });
+  return result.data || [];
+}

--- a/workers/api/src/routes/knowledge.ts
+++ b/workers/api/src/routes/knowledge.ts
@@ -5,12 +5,19 @@ import { getDb } from '../db';
 import type { 
   CreateIndexRequest, 
   IngestDocumentRequest, 
-  SearchRequest,
-  IndexRecord,
-  DocumentRecord,
-  SearchResult
+  SearchRequest
 } from '@saas-maker/shared-types';
 import { capture } from '../lib/telemetry';
+import {
+  deleteRagDocument,
+  deleteRagIndex,
+  ensureRagIndex,
+  getRagBackend,
+  ingestRagVectors,
+  isRagServiceConfigured,
+  searchRag,
+  type RagSearchResult,
+} from '../lib/rag-service';
 
 const knowledge = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 
@@ -58,6 +65,27 @@ async function getEmbeddings(c: any, text: string | string[]): Promise<number[][
   throw new Error('AI binding not available for embeddings');
 }
 
+function parseJsonRecord(value: unknown): Record<string, unknown> {
+  if (!value) return {};
+  if (typeof value === 'object' && !Array.isArray(value)) return value as Record<string, unknown>;
+  if (typeof value !== 'string') return {};
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed as Record<string, unknown> : {};
+  } catch {
+    return {};
+  }
+}
+
+function mapRagResults(results: RagSearchResult[]) {
+  return results.map((r) => ({
+    document_id: r.document_id,
+    chunk_content: r.chunk_content,
+    score: r.score,
+    metadata: r.metadata || {},
+  }));
+}
+
 // --- Indexes ---
 
 knowledge.post('/indexes', requireSession, async (c) => {
@@ -76,6 +104,19 @@ knowledge.post('/indexes', requireSession, async (c) => {
     name: body.name.trim(),
     external_id: body.external_id || null,
   });
+
+  const backend = getRagBackend(c.env);
+  if (backend !== 'local' && isRagServiceConfigured(c.env)) {
+    try {
+      await ensureRagIndex(c.env, { id: index.id, name: index.name });
+    } catch (err) {
+      console.error('RAG index mirror error:', err);
+      if (backend === 'service') {
+        await db.deleteIndex(index.id);
+        return c.json({ error: 'Failed to create RAG service index' }, 502);
+      }
+    }
+  }
 
   capture({ distinctId: userId, event: 'knowledge_index_created', properties: { project_id: project.id, index_id: index.id } });
   return c.json(index, 201);
@@ -105,9 +146,47 @@ knowledge.delete('/indexes/:id', requireSession, async (c) => {
   const project = await db.getProjectById(index.project_id);
   if (!project || project.owner_id !== userId) return c.json({ error: 'Forbidden' }, 403);
 
+  const backend = getRagBackend(c.env);
+  if (backend !== 'local' && isRagServiceConfigured(c.env)) {
+    try {
+      await deleteRagIndex(c.env, { id: index.id, name: index.name });
+    } catch (err) {
+      console.error('RAG index delete mirror error:', err);
+      if (backend === 'service') return c.json({ error: 'Failed to delete RAG service index' }, 502);
+    }
+  }
   await db.deleteIndex(indexId);
   capture({ distinctId: userId, event: 'knowledge_index_deleted', properties: { project_id: project.id, index_id: indexId } });
   return c.json({ ok: true });
+});
+
+knowledge.get('/indexes/:id/export', requireSession, async (c) => {
+  const userId = c.get('userId')!;
+  const indexId = c.req.param('id');
+  const db = getDb(c.env.DB);
+  const index = await db.getIndexById(indexId);
+  if (!index) return c.json({ error: 'Index not found' }, 404);
+  const project = await db.getProjectById(index.project_id);
+  if (!project || project.owner_id !== userId) return c.json({ error: 'Forbidden' }, 403);
+
+  const exported = await db.exportKnowledgeIndex(indexId);
+  if (!exported) return c.json({ error: 'Index not found' }, 404);
+  return c.json({
+    index: {
+      name: index.name,
+      external_id: index.id,
+      source_external_id: index.external_id,
+    },
+    chunks: exported.chunks.map((chunk: Record<string, unknown>, i: number) => ({
+      id: String(chunk.id),
+      document_id: String(chunk.document_id),
+      document_content: String(chunk.document_content || ''),
+      content: String(chunk.content || ''),
+      embedding: JSON.parse(String(chunk.embedding || '[]')) as number[],
+      chunk_index: Number(chunk.chunk_index ?? i),
+      metadata: parseJsonRecord(chunk.metadata),
+    })),
+  });
 });
 
 // --- Documents ---
@@ -140,6 +219,10 @@ knowledge.post('/indexes/:id/documents', requireApiKeyOrSession, async (c) => {
 
   const index = await db.getIndexById(indexId);
   if (!index || index.project_id !== projectId) return c.json({ error: 'Index not found' }, 404);
+  const backend = getRagBackend(c.env);
+  if (backend === 'service' && !isRagServiceConfigured(c.env)) {
+    return c.json({ error: 'RAG service is not configured' }, 503);
+  }
 
   const doc = await db.createDocument({
     id: crypto.randomUUID(),
@@ -149,6 +232,7 @@ knowledge.post('/indexes/:id/documents', requireApiKeyOrSession, async (c) => {
   });
 
   const chunks = chunkText(body.content);
+  let ragServiceSynced = backend === 'local';
   if (chunks.length > 0) {
     try {
       const vectors = await getEmbeddings(c, chunks);
@@ -160,7 +244,27 @@ knowledge.post('/indexes/:id/documents', requireApiKeyOrSession, async (c) => {
         embedding: vectors[i],
         chunk_index: i,
       }));
-      await db.createChunks(chunkRecords);
+      if (backend !== 'service') await db.createChunks(chunkRecords);
+      if (backend !== 'local' && isRagServiceConfigured(c.env)) {
+        try {
+          await ingestRagVectors(c.env, { id: index.id, name: index.name }, chunkRecords.map((chunk) => ({
+            id: chunk.id,
+            document_id: doc.id,
+            document_content: body.content,
+            content: chunk.content,
+            embedding: chunk.embedding || [],
+            chunk_index: chunk.chunk_index,
+            metadata: body.metadata || {},
+          })));
+          ragServiceSynced = true;
+        } catch (err: any) {
+          console.error('RAG ingest mirror error:', err);
+          if (backend === 'service') {
+            await db.deleteDocument(doc.id);
+            return c.json({ error: `Failed to index document in RAG service: ${err.message}` }, 502);
+          }
+        }
+      }
     } catch (err: any) {
       console.error('Embedding error:', err);
       await db.deleteDocument(doc.id);
@@ -169,7 +273,7 @@ knowledge.post('/indexes/:id/documents', requireApiKeyOrSession, async (c) => {
   }
 
   capture({ distinctId: ownerId, event: 'knowledge_document_ingested', properties: { project_id: projectId, index_id: indexId, doc_id: doc.id, chunks: chunks.length } });
-  return c.json({ ...doc, chunks_created: chunks.length }, 201);
+  return c.json({ ...doc, chunks_created: chunks.length, rag_service_synced: ragServiceSynced }, 201);
 });
 
 knowledge.get('/indexes/:id/documents', requireApiKeyOrSession, async (c) => {
@@ -217,6 +321,15 @@ knowledge.delete('/documents/:id', requireApiKeyOrSession, async (c) => {
     ownerId = userId;
   }
 
+  const backend = getRagBackend(c.env);
+  if (backend !== 'local' && isRagServiceConfigured(c.env)) {
+    try {
+      await deleteRagDocument(c.env, docId);
+    } catch (err) {
+      console.error('RAG document delete mirror error:', err);
+      if (backend === 'service') return c.json({ error: 'Failed to delete RAG service document' }, 502);
+    }
+  }
   await db.deleteChunksByDocument(docId);
   await db.deleteDocument(docId);
   
@@ -251,12 +364,48 @@ knowledge.post('/indexes/:id/search', requireApiKeyOrSession, async (c) => {
 
   if (!body.query?.trim()) return c.json({ error: 'query is required' }, 400);
   const topK = Math.min(Math.max(body.top_k || 5, 1), 20);
+  const index = await db.getIndexById(indexId);
+  if (!index || index.project_id !== projectId) return c.json({ error: 'Index not found' }, 404);
+  const backend = getRagBackend(c.env);
+  if (backend === 'service') {
+    if (!isRagServiceConfigured(c.env)) return c.json({ error: 'RAG service is not configured' }, 503);
+    try {
+      const results = await searchRag(c.env, { id: index.id, name: index.name }, body.query, topK);
+      capture({ distinctId: ownerId, event: 'knowledge_search', properties: { project_id: projectId, index_id: indexId, query: body.query, results: results.length, rag_backend: 'service' } });
+      c.header('X-RAG-Backend', 'service');
+      return c.json({ data: mapRagResults(results) });
+    } catch (err: any) {
+      console.error('RAG search error:', err);
+      return c.json({ error: `Search failed: ${err.message}` }, 502);
+    }
+  }
 
   try {
     const [queryVector] = await getEmbeddings(c, body.query);
     const results = await db.searchChunks(indexId, queryVector, topK);
+    if (backend === 'dual' && isRagServiceConfigured(c.env)) {
+      c.executionCtx.waitUntil(
+        searchRag(c.env, { id: index.id, name: index.name }, body.query, topK)
+          .then((ragResults) => {
+            capture({
+              distinctId: ownerId,
+              event: 'knowledge_dual_search_compared',
+              properties: {
+                project_id: projectId,
+                index_id: indexId,
+                local_results: results.length,
+                rag_results: ragResults.length,
+              },
+            });
+          })
+          .catch((err) => {
+            console.error('RAG dual search error:', err);
+          }),
+      );
+    }
     
-    capture({ distinctId: ownerId, event: 'knowledge_search', properties: { project_id: projectId, index_id: indexId, query: body.query, results: results.length } });
+    capture({ distinctId: ownerId, event: 'knowledge_search', properties: { project_id: projectId, index_id: indexId, query: body.query, results: results.length, rag_backend: backend } });
+    c.header('X-RAG-Backend', backend);
     
     return c.json({ 
       data: results.map(r => ({

--- a/workers/api/wrangler.toml
+++ b/workers/api/wrangler.toml
@@ -4,11 +4,18 @@ compatibility_date = "2026-02-22"
 compatibility_flags = ["nodejs_compat"]
 workers_dev = true
 
+[vars]
+RAG_BACKEND = "service"
+
 [observability]
 enabled = true
 
 [ai]
 binding = "AI"
+
+[[services]]
+binding = "RAG_SERVICE"
+service = "rag-service"
 
 [[unsafe.bindings]]
 name = "RATE_LIMITER"


### PR DESCRIPTION
## Summary

Stacked on #26. Integrates the fleet `rag-service` Worker as an optional backend for SaaS Maker knowledge indexes (local / dual / service modes), adds a chunk export endpoint for backfill, and registers rag-service in fleet health contracts.

- `workers/api/src/lib/rag-service.ts` — service client with index cache
- Knowledge routes: dual-backend search/ingest, `/indexes/:id/export`
- Fleet registry + secret-audit coverage for `rag-service`
- OpenAPI + docs updates for export route

## Test plan

- [x] `pnpm test` — 325 passed
- [x] `pnpm -F @saas-maker/api typecheck`
- [ ] CI green after #26 merges

Made with [Cursor](https://cursor.com)