### PR TITLE
Registry: Karte / RolePatch display names (no slug/deploy change)

### DIFF
--- a/foundry.projects.json
+++ b/foundry.projects.json
@@ -80,8 +80,8 @@
     "maturity": "internal-first"
   },
   "linkchat": {
-    "desc": "Real-time chat application built with Next.js.",
-    "url": "https://github.com/sarthak-fleet/linkchat.git",
+    "desc": "Karte — AI link-in-bio (chat, encyclopedia, roast) at karte.cc.",
+    "url": "https://github.com/sarthak-fleet/karte.git",
     "tier": "active-ai",
     "category": "product",
     "priority": "P2",
@@ -145,7 +145,7 @@
   },
   "resume-tailor": {
     "desc": "RolePatch — AI-powered resume tailoring system.",
-    "url": "git@github.com:sarthak-fleet/resume-tailor.git",
+    "url": "git@github.com:sarthak-fleet/rolepatch.git",
     "tier": "core",
     "category": "product",
     "priority": "P1",

--- a/scripts/lib/fleet-health-contracts.mjs
+++ b/scripts/lib/fleet-health-contracts.mjs
@@ -121,7 +121,7 @@ export const FLEET_HEALTH_CONTRACTS = {
     smokeCommand: null,
   },
   linkchat: {
-    displayName: 'Linkchat',
+    displayName: 'Karte',
     prodUrl: 'https://linkchat.sarthakagrawal927.workers.dev',
     expectedStatus: 200,
     criticalRoutes: ['/'],


### PR DESCRIPTION
Reflects the renamed products in the saas-maker registry **without** renaming the deploy-bound slugs.

- `foundry.projects.json`: linkchat → desc "Karte — AI link-in-bio …" + git_url → karte.git; resume-tailor git_url → rolepatch.git (desc already "RolePatch …").
- `fleet-health-contracts.mjs`: linkchat displayName `Linkchat` → `Karte` (resume-tailor already `RolePatch`).

**Slugs kept** (`linkchat`/`resume-tailor`) because they're identifiers across cloudflare.targets, prod-smoke, secret-audit, contracts, and are enforced by check-fleet-contract-sync. The live CF Workers + custom domains are untouched (zero downtime). Repos already renamed on GitHub (old names redirect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)