### PR TITLE
feat(tooling): add astro-landing CLI for Beasties critical CSS

### DIFF
--- a/packages/tooling/astro-landing/cli.js
+++ b/packages/tooling/astro-landing/cli.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+import { runInlineCss } from './inline-css.js';
+import { runOverlay } from './overlay.js';
+
+const [, , subcommand, ...rest] = process.argv;
+
+function parseArgs(argv) {
+  const opts = { strict: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--strict') {
+      opts.strict = true;
+    } else if (arg === '--astro-dist' && argv[i + 1]) {
+      opts.astroDist = argv[++i];
+    } else if (arg === '--assets' && argv[i + 1]) {
+      opts.assets = argv[++i];
+    }
+  }
+  return opts;
+}
+
+const opts = parseArgs(rest);
+
+try {
+  if (subcommand === 'inline-css') {
+    await runInlineCss(opts);
+  } else if (subcommand === 'overlay') {
+    await runOverlay(opts);
+  } else {
+    console.error('Usage: astro-landing <inline-css|overlay> [--astro-dist path] [--assets path] [--strict]');
+    process.exit(1);
+  }
+} catch (err) {
+  console.error('[astro-landing] fatal:', err);
+  process.exit(1);
+}

--- a/packages/tooling/astro-landing/inline-css.js
+++ b/packages/tooling/astro-landing/inline-css.js
@@ -1,0 +1,95 @@
+import { readFile, readdir, stat, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+import Beasties from 'beasties';
+
+const DEFAULT_PRERENDERED_ROOTS = [
+  '.next/server/app',
+  '.next/standalone/.next/server/app',
+  '.next/standalone/apps/web/.next/server/app',
+];
+
+async function walkHtml(dir) {
+  const out = [];
+  for (const entry of await readdir(dir)) {
+    const full = join(dir, entry);
+    const st = await stat(full);
+    if (st.isDirectory()) {
+      out.push(...(await walkHtml(full)));
+    } else if (entry.endsWith('.html')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function deRenderBlockCss(html) {
+  return html.replace(
+    /<link rel="stylesheet" href="([^"]+\.css)"[^>]*\/?>(?!<\/noscript>)/g,
+    (match, href) => {
+      const preloadPattern = new RegExp(
+        `<link rel="preload" href="${href.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}"[^>]*onload=`,
+      );
+      return preloadPattern.test(html) ? '' : match;
+    },
+  );
+}
+
+export async function runInlineCss(opts = {}) {
+  const strict = opts.strict ?? false;
+  const staticRoot = resolve('.next');
+  const prerenderedRoots = DEFAULT_PRERENDERED_ROOTS.map((p) => resolve(p)).filter((p) =>
+    existsSync(p),
+  );
+
+  const htmls = [];
+  for (const root of prerenderedRoots) {
+    htmls.push(...(await walkHtml(root)));
+  }
+  if (htmls.length === 0) {
+    const msg = '[inline-critical-css] no .html files under .next/server/app — skipping';
+    if (strict) {
+      console.error(msg);
+      process.exit(1);
+    }
+    console.log(msg);
+    return;
+  }
+
+  const beasties = new Beasties({
+    path: staticRoot,
+    publicPath: '/_next/',
+    preload: 'swap',
+    inlineFonts: false,
+    pruneSource: false,
+    logLevel: 'warn',
+  });
+
+  let total = 0;
+  let saved = 0;
+  for (const file of htmls) {
+    const before = await readFile(file, 'utf8');
+    let after;
+    try {
+      after = await beasties.process(before);
+    } catch (err) {
+      console.warn(`[inline-critical-css] skipping ${file}: ${err.message}`);
+      continue;
+    }
+    after = deRenderBlockCss(after);
+    if (after === before) continue;
+    await writeFile(file, after);
+    const delta = before.length - after.length;
+    total += 1;
+    saved += delta;
+    const rel = file.replace(`${process.cwd()}/`, '');
+    console.log(
+      `[inline-critical-css] ${rel}: ${(before.length / 1024).toFixed(1)}KB → ${(after.length / 1024).toFixed(1)}KB`,
+    );
+  }
+
+  console.log(
+    `[inline-critical-css] done — processed ${total} file(s), net size change ${(saved / 1024).toFixed(1)}KB`,
+  );
+}

--- a/packages/tooling/astro-landing/overlay.js
+++ b/packages/tooling/astro-landing/overlay.js
@@ -1,0 +1,82 @@
+import { copyFile, mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+
+const PROTECTED_PREFIXES = ['_next/', 'cdn-cgi/', 'BUILD_ID'];
+
+async function walk(dir, rel = '') {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const out = [];
+  for (const e of entries) {
+    const fullSrc = join(dir, e.name);
+    const fullRel = rel ? `${rel}/${e.name}` : e.name;
+    if (e.isDirectory()) {
+      out.push(...(await walk(fullSrc, fullRel)));
+    } else {
+      out.push({ src: fullSrc, rel: fullRel });
+    }
+  }
+  return out;
+}
+
+async function mergeHeaders(astroHeadersPath, targetHeadersPath) {
+  const astroHeaders = existsSync(astroHeadersPath)
+    ? await readFile(astroHeadersPath, 'utf8')
+    : '';
+  const targetHeaders = existsSync(targetHeadersPath)
+    ? await readFile(targetHeadersPath, 'utf8')
+    : '';
+  if (!astroHeaders) return false;
+  const merged = `# --- from landing-astro/dist/_headers (LCP-critical, takes precedence) ---\n${astroHeaders.trim()}\n\n# --- from Next.js / OpenNext build ---\n${targetHeaders.trim()}\n`;
+  await writeFile(targetHeadersPath, merged);
+  return true;
+}
+
+export async function runOverlay(opts = {}) {
+  const astroDist = resolve(opts.astroDist ?? 'landing-astro/dist');
+  const target = resolve(opts.assets ?? '.open-next/assets');
+  const strict = opts.strict ?? false;
+
+  if (!existsSync(astroDist)) {
+    const msg = `[overlay-astro] no ${astroDist} — skipping. Build landing-astro first.`;
+    if (strict) {
+      console.error(msg);
+      process.exit(1);
+    }
+    console.warn(msg);
+    return;
+  }
+  if (!existsSync(target)) {
+    const msg = `[overlay-astro] no ${target} — OpenNext build hasn't run yet. Skipping.`;
+    if (strict) {
+      console.error(msg);
+      process.exit(1);
+    }
+    console.warn(msg);
+    return;
+  }
+
+  const files = await walk(astroDist);
+  let copied = 0;
+  let skipped = 0;
+  for (const { src, rel } of files) {
+    if (PROTECTED_PREFIXES.some((p) => rel.startsWith(p))) {
+      skipped += 1;
+      continue;
+    }
+    if (rel === '_headers') {
+      const merged = await mergeHeaders(src, join(target, '_headers'));
+      console.log(
+        `[overlay-astro] merged _headers (Astro wins for /)${merged ? '' : ' — no Astro headers found'}`,
+      );
+      continue;
+    }
+    const dest = join(target, rel);
+    await mkdir(dirname(dest), { recursive: true });
+    await copyFile(src, dest);
+    copied += 1;
+  }
+  console.log(
+    `[overlay-astro] copied ${copied} file(s) from ${astroDist} → ${target}, skipped ${skipped} protected path(s)`,
+  );
+}

--- a/packages/tooling/astro-landing/package.json
+++ b/packages/tooling/astro-landing/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@saas-maker/astro-landing",
+  "version": "1.0.0",
+  "description": "OpenNext deploy glue: Beasties critical CSS + Astro landing overlay",
+  "type": "module",
+  "bin": {
+    "astro-landing": "cli.js"
+  },
+  "files": ["cli.js", "overlay.js", "inline-css.js"],
+  "publishConfig": { "access": "public" },
+  "dependencies": {
+    "beasties": "^0.3.5"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -273,6 +273,12 @@ importers:
         specifier: 4.1.5
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@29.0.2(@noble/hashes@2.2.0))(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.21.0)(yaml@2.8.3))
 
+  packages/tooling/astro-landing:
+    dependencies:
+      beasties:
+        specifier: ^0.3.5
+        version: 0.3.5
+
   packages/tooling/eslint-config:
     dependencies:
       '@eslint/js':
@@ -5218,6 +5224,10 @@ packages:
   bcp-47@2.1.0:
     resolution: {integrity: sha512-9IIS3UPrvIa1Ej+lVDdDwO7zLehjqsaByECw0bu2RRGP73jALm6FYbzI5gWbgHLvNdkvfXB5YrSbocZdOS0c0w==}
 
+  beasties@0.3.5:
+    resolution: {integrity: sha512-NaWu+f4YrJxEttJSm16AzMIFtVldCvaJ68b1L098KpqXmxt9xOLtKoLkKxb8ekhOrLqEJAbvT6n6SEvB/sac7A==}
+    engines: {node: '>=14.0.0'}
+
   better-auth@1.6.9:
     resolution: {integrity: sha512-EBFURtglyiEZxbx4NJBoqUD8J65dX24yC+6I9AUbIXNgUkt76mshzGbHkxZ3n/lB7Dwq3kBC+hHt0hUQsnL7HA==}
     peerDependencies:
@@ -5590,6 +5600,9 @@ packages:
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
 
+  css-select@6.0.0:
+    resolution: {integrity: sha512-rZZVSLle8v0+EY8QAkDWrKhpgt6SA5OtHsgBnsj6ZaLb5dmDVOWUDtQitd9ydxxvEjhewNudS6eTVU7uOyzvXw==}
+
   css-selector-parser@3.3.0:
     resolution: {integrity: sha512-Y2asgMGFqJKF4fq4xHDSlFYIkeVfRsm69lQC1q9kbEsH5XtnINTMrweLkjYMeaUgiXBy/uvKeO/a1JHTNnmB2g==}
 
@@ -5603,6 +5616,10 @@ packages:
 
   css-what@6.2.2:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
+
+  css-what@7.0.0:
+    resolution: {integrity: sha512-wD5oz5xibMOPHzy13CyGmogB3phdvcDaB5t0W/Nr5Z2O/agcB8YwOz6e2Lsp10pNDzBoDO9nVa3RGs/2BttpHQ==}
     engines: {node: '>= 6'}
 
   css.escape@1.5.1:
@@ -6754,6 +6771,9 @@ packages:
 
   html-whitespace-sensitive-tag-names@3.0.1:
     resolution: {integrity: sha512-q+310vW8zmymYHALr1da4HyXUQ0zgiIwIicEfotYPWGN0OJVEN/58IJ3A4GBYcEq3LGAZqKb+ugvP0GNB9CEAA==}
+
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
@@ -8102,6 +8122,9 @@ packages:
         optional: true
       ts-node:
         optional: true
+
+  postcss-media-query-parser@0.2.3:
+    resolution: {integrity: sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==}
 
   postcss-nested@6.2.0:
     resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
@@ -15034,6 +15057,17 @@ snapshots:
       is-alphanumerical: 2.0.1
       is-decimal: 2.0.1
 
+  beasties@0.3.5:
+    dependencies:
+      css-select: 6.0.0
+      css-what: 7.0.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      htmlparser2: 10.1.0
+      picocolors: 1.1.1
+      postcss: 8.5.10
+      postcss-media-query-parser: 0.2.3
+
   better-auth@1.6.9(@cloudflare/workers-types@4.20260424.1)(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260424.1)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.0)(@types/pg@8.6.1)(kysely@0.28.16))(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.5):
     dependencies:
       '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260424.1)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
@@ -15374,6 +15408,14 @@ snapshots:
       domutils: 3.2.2
       nth-check: 2.1.1
 
+  css-select@6.0.0:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 7.0.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
   css-selector-parser@3.3.0: {}
 
   css-tree@2.2.1:
@@ -15387,6 +15429,8 @@ snapshots:
       source-map-js: 1.2.1
 
   css-what@6.2.2: {}
+
+  css-what@7.0.0: {}
 
   css.escape@1.5.1: {}
 
@@ -15631,8 +15675,7 @@ snapshots:
 
   entities@6.0.1: {}
 
-  entities@7.0.1:
-    optional: true
+  entities@7.0.1: {}
 
   entities@8.0.0:
     optional: true
@@ -16974,6 +17017,13 @@ snapshots:
   html-void-elements@3.0.0: {}
 
   html-whitespace-sensitive-tag-names@3.0.1: {}
+
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
 
   http-cache-semantics@4.2.0: {}
 
@@ -18598,6 +18648,8 @@ snapshots:
       yaml: 2.8.3
     optionalDependencies:
       postcss: 8.5.10
+
+  postcss-media-query-parser@0.2.3: {}
 
   postcss-nested@6.2.0(postcss@8.5.10):
     dependencies:


### PR DESCRIPTION
## Summary

Stacked on #26. Adds `@saas-maker/astro-landing` — a small CLI bundling Beasties critical CSS inlining and Astro landing overlay helpers for fleet landing-page OpenNext/Astro migrations.

## Test plan

- [x] `pnpm install` resolves workspace package
- [ ] CI green after #26 merges

Made with [Cursor](https://cursor.com)