### PR TITLE
chore: pin pnpm to 10.33.2

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -24,7 +24,7 @@ jobs:
           if node -e "const pm=require('./package.json').packageManager||''; process.exit(pm.startsWith('pnpm@')?0:1)"; then
             corepack install
           else
-            corepack prepare pnpm@10.32.1 --activate
+            corepack prepare pnpm@10.33.2 --activate
           fi
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- Standardize fleet-wide pnpm version to 10.33.2
- Add missing `packageManager` field where absent
- Update CI fallback `corepack prepare` version

Generated with [Devin](https://devin.ai)