### PR TITLE
fix(ci): resolve OpenAPI spec drift after Biome migration

### DIFF
--- a/apps/docs/public/openapi.json
+++ b/apps/docs/public/openapi.json
@@ -14,7 +14,9 @@
   "paths": {
     "/health": {
       "get": {
-        "tags": ["system"],
+        "tags": [
+          "system"
+        ],
         "summary": "GET /health",
         "responses": {
           "200": {
@@ -25,7 +27,9 @@
     },
     "/v1/ai/chat/completions": {
       "post": {
-        "tags": ["ai"],
+        "tags": [
+          "ai"
+        ],
         "summary": "POST /v1/ai/chat/completions",
         "responses": {
           "200": {
@@ -36,7 +40,9 @@
     },
     "/v1/ai/config": {
       "get": {
-        "tags": ["ai"],
+        "tags": [
+          "ai"
+        ],
         "summary": "GET /v1/ai/config",
         "responses": {
           "200": {
@@ -45,7 +51,9 @@
         }
       },
       "put": {
-        "tags": ["ai"],
+        "tags": [
+          "ai"
+        ],
         "summary": "PUT /v1/ai/config",
         "responses": {
           "200": {
@@ -54,7 +62,9 @@
         }
       },
       "delete": {
-        "tags": ["ai"],
+        "tags": [
+          "ai"
+        ],
         "summary": "DELETE /v1/ai/config",
         "responses": {
           "200": {
@@ -65,7 +75,9 @@
     },
     "/v1/ai/embeddings": {
       "post": {
-        "tags": ["ai"],
+        "tags": [
+          "ai"
+        ],
         "summary": "POST /v1/ai/embeddings",
         "responses": {
           "200": {
@@ -76,7 +88,9 @@
     },
     "/v1/ai/requests": {
       "get": {
-        "tags": ["ai"],
+        "tags": [
+          "ai"
+        ],
         "summary": "GET /v1/ai/requests",
         "responses": {
           "200": {
@@ -87,7 +101,9 @@
     },
     "/v1/ai/usage": {
       "get": {
-        "tags": ["ai"],
+        "tags": [
+          "ai"
+        ],
         "summary": "GET /v1/ai/usage",
         "responses": {
           "200": {
@@ -98,7 +114,9 @@
     },
     "/v1/auth/logout": {
       "post": {
-        "tags": ["auth"],
+        "tags": [
+          "auth"
+        ],
         "summary": "POST /v1/auth/logout",
         "responses": {
           "200": {
@@ -109,7 +127,9 @@
     },
     "/v1/auth/session": {
       "get": {
-        "tags": ["auth"],
+        "tags": [
+          "auth"
+        ],
         "summary": "GET /v1/auth/session",
         "responses": {
           "200": {
@@ -120,7 +140,9 @@
     },
     "/v1/changelog": {
       "get": {
-        "tags": ["changelog"],
+        "tags": [
+          "changelog"
+        ],
         "summary": "GET /v1/changelog",
         "responses": {
           "200": {
@@ -131,7 +153,9 @@
     },
     "/v1/changelog/dashboard/{projectId}": {
       "get": {
-        "tags": ["changelog"],
+        "tags": [
+          "changelog"
+        ],
         "summary": "GET /v1/changelog/dashboard/{projectId}",
         "responses": {
           "200": {
@@ -140,7 +164,9 @@
         }
       },
       "post": {
-        "tags": ["changelog"],
+        "tags": [
+          "changelog"
+        ],
         "summary": "POST /v1/changelog/dashboard/{projectId}",
         "responses": {
           "200": {
@@ -151,7 +177,9 @@
     },
     "/v1/changelog/dashboard/{projectId}/{id}": {
       "patch": {
-        "tags": ["changelog"],
+        "tags": [
+          "changelog"
+        ],
         "summary": "PATCH /v1/changelog/dashboard/{projectId}/{id}",
         "responses": {
           "200": {
@@ -160,7 +188,9 @@
         }
       },
       "delete": {
-        "tags": ["changelog"],
+        "tags": [
+          "changelog"
+        ],
         "summary": "DELETE /v1/changelog/dashboard/{projectId}/{id}",
         "responses": {
           "200": {
@@ -171,7 +201,9 @@
     },
     "/v1/changelog/fleet/daily": {
       "get": {
-        "tags": ["changelog"],
+        "tags": [
+          "changelog"
+        ],
         "summary": "GET /v1/changelog/fleet/daily",
         "responses": {
           "200": {
@@ -182,7 +214,9 @@
     },
     "/v1/changelog/from-task": {
       "post": {
-        "tags": ["changelog"],
+        "tags": [
+          "changelog"
+        ],
         "summary": "POST /v1/changelog/from-task",
         "responses": {
           "200": {
@@ -193,7 +227,9 @@
     },
     "/v1/cli/approve": {
       "post": {
-        "tags": ["cli"],
+        "tags": [
+          "cli"
+        ],
         "summary": "POST /v1/cli/approve",
         "responses": {
           "200": {
@@ -204,7 +240,9 @@
     },
     "/v1/cli/code": {
       "post": {
-        "tags": ["cli"],
+        "tags": [
+          "cli"
+        ],
         "summary": "POST /v1/cli/code",
         "responses": {
           "200": {
@@ -215,7 +253,9 @@
     },
     "/v1/cli/poll": {
       "get": {
-        "tags": ["cli"],
+        "tags": [
+          "cli"
+        ],
         "summary": "GET /v1/cli/poll",
         "responses": {
           "200": {
@@ -226,7 +266,9 @@
     },
     "/v1/events": {
       "get": {
-        "tags": ["events"],
+        "tags": [
+          "events"
+        ],
         "summary": "GET /v1/events",
         "responses": {
           "200": {
@@ -235,7 +277,9 @@
         }
       },
       "post": {
-        "tags": ["events"],
+        "tags": [
+          "events"
+        ],
         "summary": "POST /v1/events",
         "responses": {
           "200": {
@@ -246,7 +290,9 @@
     },
     "/v1/feedback": {
       "get": {
-        "tags": ["feedback"],
+        "tags": [
+          "feedback"
+        ],
         "summary": "GET /v1/feedback",
         "responses": {
           "200": {
@@ -255,7 +301,9 @@
         }
       },
       "post": {
-        "tags": ["feedback"],
+        "tags": [
+          "feedback"
+        ],
         "summary": "POST /v1/feedback",
         "responses": {
           "200": {
@@ -266,7 +314,9 @@
     },
     "/v1/feedback/board": {
       "get": {
-        "tags": ["feedback"],
+        "tags": [
+          "feedback"
+        ],
         "summary": "GET /v1/feedback/board",
         "responses": {
           "200": {
@@ -277,7 +327,9 @@
     },
     "/v1/feedback/by-project/{slug}": {
       "get": {
-        "tags": ["feedback"],
+        "tags": [
+          "feedback"
+        ],
         "summary": "GET /v1/feedback/by-project/{slug}",
         "responses": {
           "200": {
@@ -288,7 +340,9 @@
     },
     "/v1/feedback/inbox/{projectId}": {
       "get": {
-        "tags": ["feedback"],
+        "tags": [
+          "feedback"
+        ],
         "summary": "GET /v1/feedback/inbox/{projectId}",
         "responses": {
           "200": {
@@ -299,7 +353,9 @@
     },
     "/v1/feedback/{id}": {
       "patch": {
-        "tags": ["feedback"],
+        "tags": [
+          "feedback"
+        ],
         "summary": "PATCH /v1/feedback/{id}",
         "responses": {
           "200": {
@@ -308,7 +364,9 @@
         }
       },
       "delete": {
-        "tags": ["feedback"],
+        "tags": [
+          "feedback"
+        ],
         "summary": "DELETE /v1/feedback/{id}",
         "responses": {
           "200": {
@@ -319,7 +377,9 @@
     },
     "/v1/feedback/{id}/downvote": {
       "post": {
-        "tags": ["feedback"],
+        "tags": [
+          "feedback"
+        ],
         "summary": "POST /v1/feedback/{id}/downvote",
         "responses": {
           "200": {
@@ -328,7 +388,9 @@
         }
       },
       "delete": {
-        "tags": ["feedback"],
+        "tags": [
+          "feedback"
+        ],
         "summary": "DELETE /v1/feedback/{id}/downvote",
         "responses": {
           "200": {
@@ -339,7 +401,9 @@
     },
     "/v1/feedback/{id}/upvote": {
       "post": {
-        "tags": ["feedback"],
+        "tags": [
+          "feedback"
+        ],
         "summary": "POST /v1/feedback/{id}/upvote",
         "responses": {
           "200": {
@@ -348,7 +412,9 @@
         }
       },
       "delete": {
-        "tags": ["feedback"],
+        "tags": [
+          "feedback"
+        ],
         "summary": "DELETE /v1/feedback/{id}/upvote",
         "responses": {
           "200": {
@@ -359,7 +425,9 @@
     },
     "/v1/fleet/metadata": {
       "get": {
-        "tags": ["fleet"],
+        "tags": [
+          "fleet"
+        ],
         "summary": "GET /v1/fleet/metadata",
         "responses": {
           "200": {
@@ -368,7 +436,9 @@
         }
       },
       "post": {
-        "tags": ["fleet"],
+        "tags": [
+          "fleet"
+        ],
         "summary": "POST /v1/fleet/metadata",
         "responses": {
           "200": {
@@ -379,7 +449,9 @@
     },
     "/v1/jobs": {
       "get": {
-        "tags": ["jobs"],
+        "tags": [
+          "jobs"
+        ],
         "summary": "GET /v1/jobs",
         "responses": {
           "200": {
@@ -390,7 +462,9 @@
     },
     "/v1/jobs/{id}/logs": {
       "post": {
-        "tags": ["jobs"],
+        "tags": [
+          "jobs"
+        ],
         "summary": "POST /v1/jobs/{id}/logs",
         "responses": {
           "200": {
@@ -401,7 +475,9 @@
     },
     "/v1/marketing/posts": {
       "get": {
-        "tags": ["marketing"],
+        "tags": [
+          "marketing"
+        ],
         "summary": "GET /v1/marketing/posts",
         "responses": {
           "200": {
@@ -410,7 +486,9 @@
         }
       },
       "post": {
-        "tags": ["marketing"],
+        "tags": [
+          "marketing"
+        ],
         "summary": "POST /v1/marketing/posts",
         "responses": {
           "200": {
@@ -421,7 +499,9 @@
     },
     "/v1/marketing/posts/{id}": {
       "patch": {
-        "tags": ["marketing"],
+        "tags": [
+          "marketing"
+        ],
         "summary": "PATCH /v1/marketing/posts/{id}",
         "responses": {
           "200": {
@@ -432,7 +512,9 @@
     },
     "/v1/projects": {
       "get": {
-        "tags": ["projects"],
+        "tags": [
+          "projects"
+        ],
         "summary": "GET /v1/projects",
         "responses": {
           "200": {
@@ -441,7 +523,9 @@
         }
       },
       "post": {
-        "tags": ["projects"],
+        "tags": [
+          "projects"
+        ],
         "summary": "POST /v1/projects",
         "responses": {
           "200": {
@@ -452,7 +536,9 @@
     },
     "/v1/projects/by-slug/{slug}": {
       "get": {
-        "tags": ["projects"],
+        "tags": [
+          "projects"
+        ],
         "summary": "GET /v1/projects/by-slug/{slug}",
         "responses": {
           "200": {
@@ -463,7 +549,9 @@
     },
     "/v1/projects/readme": {
       "get": {
-        "tags": ["projects"],
+        "tags": [
+          "projects"
+        ],
         "summary": "GET /v1/projects/readme",
         "responses": {
           "200": {
@@ -472,7 +560,9 @@
         }
       },
       "put": {
-        "tags": ["projects"],
+        "tags": [
+          "projects"
+        ],
         "summary": "PUT /v1/projects/readme",
         "responses": {
           "200": {
@@ -483,7 +573,9 @@
     },
     "/v1/projects/{id}": {
       "patch": {
-        "tags": ["projects"],
+        "tags": [
+          "projects"
+        ],
         "summary": "PATCH /v1/projects/{id}",
         "responses": {
           "200": {
@@ -492,7 +584,9 @@
         }
       },
       "delete": {
-        "tags": ["projects"],
+        "tags": [
+          "projects"
+        ],
         "summary": "DELETE /v1/projects/{id}",
         "responses": {
           "200": {
@@ -503,7 +597,9 @@
     },
     "/v1/projects/{id}/readme": {
       "get": {
-        "tags": ["projects"],
+        "tags": [
+          "projects"
+        ],
         "summary": "GET /v1/projects/{id}/readme",
         "responses": {
           "200": {
@@ -512,7 +608,9 @@
         }
       },
       "put": {
-        "tags": ["projects"],
+        "tags": [
+          "projects"
+        ],
         "summary": "PUT /v1/projects/{id}/readme",
         "responses": {
           "200": {
@@ -523,7 +621,9 @@
     },
     "/v1/roadmap/dashboard/{projectId}": {
       "get": {
-        "tags": ["roadmap"],
+        "tags": [
+          "roadmap"
+        ],
         "summary": "GET /v1/roadmap/dashboard/{projectId}",
         "responses": {
           "200": {
@@ -532,7 +632,9 @@
         }
       },
       "post": {
-        "tags": ["roadmap"],
+        "tags": [
+          "roadmap"
+        ],
         "summary": "POST /v1/roadmap/dashboard/{projectId}",
         "responses": {
           "200": {
@@ -543,7 +645,9 @@
     },
     "/v1/roadmap/dashboard/{projectId}/from-feedback/{feedbackId}": {
       "post": {
-        "tags": ["roadmap"],
+        "tags": [
+          "roadmap"
+        ],
         "summary": "POST /v1/roadmap/dashboard/{projectId}/from-feedback/{feedbackId}",
         "responses": {
           "200": {
@@ -554,7 +658,9 @@
     },
     "/v1/roadmap/dashboard/{projectId}/reorder": {
       "post": {
-        "tags": ["roadmap"],
+        "tags": [
+          "roadmap"
+        ],
         "summary": "POST /v1/roadmap/dashboard/{projectId}/reorder",
         "responses": {
           "200": {
@@ -565,7 +671,9 @@
     },
     "/v1/roadmap/dashboard/{projectId}/{id}": {
       "patch": {
-        "tags": ["roadmap"],
+        "tags": [
+          "roadmap"
+        ],
         "summary": "PATCH /v1/roadmap/dashboard/{projectId}/{id}",
         "responses": {
           "200": {
@@ -574,7 +682,9 @@
         }
       },
       "delete": {
-        "tags": ["roadmap"],
+        "tags": [
+          "roadmap"
+        ],
         "summary": "DELETE /v1/roadmap/dashboard/{projectId}/{id}",
         "responses": {
           "200": {
@@ -585,7 +695,9 @@
     },
     "/v1/roadmap/public/{slug}": {
       "get": {
-        "tags": ["roadmap"],
+        "tags": [
+          "roadmap"
+        ],
         "summary": "GET /v1/roadmap/public/{slug}",
         "responses": {
           "200": {
@@ -596,7 +708,9 @@
     },
     "/v1/roadmap/public/{slug}/submit": {
       "post": {
-        "tags": ["roadmap"],
+        "tags": [
+          "roadmap"
+        ],
         "summary": "POST /v1/roadmap/public/{slug}/submit",
         "responses": {
           "200": {
@@ -607,7 +721,9 @@
     },
     "/v1/roadmap/public/{slug}/{id}/vote": {
       "post": {
-        "tags": ["roadmap"],
+        "tags": [
+          "roadmap"
+        ],
         "summary": "POST /v1/roadmap/public/{slug}/{id}/vote",
         "responses": {
           "200": {
@@ -616,7 +732,9 @@
         }
       },
       "delete": {
-        "tags": ["roadmap"],
+        "tags": [
+          "roadmap"
+        ],
         "summary": "DELETE /v1/roadmap/public/{slug}/{id}/vote",
         "responses": {
           "200": {
@@ -627,7 +745,9 @@
     },
     "/v1/secrets": {
       "get": {
-        "tags": ["secrets"],
+        "tags": [
+          "secrets"
+        ],
         "summary": "GET /v1/secrets",
         "responses": {
           "200": {
@@ -636,7 +756,9 @@
         }
       },
       "post": {
-        "tags": ["secrets"],
+        "tags": [
+          "secrets"
+        ],
         "summary": "POST /v1/secrets",
         "responses": {
           "200": {
@@ -647,7 +769,9 @@
     },
     "/v1/secrets/{id}": {
       "delete": {
-        "tags": ["secrets"],
+        "tags": [
+          "secrets"
+        ],
         "summary": "DELETE /v1/secrets/{id}",
         "responses": {
           "200": {
@@ -658,7 +782,9 @@
     },
     "/v1/standards": {
       "get": {
-        "tags": ["standards"],
+        "tags": [
+          "standards"
+        ],
         "summary": "GET /v1/standards",
         "responses": {
           "200": {
@@ -669,7 +795,9 @@
     },
     "/v1/standards/{type}": {
       "get": {
-        "tags": ["standards"],
+        "tags": [
+          "standards"
+        ],
         "summary": "GET /v1/standards/{type}",
         "responses": {
           "200": {
@@ -678,7 +806,9 @@
         }
       },
       "put": {
-        "tags": ["standards"],
+        "tags": [
+          "standards"
+        ],
         "summary": "PUT /v1/standards/{type}",
         "responses": {
           "200": {
@@ -689,7 +819,9 @@
     },
     "/v1/symphony/audit": {
       "get": {
-        "tags": ["symphony"],
+        "tags": [
+          "symphony"
+        ],
         "summary": "GET /v1/symphony/audit",
         "responses": {
           "200": {
@@ -698,7 +830,9 @@
         }
       },
       "post": {
-        "tags": ["symphony"],
+        "tags": [
+          "symphony"
+        ],
         "summary": "POST /v1/symphony/audit",
         "responses": {
           "200": {
@@ -709,7 +843,9 @@
     },
     "/v1/symphony/memory": {
       "get": {
-        "tags": ["symphony"],
+        "tags": [
+          "symphony"
+        ],
         "summary": "GET /v1/symphony/memory",
         "responses": {
           "200": {
@@ -718,7 +854,9 @@
         }
       },
       "put": {
-        "tags": ["symphony"],
+        "tags": [
+          "symphony"
+        ],
         "summary": "PUT /v1/symphony/memory",
         "responses": {
           "200": {
@@ -729,7 +867,9 @@
     },
     "/v1/symphony/runs": {
       "get": {
-        "tags": ["symphony"],
+        "tags": [
+          "symphony"
+        ],
         "summary": "GET /v1/symphony/runs",
         "responses": {
           "200": {
@@ -738,7 +878,9 @@
         }
       },
       "post": {
-        "tags": ["symphony"],
+        "tags": [
+          "symphony"
+        ],
         "summary": "POST /v1/symphony/runs",
         "responses": {
           "200": {
@@ -749,7 +891,9 @@
     },
     "/v1/task-workflows": {
       "get": {
-        "tags": ["task-workflows"],
+        "tags": [
+          "task-workflows"
+        ],
         "summary": "GET /v1/task-workflows",
         "responses": {
           "200": {
@@ -758,7 +902,9 @@
         }
       },
       "post": {
-        "tags": ["task-workflows"],
+        "tags": [
+          "task-workflows"
+        ],
         "summary": "POST /v1/task-workflows",
         "responses": {
           "200": {
@@ -769,7 +915,9 @@
     },
     "/v1/task-workflows/artifacts/{shareToken}": {
       "get": {
-        "tags": ["task-workflows"],
+        "tags": [
+          "task-workflows"
+        ],
         "summary": "GET /v1/task-workflows/artifacts/{shareToken}",
         "responses": {
           "200": {
@@ -780,7 +928,9 @@
     },
     "/v1/task-workflows/{id}": {
       "get": {
-        "tags": ["task-workflows"],
+        "tags": [
+          "task-workflows"
+        ],
         "summary": "GET /v1/task-workflows/{id}",
         "responses": {
           "200": {
@@ -789,7 +939,9 @@
         }
       },
       "patch": {
-        "tags": ["task-workflows"],
+        "tags": [
+          "task-workflows"
+        ],
         "summary": "PATCH /v1/task-workflows/{id}",
         "responses": {
           "200": {
@@ -800,7 +952,9 @@
     },
     "/v1/task-workflows/{id}/artifacts": {
       "post": {
-        "tags": ["task-workflows"],
+        "tags": [
+          "task-workflows"
+        ],
         "summary": "POST /v1/task-workflows/{id}/artifacts",
         "responses": {
           "200": {
@@ -811,7 +965,9 @@
     },
     "/v1/task-workflows/{id}/runs": {
       "post": {
-        "tags": ["task-workflows"],
+        "tags": [
+          "task-workflows"
+        ],
         "summary": "POST /v1/task-workflows/{id}/runs",
         "responses": {
           "200": {
@@ -822,7 +978,9 @@
     },
     "/v1/tasks": {
       "get": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "GET /v1/tasks",
         "responses": {
           "200": {
@@ -831,7 +989,9 @@
         }
       },
       "post": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "POST /v1/tasks",
         "responses": {
           "200": {
@@ -842,7 +1002,9 @@
     },
     "/v1/tasks/claim": {
       "post": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "POST /v1/tasks/claim",
         "responses": {
           "200": {
@@ -853,7 +1015,9 @@
     },
     "/v1/tasks/{id}": {
       "get": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "GET /v1/tasks/{id}",
         "responses": {
           "200": {
@@ -862,7 +1026,9 @@
         }
       },
       "patch": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "PATCH /v1/tasks/{id}",
         "responses": {
           "200": {
@@ -871,7 +1037,9 @@
         }
       },
       "delete": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "DELETE /v1/tasks/{id}",
         "responses": {
           "200": {
@@ -882,7 +1050,9 @@
     },
     "/v1/tasks/{id}/comments": {
       "get": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "GET /v1/tasks/{id}/comments",
         "responses": {
           "200": {
@@ -891,7 +1061,9 @@
         }
       },
       "post": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "POST /v1/tasks/{id}/comments",
         "responses": {
           "200": {
@@ -902,7 +1074,9 @@
     },
     "/v1/tasks/{id}/complete": {
       "post": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "POST /v1/tasks/{id}/complete",
         "responses": {
           "200": {
@@ -913,7 +1087,9 @@
     },
     "/v1/tasks/{id}/fail": {
       "post": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "POST /v1/tasks/{id}/fail",
         "responses": {
           "200": {
@@ -924,7 +1100,9 @@
     },
     "/v1/tasks/{id}/heartbeat": {
       "post": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "POST /v1/tasks/{id}/heartbeat",
         "responses": {
           "200": {
@@ -935,7 +1113,9 @@
     },
     "/v1/testimonials": {
       "get": {
-        "tags": ["testimonials"],
+        "tags": [
+          "testimonials"
+        ],
         "summary": "GET /v1/testimonials",
         "responses": {
           "200": {
@@ -944,7 +1124,9 @@
         }
       },
       "post": {
-        "tags": ["testimonials"],
+        "tags": [
+          "testimonials"
+        ],
         "summary": "POST /v1/testimonials",
         "responses": {
           "200": {
@@ -955,7 +1137,9 @@
     },
     "/v1/testimonials/all": {
       "get": {
-        "tags": ["testimonials"],
+        "tags": [
+          "testimonials"
+        ],
         "summary": "GET /v1/testimonials/all",
         "responses": {
           "200": {
@@ -966,7 +1150,9 @@
     },
     "/v1/testimonials/by-project/{slug}": {
       "get": {
-        "tags": ["testimonials"],
+        "tags": [
+          "testimonials"
+        ],
         "summary": "GET /v1/testimonials/by-project/{slug}",
         "responses": {
           "200": {
@@ -975,7 +1161,9 @@
         }
       },
       "post": {
-        "tags": ["testimonials"],
+        "tags": [
+          "testimonials"
+        ],
         "summary": "POST /v1/testimonials/by-project/{slug}",
         "responses": {
           "200": {
@@ -986,7 +1174,9 @@
     },
     "/v1/testimonials/dashboard/{projectId}": {
       "post": {
-        "tags": ["testimonials"],
+        "tags": [
+          "testimonials"
+        ],
         "summary": "POST /v1/testimonials/dashboard/{projectId}",
         "responses": {
           "200": {
@@ -997,7 +1187,9 @@
     },
     "/v1/testimonials/{id}": {
       "patch": {
-        "tags": ["testimonials"],
+        "tags": [
+          "testimonials"
+        ],
         "summary": "PATCH /v1/testimonials/{id}",
         "responses": {
           "200": {
@@ -1006,7 +1198,9 @@
         }
       },
       "delete": {
-        "tags": ["testimonials"],
+        "tags": [
+          "testimonials"
+        ],
         "summary": "DELETE /v1/testimonials/{id}",
         "responses": {
           "200": {
@@ -1017,7 +1211,9 @@
     },
     "/v1/upload": {
       "post": {
-        "tags": ["upload"],
+        "tags": [
+          "upload"
+        ],
         "summary": "POST /v1/upload",
         "responses": {
           "200": {
@@ -1028,7 +1224,9 @@
     },
     "/v1/waitlist": {
       "get": {
-        "tags": ["waitlist"],
+        "tags": [
+          "waitlist"
+        ],
         "summary": "GET /v1/waitlist",
         "responses": {
           "200": {
@@ -1037,7 +1235,9 @@
         }
       },
       "post": {
-        "tags": ["waitlist"],
+        "tags": [
+          "waitlist"
+        ],
         "summary": "POST /v1/waitlist",
         "responses": {
           "200": {
@@ -1048,7 +1248,9 @@
     },
     "/v1/waitlist/count": {
       "get": {
-        "tags": ["waitlist"],
+        "tags": [
+          "waitlist"
+        ],
         "summary": "GET /v1/waitlist/count",
         "responses": {
           "200": {
@@ -1059,7 +1261,9 @@
     },
     "/v1/waitlist/{id}": {
       "delete": {
-        "tags": ["waitlist"],
+        "tags": [
+          "waitlist"
+        ],
         "summary": "DELETE /v1/waitlist/{id}",
         "responses": {
           "200": {

--- a/biome.json
+++ b/biome.json
@@ -19,6 +19,7 @@
       "!**/pnpm-lock.yaml",
       "!**/tsconfig.tsbuildinfo",
       "!**/packages/cli/templates",
+      "!**/openapi.json",
       "!**/design.html",
       "!**/*.css",
       "!**/*.astro"

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -14,7 +14,9 @@
   "paths": {
     "/health": {
       "get": {
-        "tags": ["system"],
+        "tags": [
+          "system"
+        ],
         "summary": "GET /health",
         "responses": {
           "200": {
@@ -25,7 +27,9 @@
     },
     "/v1/ai/chat/completions": {
       "post": {
-        "tags": ["ai"],
+        "tags": [
+          "ai"
+        ],
         "summary": "POST /v1/ai/chat/completions",
         "responses": {
           "200": {
@@ -36,7 +40,9 @@
     },
     "/v1/ai/config": {
       "get": {
-        "tags": ["ai"],
+        "tags": [
+          "ai"
+        ],
         "summary": "GET /v1/ai/config",
         "responses": {
           "200": {
@@ -45,7 +51,9 @@
         }
       },
       "put": {
-        "tags": ["ai"],
+        "tags": [
+          "ai"
+        ],
         "summary": "PUT /v1/ai/config",
         "responses": {
           "200": {
@@ -54,7 +62,9 @@
         }
       },
       "delete": {
-        "tags": ["ai"],
+        "tags": [
+          "ai"
+        ],
         "summary": "DELETE /v1/ai/config",
         "responses": {
           "200": {
@@ -65,7 +75,9 @@
     },
     "/v1/ai/embeddings": {
       "post": {
-        "tags": ["ai"],
+        "tags": [
+          "ai"
+        ],
         "summary": "POST /v1/ai/embeddings",
         "responses": {
           "200": {
@@ -76,7 +88,9 @@
     },
     "/v1/ai/requests": {
       "get": {
-        "tags": ["ai"],
+        "tags": [
+          "ai"
+        ],
         "summary": "GET /v1/ai/requests",
         "responses": {
           "200": {
@@ -87,7 +101,9 @@
     },
     "/v1/ai/usage": {
       "get": {
-        "tags": ["ai"],
+        "tags": [
+          "ai"
+        ],
         "summary": "GET /v1/ai/usage",
         "responses": {
           "200": {
@@ -98,7 +114,9 @@
     },
     "/v1/auth/logout": {
       "post": {
-        "tags": ["auth"],
+        "tags": [
+          "auth"
+        ],
         "summary": "POST /v1/auth/logout",
         "responses": {
           "200": {
@@ -109,7 +127,9 @@
     },
     "/v1/auth/session": {
       "get": {
-        "tags": ["auth"],
+        "tags": [
+          "auth"
+        ],
         "summary": "GET /v1/auth/session",
         "responses": {
           "200": {
@@ -120,7 +140,9 @@
     },
     "/v1/changelog": {
       "get": {
-        "tags": ["changelog"],
+        "tags": [
+          "changelog"
+        ],
         "summary": "GET /v1/changelog",
         "responses": {
           "200": {
@@ -131,7 +153,9 @@
     },
     "/v1/changelog/dashboard/{projectId}": {
       "get": {
-        "tags": ["changelog"],
+        "tags": [
+          "changelog"
+        ],
         "summary": "GET /v1/changelog/dashboard/{projectId}",
         "responses": {
           "200": {
@@ -140,7 +164,9 @@
         }
       },
       "post": {
-        "tags": ["changelog"],
+        "tags": [
+          "changelog"
+        ],
         "summary": "POST /v1/changelog/dashboard/{projectId}",
         "responses": {
           "200": {
@@ -151,7 +177,9 @@
     },
     "/v1/changelog/dashboard/{projectId}/{id}": {
       "patch": {
-        "tags": ["changelog"],
+        "tags": [
+          "changelog"
+        ],
         "summary": "PATCH /v1/changelog/dashboard/{projectId}/{id}",
         "responses": {
           "200": {
@@ -160,7 +188,9 @@
         }
       },
       "delete": {
-        "tags": ["changelog"],
+        "tags": [
+          "changelog"
+        ],
         "summary": "DELETE /v1/changelog/dashboard/{projectId}/{id}",
         "responses": {
           "200": {
@@ -171,7 +201,9 @@
     },
     "/v1/changelog/fleet/daily": {
       "get": {
-        "tags": ["changelog"],
+        "tags": [
+          "changelog"
+        ],
         "summary": "GET /v1/changelog/fleet/daily",
         "responses": {
           "200": {
@@ -182,7 +214,9 @@
     },
     "/v1/changelog/from-task": {
       "post": {
-        "tags": ["changelog"],
+        "tags": [
+          "changelog"
+        ],
         "summary": "POST /v1/changelog/from-task",
         "responses": {
           "200": {
@@ -193,7 +227,9 @@
     },
     "/v1/cli/approve": {
       "post": {
-        "tags": ["cli"],
+        "tags": [
+          "cli"
+        ],
         "summary": "POST /v1/cli/approve",
         "responses": {
           "200": {
@@ -204,7 +240,9 @@
     },
     "/v1/cli/code": {
       "post": {
-        "tags": ["cli"],
+        "tags": [
+          "cli"
+        ],
         "summary": "POST /v1/cli/code",
         "responses": {
           "200": {
@@ -215,7 +253,9 @@
     },
     "/v1/cli/poll": {
       "get": {
-        "tags": ["cli"],
+        "tags": [
+          "cli"
+        ],
         "summary": "GET /v1/cli/poll",
         "responses": {
           "200": {
@@ -226,7 +266,9 @@
     },
     "/v1/events": {
       "get": {
-        "tags": ["events"],
+        "tags": [
+          "events"
+        ],
         "summary": "GET /v1/events",
         "responses": {
           "200": {
@@ -235,7 +277,9 @@
         }
       },
       "post": {
-        "tags": ["events"],
+        "tags": [
+          "events"
+        ],
         "summary": "POST /v1/events",
         "responses": {
           "200": {
@@ -246,7 +290,9 @@
     },
     "/v1/feedback": {
       "get": {
-        "tags": ["feedback"],
+        "tags": [
+          "feedback"
+        ],
         "summary": "GET /v1/feedback",
         "responses": {
           "200": {
@@ -255,7 +301,9 @@
         }
       },
       "post": {
-        "tags": ["feedback"],
+        "tags": [
+          "feedback"
+        ],
         "summary": "POST /v1/feedback",
         "responses": {
           "200": {
@@ -266,7 +314,9 @@
     },
     "/v1/feedback/board": {
       "get": {
-        "tags": ["feedback"],
+        "tags": [
+          "feedback"
+        ],
         "summary": "GET /v1/feedback/board",
         "responses": {
           "200": {
@@ -277,7 +327,9 @@
     },
     "/v1/feedback/by-project/{slug}": {
       "get": {
-        "tags": ["feedback"],
+        "tags": [
+          "feedback"
+        ],
         "summary": "GET /v1/feedback/by-project/{slug}",
         "responses": {
           "200": {
@@ -288,7 +340,9 @@
     },
     "/v1/feedback/inbox/{projectId}": {
       "get": {
-        "tags": ["feedback"],
+        "tags": [
+          "feedback"
+        ],
         "summary": "GET /v1/feedback/inbox/{projectId}",
         "responses": {
           "200": {
@@ -299,7 +353,9 @@
     },
     "/v1/feedback/{id}": {
       "patch": {
-        "tags": ["feedback"],
+        "tags": [
+          "feedback"
+        ],
         "summary": "PATCH /v1/feedback/{id}",
         "responses": {
           "200": {
@@ -308,7 +364,9 @@
         }
       },
       "delete": {
-        "tags": ["feedback"],
+        "tags": [
+          "feedback"
+        ],
         "summary": "DELETE /v1/feedback/{id}",
         "responses": {
           "200": {
@@ -319,7 +377,9 @@
     },
     "/v1/feedback/{id}/downvote": {
       "post": {
-        "tags": ["feedback"],
+        "tags": [
+          "feedback"
+        ],
         "summary": "POST /v1/feedback/{id}/downvote",
         "responses": {
           "200": {
@@ -328,7 +388,9 @@
         }
       },
       "delete": {
-        "tags": ["feedback"],
+        "tags": [
+          "feedback"
+        ],
         "summary": "DELETE /v1/feedback/{id}/downvote",
         "responses": {
           "200": {
@@ -339,7 +401,9 @@
     },
     "/v1/feedback/{id}/upvote": {
       "post": {
-        "tags": ["feedback"],
+        "tags": [
+          "feedback"
+        ],
         "summary": "POST /v1/feedback/{id}/upvote",
         "responses": {
           "200": {
@@ -348,7 +412,9 @@
         }
       },
       "delete": {
-        "tags": ["feedback"],
+        "tags": [
+          "feedback"
+        ],
         "summary": "DELETE /v1/feedback/{id}/upvote",
         "responses": {
           "200": {
@@ -359,7 +425,9 @@
     },
     "/v1/fleet/metadata": {
       "get": {
-        "tags": ["fleet"],
+        "tags": [
+          "fleet"
+        ],
         "summary": "GET /v1/fleet/metadata",
         "responses": {
           "200": {
@@ -368,7 +436,9 @@
         }
       },
       "post": {
-        "tags": ["fleet"],
+        "tags": [
+          "fleet"
+        ],
         "summary": "POST /v1/fleet/metadata",
         "responses": {
           "200": {
@@ -379,7 +449,9 @@
     },
     "/v1/jobs": {
       "get": {
-        "tags": ["jobs"],
+        "tags": [
+          "jobs"
+        ],
         "summary": "GET /v1/jobs",
         "responses": {
           "200": {
@@ -390,7 +462,9 @@
     },
     "/v1/jobs/{id}/logs": {
       "post": {
-        "tags": ["jobs"],
+        "tags": [
+          "jobs"
+        ],
         "summary": "POST /v1/jobs/{id}/logs",
         "responses": {
           "200": {
@@ -401,7 +475,9 @@
     },
     "/v1/marketing/posts": {
       "get": {
-        "tags": ["marketing"],
+        "tags": [
+          "marketing"
+        ],
         "summary": "GET /v1/marketing/posts",
         "responses": {
           "200": {
@@ -410,7 +486,9 @@
         }
       },
       "post": {
-        "tags": ["marketing"],
+        "tags": [
+          "marketing"
+        ],
         "summary": "POST /v1/marketing/posts",
         "responses": {
           "200": {
@@ -421,7 +499,9 @@
     },
     "/v1/marketing/posts/{id}": {
       "patch": {
-        "tags": ["marketing"],
+        "tags": [
+          "marketing"
+        ],
         "summary": "PATCH /v1/marketing/posts/{id}",
         "responses": {
           "200": {
@@ -432,7 +512,9 @@
     },
     "/v1/projects": {
       "get": {
-        "tags": ["projects"],
+        "tags": [
+          "projects"
+        ],
         "summary": "GET /v1/projects",
         "responses": {
           "200": {
@@ -441,7 +523,9 @@
         }
       },
       "post": {
-        "tags": ["projects"],
+        "tags": [
+          "projects"
+        ],
         "summary": "POST /v1/projects",
         "responses": {
           "200": {
@@ -452,7 +536,9 @@
     },
     "/v1/projects/by-slug/{slug}": {
       "get": {
-        "tags": ["projects"],
+        "tags": [
+          "projects"
+        ],
         "summary": "GET /v1/projects/by-slug/{slug}",
         "responses": {
           "200": {
@@ -463,7 +549,9 @@
     },
     "/v1/projects/readme": {
       "get": {
-        "tags": ["projects"],
+        "tags": [
+          "projects"
+        ],
         "summary": "GET /v1/projects/readme",
         "responses": {
           "200": {
@@ -472,7 +560,9 @@
         }
       },
       "put": {
-        "tags": ["projects"],
+        "tags": [
+          "projects"
+        ],
         "summary": "PUT /v1/projects/readme",
         "responses": {
           "200": {
@@ -483,7 +573,9 @@
     },
     "/v1/projects/{id}": {
       "patch": {
-        "tags": ["projects"],
+        "tags": [
+          "projects"
+        ],
         "summary": "PATCH /v1/projects/{id}",
         "responses": {
           "200": {
@@ -492,7 +584,9 @@
         }
       },
       "delete": {
-        "tags": ["projects"],
+        "tags": [
+          "projects"
+        ],
         "summary": "DELETE /v1/projects/{id}",
         "responses": {
           "200": {
@@ -503,7 +597,9 @@
     },
     "/v1/projects/{id}/readme": {
       "get": {
-        "tags": ["projects"],
+        "tags": [
+          "projects"
+        ],
         "summary": "GET /v1/projects/{id}/readme",
         "responses": {
           "200": {
@@ -512,7 +608,9 @@
         }
       },
       "put": {
-        "tags": ["projects"],
+        "tags": [
+          "projects"
+        ],
         "summary": "PUT /v1/projects/{id}/readme",
         "responses": {
           "200": {
@@ -523,7 +621,9 @@
     },
     "/v1/roadmap/dashboard/{projectId}": {
       "get": {
-        "tags": ["roadmap"],
+        "tags": [
+          "roadmap"
+        ],
         "summary": "GET /v1/roadmap/dashboard/{projectId}",
         "responses": {
           "200": {
@@ -532,7 +632,9 @@
         }
       },
       "post": {
-        "tags": ["roadmap"],
+        "tags": [
+          "roadmap"
+        ],
         "summary": "POST /v1/roadmap/dashboard/{projectId}",
         "responses": {
           "200": {
@@ -543,7 +645,9 @@
     },
     "/v1/roadmap/dashboard/{projectId}/from-feedback/{feedbackId}": {
       "post": {
-        "tags": ["roadmap"],
+        "tags": [
+          "roadmap"
+        ],
         "summary": "POST /v1/roadmap/dashboard/{projectId}/from-feedback/{feedbackId}",
         "responses": {
           "200": {
@@ -554,7 +658,9 @@
     },
     "/v1/roadmap/dashboard/{projectId}/reorder": {
       "post": {
-        "tags": ["roadmap"],
+        "tags": [
+          "roadmap"
+        ],
         "summary": "POST /v1/roadmap/dashboard/{projectId}/reorder",
         "responses": {
           "200": {
@@ -565,7 +671,9 @@
     },
     "/v1/roadmap/dashboard/{projectId}/{id}": {
       "patch": {
-        "tags": ["roadmap"],
+        "tags": [
+          "roadmap"
+        ],
         "summary": "PATCH /v1/roadmap/dashboard/{projectId}/{id}",
         "responses": {
           "200": {
@@ -574,7 +682,9 @@
         }
       },
       "delete": {
-        "tags": ["roadmap"],
+        "tags": [
+          "roadmap"
+        ],
         "summary": "DELETE /v1/roadmap/dashboard/{projectId}/{id}",
         "responses": {
           "200": {
@@ -585,7 +695,9 @@
     },
     "/v1/roadmap/public/{slug}": {
       "get": {
-        "tags": ["roadmap"],
+        "tags": [
+          "roadmap"
+        ],
         "summary": "GET /v1/roadmap/public/{slug}",
         "responses": {
           "200": {
@@ -596,7 +708,9 @@
     },
     "/v1/roadmap/public/{slug}/submit": {
       "post": {
-        "tags": ["roadmap"],
+        "tags": [
+          "roadmap"
+        ],
         "summary": "POST /v1/roadmap/public/{slug}/submit",
         "responses": {
           "200": {
@@ -607,7 +721,9 @@
     },
     "/v1/roadmap/public/{slug}/{id}/vote": {
       "post": {
-        "tags": ["roadmap"],
+        "tags": [
+          "roadmap"
+        ],
         "summary": "POST /v1/roadmap/public/{slug}/{id}/vote",
         "responses": {
           "200": {
@@ -616,7 +732,9 @@
         }
       },
       "delete": {
-        "tags": ["roadmap"],
+        "tags": [
+          "roadmap"
+        ],
         "summary": "DELETE /v1/roadmap/public/{slug}/{id}/vote",
         "responses": {
           "200": {
@@ -627,7 +745,9 @@
     },
     "/v1/secrets": {
       "get": {
-        "tags": ["secrets"],
+        "tags": [
+          "secrets"
+        ],
         "summary": "GET /v1/secrets",
         "responses": {
           "200": {
@@ -636,7 +756,9 @@
         }
       },
       "post": {
-        "tags": ["secrets"],
+        "tags": [
+          "secrets"
+        ],
         "summary": "POST /v1/secrets",
         "responses": {
           "200": {
@@ -647,7 +769,9 @@
     },
     "/v1/secrets/{id}": {
       "delete": {
-        "tags": ["secrets"],
+        "tags": [
+          "secrets"
+        ],
         "summary": "DELETE /v1/secrets/{id}",
         "responses": {
           "200": {
@@ -658,7 +782,9 @@
     },
     "/v1/standards": {
       "get": {
-        "tags": ["standards"],
+        "tags": [
+          "standards"
+        ],
         "summary": "GET /v1/standards",
         "responses": {
           "200": {
@@ -669,7 +795,9 @@
     },
     "/v1/standards/{type}": {
       "get": {
-        "tags": ["standards"],
+        "tags": [
+          "standards"
+        ],
         "summary": "GET /v1/standards/{type}",
         "responses": {
           "200": {
@@ -678,7 +806,9 @@
         }
       },
       "put": {
-        "tags": ["standards"],
+        "tags": [
+          "standards"
+        ],
         "summary": "PUT /v1/standards/{type}",
         "responses": {
           "200": {
@@ -689,7 +819,9 @@
     },
     "/v1/symphony/audit": {
       "get": {
-        "tags": ["symphony"],
+        "tags": [
+          "symphony"
+        ],
         "summary": "GET /v1/symphony/audit",
         "responses": {
           "200": {
@@ -698,7 +830,9 @@
         }
       },
       "post": {
-        "tags": ["symphony"],
+        "tags": [
+          "symphony"
+        ],
         "summary": "POST /v1/symphony/audit",
         "responses": {
           "200": {
@@ -709,7 +843,9 @@
     },
     "/v1/symphony/memory": {
       "get": {
-        "tags": ["symphony"],
+        "tags": [
+          "symphony"
+        ],
         "summary": "GET /v1/symphony/memory",
         "responses": {
           "200": {
@@ -718,7 +854,9 @@
         }
       },
       "put": {
-        "tags": ["symphony"],
+        "tags": [
+          "symphony"
+        ],
         "summary": "PUT /v1/symphony/memory",
         "responses": {
           "200": {
@@ -729,7 +867,9 @@
     },
     "/v1/symphony/runs": {
       "get": {
-        "tags": ["symphony"],
+        "tags": [
+          "symphony"
+        ],
         "summary": "GET /v1/symphony/runs",
         "responses": {
           "200": {
@@ -738,7 +878,9 @@
         }
       },
       "post": {
-        "tags": ["symphony"],
+        "tags": [
+          "symphony"
+        ],
         "summary": "POST /v1/symphony/runs",
         "responses": {
           "200": {
@@ -749,7 +891,9 @@
     },
     "/v1/task-workflows": {
       "get": {
-        "tags": ["task-workflows"],
+        "tags": [
+          "task-workflows"
+        ],
         "summary": "GET /v1/task-workflows",
         "responses": {
           "200": {
@@ -758,7 +902,9 @@
         }
       },
       "post": {
-        "tags": ["task-workflows"],
+        "tags": [
+          "task-workflows"
+        ],
         "summary": "POST /v1/task-workflows",
         "responses": {
           "200": {
@@ -769,7 +915,9 @@
     },
     "/v1/task-workflows/artifacts/{shareToken}": {
       "get": {
-        "tags": ["task-workflows"],
+        "tags": [
+          "task-workflows"
+        ],
         "summary": "GET /v1/task-workflows/artifacts/{shareToken}",
         "responses": {
           "200": {
@@ -780,7 +928,9 @@
     },
     "/v1/task-workflows/{id}": {
       "get": {
-        "tags": ["task-workflows"],
+        "tags": [
+          "task-workflows"
+        ],
         "summary": "GET /v1/task-workflows/{id}",
         "responses": {
           "200": {
@@ -789,7 +939,9 @@
         }
       },
       "patch": {
-        "tags": ["task-workflows"],
+        "tags": [
+          "task-workflows"
+        ],
         "summary": "PATCH /v1/task-workflows/{id}",
         "responses": {
           "200": {
@@ -800,7 +952,9 @@
     },
     "/v1/task-workflows/{id}/artifacts": {
       "post": {
-        "tags": ["task-workflows"],
+        "tags": [
+          "task-workflows"
+        ],
         "summary": "POST /v1/task-workflows/{id}/artifacts",
         "responses": {
           "200": {
@@ -811,7 +965,9 @@
     },
     "/v1/task-workflows/{id}/runs": {
       "post": {
-        "tags": ["task-workflows"],
+        "tags": [
+          "task-workflows"
+        ],
         "summary": "POST /v1/task-workflows/{id}/runs",
         "responses": {
           "200": {
@@ -822,7 +978,9 @@
     },
     "/v1/tasks": {
       "get": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "GET /v1/tasks",
         "responses": {
           "200": {
@@ -831,7 +989,9 @@
         }
       },
       "post": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "POST /v1/tasks",
         "responses": {
           "200": {
@@ -842,7 +1002,9 @@
     },
     "/v1/tasks/claim": {
       "post": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "POST /v1/tasks/claim",
         "responses": {
           "200": {
@@ -853,7 +1015,9 @@
     },
     "/v1/tasks/{id}": {
       "get": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "GET /v1/tasks/{id}",
         "responses": {
           "200": {
@@ -862,7 +1026,9 @@
         }
       },
       "patch": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "PATCH /v1/tasks/{id}",
         "responses": {
           "200": {
@@ -871,7 +1037,9 @@
         }
       },
       "delete": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "DELETE /v1/tasks/{id}",
         "responses": {
           "200": {
@@ -882,7 +1050,9 @@
     },
     "/v1/tasks/{id}/comments": {
       "get": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "GET /v1/tasks/{id}/comments",
         "responses": {
           "200": {
@@ -891,7 +1061,9 @@
         }
       },
       "post": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "POST /v1/tasks/{id}/comments",
         "responses": {
           "200": {
@@ -902,7 +1074,9 @@
     },
     "/v1/tasks/{id}/complete": {
       "post": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "POST /v1/tasks/{id}/complete",
         "responses": {
           "200": {
@@ -913,7 +1087,9 @@
     },
     "/v1/tasks/{id}/fail": {
       "post": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "POST /v1/tasks/{id}/fail",
         "responses": {
           "200": {
@@ -924,7 +1100,9 @@
     },
     "/v1/tasks/{id}/heartbeat": {
       "post": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "POST /v1/tasks/{id}/heartbeat",
         "responses": {
           "200": {
@@ -935,7 +1113,9 @@
     },
     "/v1/testimonials": {
       "get": {
-        "tags": ["testimonials"],
+        "tags": [
+          "testimonials"
+        ],
         "summary": "GET /v1/testimonials",
         "responses": {
           "200": {
@@ -944,7 +1124,9 @@
         }
       },
       "post": {
-        "tags": ["testimonials"],
+        "tags": [
+          "testimonials"
+        ],
         "summary": "POST /v1/testimonials",
         "responses": {
           "200": {
@@ -955,7 +1137,9 @@
     },
     "/v1/testimonials/all": {
       "get": {
-        "tags": ["testimonials"],
+        "tags": [
+          "testimonials"
+        ],
         "summary": "GET /v1/testimonials/all",
         "responses": {
           "200": {
@@ -966,7 +1150,9 @@
     },
     "/v1/testimonials/by-project/{slug}": {
       "get": {
-        "tags": ["testimonials"],
+        "tags": [
+          "testimonials"
+        ],
         "summary": "GET /v1/testimonials/by-project/{slug}",
         "responses": {
           "200": {
@@ -975,7 +1161,9 @@
         }
       },
       "post": {
-        "tags": ["testimonials"],
+        "tags": [
+          "testimonials"
+        ],
         "summary": "POST /v1/testimonials/by-project/{slug}",
         "responses": {
           "200": {
@@ -986,7 +1174,9 @@
     },
     "/v1/testimonials/dashboard/{projectId}": {
       "post": {
-        "tags": ["testimonials"],
+        "tags": [
+          "testimonials"
+        ],
         "summary": "POST /v1/testimonials/dashboard/{projectId}",
         "responses": {
           "200": {
@@ -997,7 +1187,9 @@
     },
     "/v1/testimonials/{id}": {
       "patch": {
-        "tags": ["testimonials"],
+        "tags": [
+          "testimonials"
+        ],
         "summary": "PATCH /v1/testimonials/{id}",
         "responses": {
           "200": {
@@ -1006,7 +1198,9 @@
         }
       },
       "delete": {
-        "tags": ["testimonials"],
+        "tags": [
+          "testimonials"
+        ],
         "summary": "DELETE /v1/testimonials/{id}",
         "responses": {
           "200": {
@@ -1017,7 +1211,9 @@
     },
     "/v1/upload": {
       "post": {
-        "tags": ["upload"],
+        "tags": [
+          "upload"
+        ],
         "summary": "POST /v1/upload",
         "responses": {
           "200": {
@@ -1028,7 +1224,9 @@
     },
     "/v1/waitlist": {
       "get": {
-        "tags": ["waitlist"],
+        "tags": [
+          "waitlist"
+        ],
         "summary": "GET /v1/waitlist",
         "responses": {
           "200": {
@@ -1037,7 +1235,9 @@
         }
       },
       "post": {
-        "tags": ["waitlist"],
+        "tags": [
+          "waitlist"
+        ],
         "summary": "POST /v1/waitlist",
         "responses": {
           "200": {
@@ -1048,7 +1248,9 @@
     },
     "/v1/waitlist/count": {
       "get": {
-        "tags": ["waitlist"],
+        "tags": [
+          "waitlist"
+        ],
         "summary": "GET /v1/waitlist/count",
         "responses": {
           "200": {
@@ -1059,7 +1261,9 @@
     },
     "/v1/waitlist/{id}": {
       "delete": {
-        "tags": ["waitlist"],
+        "tags": [
+          "waitlist"
+        ],
         "summary": "DELETE /v1/waitlist/{id}",
         "responses": {
           "200": {

--- a/packages/cli/src/openapi.json
+++ b/packages/cli/src/openapi.json
@@ -14,7 +14,9 @@
   "paths": {
     "/health": {
       "get": {
-        "tags": ["system"],
+        "tags": [
+          "system"
+        ],
         "summary": "GET /health",
         "responses": {
           "200": {
@@ -25,7 +27,9 @@
     },
     "/v1/ai/chat/completions": {
       "post": {
-        "tags": ["ai"],
+        "tags": [
+          "ai"
+        ],
         "summary": "POST /v1/ai/chat/completions",
         "responses": {
           "200": {
@@ -36,7 +40,9 @@
     },
     "/v1/ai/config": {
       "get": {
-        "tags": ["ai"],
+        "tags": [
+          "ai"
+        ],
         "summary": "GET /v1/ai/config",
         "responses": {
           "200": {
@@ -45,7 +51,9 @@
         }
       },
       "put": {
-        "tags": ["ai"],
+        "tags": [
+          "ai"
+        ],
         "summary": "PUT /v1/ai/config",
         "responses": {
           "200": {
@@ -54,7 +62,9 @@
         }
       },
       "delete": {
-        "tags": ["ai"],
+        "tags": [
+          "ai"
+        ],
         "summary": "DELETE /v1/ai/config",
         "responses": {
           "200": {
@@ -65,7 +75,9 @@
     },
     "/v1/ai/embeddings": {
       "post": {
-        "tags": ["ai"],
+        "tags": [
+          "ai"
+        ],
         "summary": "POST /v1/ai/embeddings",
         "responses": {
           "200": {
@@ -76,7 +88,9 @@
     },
     "/v1/ai/requests": {
       "get": {
-        "tags": ["ai"],
+        "tags": [
+          "ai"
+        ],
         "summary": "GET /v1/ai/requests",
         "responses": {
           "200": {
@@ -87,7 +101,9 @@
     },
     "/v1/ai/usage": {
       "get": {
-        "tags": ["ai"],
+        "tags": [
+          "ai"
+        ],
         "summary": "GET /v1/ai/usage",
         "responses": {
           "200": {
@@ -98,7 +114,9 @@
     },
     "/v1/auth/logout": {
       "post": {
-        "tags": ["auth"],
+        "tags": [
+          "auth"
+        ],
         "summary": "POST /v1/auth/logout",
         "responses": {
           "200": {
@@ -109,7 +127,9 @@
     },
     "/v1/auth/session": {
       "get": {
-        "tags": ["auth"],
+        "tags": [
+          "auth"
+        ],
         "summary": "GET /v1/auth/session",
         "responses": {
           "200": {
@@ -120,7 +140,9 @@
     },
     "/v1/changelog": {
       "get": {
-        "tags": ["changelog"],
+        "tags": [
+          "changelog"
+        ],
         "summary": "GET /v1/changelog",
         "responses": {
           "200": {
@@ -131,7 +153,9 @@
     },
     "/v1/changelog/dashboard/{projectId}": {
       "get": {
-        "tags": ["changelog"],
+        "tags": [
+          "changelog"
+        ],
         "summary": "GET /v1/changelog/dashboard/{projectId}",
         "responses": {
           "200": {
@@ -140,7 +164,9 @@
         }
       },
       "post": {
-        "tags": ["changelog"],
+        "tags": [
+          "changelog"
+        ],
         "summary": "POST /v1/changelog/dashboard/{projectId}",
         "responses": {
           "200": {
@@ -151,7 +177,9 @@
     },
     "/v1/changelog/dashboard/{projectId}/{id}": {
       "patch": {
-        "tags": ["changelog"],
+        "tags": [
+          "changelog"
+        ],
         "summary": "PATCH /v1/changelog/dashboard/{projectId}/{id}",
         "responses": {
           "200": {
@@ -160,7 +188,9 @@
         }
       },
       "delete": {
-        "tags": ["changelog"],
+        "tags": [
+          "changelog"
+        ],
         "summary": "DELETE /v1/changelog/dashboard/{projectId}/{id}",
         "responses": {
           "200": {
@@ -171,7 +201,9 @@
     },
     "/v1/changelog/fleet/daily": {
       "get": {
-        "tags": ["changelog"],
+        "tags": [
+          "changelog"
+        ],
         "summary": "GET /v1/changelog/fleet/daily",
         "responses": {
           "200": {
@@ -182,7 +214,9 @@
     },
     "/v1/changelog/from-task": {
       "post": {
-        "tags": ["changelog"],
+        "tags": [
+          "changelog"
+        ],
         "summary": "POST /v1/changelog/from-task",
         "responses": {
           "200": {
@@ -193,7 +227,9 @@
     },
     "/v1/cli/approve": {
       "post": {
-        "tags": ["cli"],
+        "tags": [
+          "cli"
+        ],
         "summary": "POST /v1/cli/approve",
         "responses": {
           "200": {
@@ -204,7 +240,9 @@
     },
     "/v1/cli/code": {
       "post": {
-        "tags": ["cli"],
+        "tags": [
+          "cli"
+        ],
         "summary": "POST /v1/cli/code",
         "responses": {
           "200": {
@@ -215,7 +253,9 @@
     },
     "/v1/cli/poll": {
       "get": {
-        "tags": ["cli"],
+        "tags": [
+          "cli"
+        ],
         "summary": "GET /v1/cli/poll",
         "responses": {
           "200": {
@@ -226,7 +266,9 @@
     },
     "/v1/events": {
       "get": {
-        "tags": ["events"],
+        "tags": [
+          "events"
+        ],
         "summary": "GET /v1/events",
         "responses": {
           "200": {
@@ -235,7 +277,9 @@
         }
       },
       "post": {
-        "tags": ["events"],
+        "tags": [
+          "events"
+        ],
         "summary": "POST /v1/events",
         "responses": {
           "200": {
@@ -246,7 +290,9 @@
     },
     "/v1/feedback": {
       "get": {
-        "tags": ["feedback"],
+        "tags": [
+          "feedback"
+        ],
         "summary": "GET /v1/feedback",
         "responses": {
           "200": {
@@ -255,7 +301,9 @@
         }
       },
       "post": {
-        "tags": ["feedback"],
+        "tags": [
+          "feedback"
+        ],
         "summary": "POST /v1/feedback",
         "responses": {
           "200": {
@@ -266,7 +314,9 @@
     },
     "/v1/feedback/board": {
       "get": {
-        "tags": ["feedback"],
+        "tags": [
+          "feedback"
+        ],
         "summary": "GET /v1/feedback/board",
         "responses": {
           "200": {
@@ -277,7 +327,9 @@
     },
     "/v1/feedback/by-project/{slug}": {
       "get": {
-        "tags": ["feedback"],
+        "tags": [
+          "feedback"
+        ],
         "summary": "GET /v1/feedback/by-project/{slug}",
         "responses": {
           "200": {
@@ -288,7 +340,9 @@
     },
     "/v1/feedback/inbox/{projectId}": {
       "get": {
-        "tags": ["feedback"],
+        "tags": [
+          "feedback"
+        ],
         "summary": "GET /v1/feedback/inbox/{projectId}",
         "responses": {
           "200": {
@@ -299,7 +353,9 @@
     },
     "/v1/feedback/{id}": {
       "patch": {
-        "tags": ["feedback"],
+        "tags": [
+          "feedback"
+        ],
         "summary": "PATCH /v1/feedback/{id}",
         "responses": {
           "200": {
@@ -308,7 +364,9 @@
         }
       },
       "delete": {
-        "tags": ["feedback"],
+        "tags": [
+          "feedback"
+        ],
         "summary": "DELETE /v1/feedback/{id}",
         "responses": {
           "200": {
@@ -319,7 +377,9 @@
     },
     "/v1/feedback/{id}/downvote": {
       "post": {
-        "tags": ["feedback"],
+        "tags": [
+          "feedback"
+        ],
         "summary": "POST /v1/feedback/{id}/downvote",
         "responses": {
           "200": {
@@ -328,7 +388,9 @@
         }
       },
       "delete": {
-        "tags": ["feedback"],
+        "tags": [
+          "feedback"
+        ],
         "summary": "DELETE /v1/feedback/{id}/downvote",
         "responses": {
           "200": {
@@ -339,7 +401,9 @@
     },
     "/v1/feedback/{id}/upvote": {
       "post": {
-        "tags": ["feedback"],
+        "tags": [
+          "feedback"
+        ],
         "summary": "POST /v1/feedback/{id}/upvote",
         "responses": {
           "200": {
@@ -348,7 +412,9 @@
         }
       },
       "delete": {
-        "tags": ["feedback"],
+        "tags": [
+          "feedback"
+        ],
         "summary": "DELETE /v1/feedback/{id}/upvote",
         "responses": {
           "200": {
@@ -359,7 +425,9 @@
     },
     "/v1/fleet/metadata": {
       "get": {
-        "tags": ["fleet"],
+        "tags": [
+          "fleet"
+        ],
         "summary": "GET /v1/fleet/metadata",
         "responses": {
           "200": {
@@ -368,7 +436,9 @@
         }
       },
       "post": {
-        "tags": ["fleet"],
+        "tags": [
+          "fleet"
+        ],
         "summary": "POST /v1/fleet/metadata",
         "responses": {
           "200": {
@@ -379,7 +449,9 @@
     },
     "/v1/jobs": {
       "get": {
-        "tags": ["jobs"],
+        "tags": [
+          "jobs"
+        ],
         "summary": "GET /v1/jobs",
         "responses": {
           "200": {
@@ -390,7 +462,9 @@
     },
     "/v1/jobs/{id}/logs": {
       "post": {
-        "tags": ["jobs"],
+        "tags": [
+          "jobs"
+        ],
         "summary": "POST /v1/jobs/{id}/logs",
         "responses": {
           "200": {
@@ -401,7 +475,9 @@
     },
     "/v1/marketing/posts": {
       "get": {
-        "tags": ["marketing"],
+        "tags": [
+          "marketing"
+        ],
         "summary": "GET /v1/marketing/posts",
         "responses": {
           "200": {
@@ -410,7 +486,9 @@
         }
       },
       "post": {
-        "tags": ["marketing"],
+        "tags": [
+          "marketing"
+        ],
         "summary": "POST /v1/marketing/posts",
         "responses": {
           "200": {
@@ -421,7 +499,9 @@
     },
     "/v1/marketing/posts/{id}": {
       "patch": {
-        "tags": ["marketing"],
+        "tags": [
+          "marketing"
+        ],
         "summary": "PATCH /v1/marketing/posts/{id}",
         "responses": {
           "200": {
@@ -432,7 +512,9 @@
     },
     "/v1/projects": {
       "get": {
-        "tags": ["projects"],
+        "tags": [
+          "projects"
+        ],
         "summary": "GET /v1/projects",
         "responses": {
           "200": {
@@ -441,7 +523,9 @@
         }
       },
       "post": {
-        "tags": ["projects"],
+        "tags": [
+          "projects"
+        ],
         "summary": "POST /v1/projects",
         "responses": {
           "200": {
@@ -452,7 +536,9 @@
     },
     "/v1/projects/by-slug/{slug}": {
       "get": {
-        "tags": ["projects"],
+        "tags": [
+          "projects"
+        ],
         "summary": "GET /v1/projects/by-slug/{slug}",
         "responses": {
           "200": {
@@ -463,7 +549,9 @@
     },
     "/v1/projects/readme": {
       "get": {
-        "tags": ["projects"],
+        "tags": [
+          "projects"
+        ],
         "summary": "GET /v1/projects/readme",
         "responses": {
           "200": {
@@ -472,7 +560,9 @@
         }
       },
       "put": {
-        "tags": ["projects"],
+        "tags": [
+          "projects"
+        ],
         "summary": "PUT /v1/projects/readme",
         "responses": {
           "200": {
@@ -483,7 +573,9 @@
     },
     "/v1/projects/{id}": {
       "patch": {
-        "tags": ["projects"],
+        "tags": [
+          "projects"
+        ],
         "summary": "PATCH /v1/projects/{id}",
         "responses": {
           "200": {
@@ -492,7 +584,9 @@
         }
       },
       "delete": {
-        "tags": ["projects"],
+        "tags": [
+          "projects"
+        ],
         "summary": "DELETE /v1/projects/{id}",
         "responses": {
           "200": {
@@ -503,7 +597,9 @@
     },
     "/v1/projects/{id}/readme": {
       "get": {
-        "tags": ["projects"],
+        "tags": [
+          "projects"
+        ],
         "summary": "GET /v1/projects/{id}/readme",
         "responses": {
           "200": {
@@ -512,7 +608,9 @@
         }
       },
       "put": {
-        "tags": ["projects"],
+        "tags": [
+          "projects"
+        ],
         "summary": "PUT /v1/projects/{id}/readme",
         "responses": {
           "200": {
@@ -523,7 +621,9 @@
     },
     "/v1/roadmap/dashboard/{projectId}": {
       "get": {
-        "tags": ["roadmap"],
+        "tags": [
+          "roadmap"
+        ],
         "summary": "GET /v1/roadmap/dashboard/{projectId}",
         "responses": {
           "200": {
@@ -532,7 +632,9 @@
         }
       },
       "post": {
-        "tags": ["roadmap"],
+        "tags": [
+          "roadmap"
+        ],
         "summary": "POST /v1/roadmap/dashboard/{projectId}",
         "responses": {
           "200": {
@@ -543,7 +645,9 @@
     },
     "/v1/roadmap/dashboard/{projectId}/from-feedback/{feedbackId}": {
       "post": {
-        "tags": ["roadmap"],
+        "tags": [
+          "roadmap"
+        ],
         "summary": "POST /v1/roadmap/dashboard/{projectId}/from-feedback/{feedbackId}",
         "responses": {
           "200": {
@@ -554,7 +658,9 @@
     },
     "/v1/roadmap/dashboard/{projectId}/reorder": {
       "post": {
-        "tags": ["roadmap"],
+        "tags": [
+          "roadmap"
+        ],
         "summary": "POST /v1/roadmap/dashboard/{projectId}/reorder",
         "responses": {
           "200": {
@@ -565,7 +671,9 @@
     },
     "/v1/roadmap/dashboard/{projectId}/{id}": {
       "patch": {
-        "tags": ["roadmap"],
+        "tags": [
+          "roadmap"
+        ],
         "summary": "PATCH /v1/roadmap/dashboard/{projectId}/{id}",
         "responses": {
           "200": {
@@ -574,7 +682,9 @@
         }
       },
       "delete": {
-        "tags": ["roadmap"],
+        "tags": [
+          "roadmap"
+        ],
         "summary": "DELETE /v1/roadmap/dashboard/{projectId}/{id}",
         "responses": {
           "200": {
@@ -585,7 +695,9 @@
     },
     "/v1/roadmap/public/{slug}": {
       "get": {
-        "tags": ["roadmap"],
+        "tags": [
+          "roadmap"
+        ],
         "summary": "GET /v1/roadmap/public/{slug}",
         "responses": {
           "200": {
@@ -596,7 +708,9 @@
     },
     "/v1/roadmap/public/{slug}/submit": {
       "post": {
-        "tags": ["roadmap"],
+        "tags": [
+          "roadmap"
+        ],
         "summary": "POST /v1/roadmap/public/{slug}/submit",
         "responses": {
           "200": {
@@ -607,7 +721,9 @@
     },
     "/v1/roadmap/public/{slug}/{id}/vote": {
       "post": {
-        "tags": ["roadmap"],
+        "tags": [
+          "roadmap"
+        ],
         "summary": "POST /v1/roadmap/public/{slug}/{id}/vote",
         "responses": {
           "200": {
@@ -616,7 +732,9 @@
         }
       },
       "delete": {
-        "tags": ["roadmap"],
+        "tags": [
+          "roadmap"
+        ],
         "summary": "DELETE /v1/roadmap/public/{slug}/{id}/vote",
         "responses": {
           "200": {
@@ -627,7 +745,9 @@
     },
     "/v1/secrets": {
       "get": {
-        "tags": ["secrets"],
+        "tags": [
+          "secrets"
+        ],
         "summary": "GET /v1/secrets",
         "responses": {
           "200": {
@@ -636,7 +756,9 @@
         }
       },
       "post": {
-        "tags": ["secrets"],
+        "tags": [
+          "secrets"
+        ],
         "summary": "POST /v1/secrets",
         "responses": {
           "200": {
@@ -647,7 +769,9 @@
     },
     "/v1/secrets/{id}": {
       "delete": {
-        "tags": ["secrets"],
+        "tags": [
+          "secrets"
+        ],
         "summary": "DELETE /v1/secrets/{id}",
         "responses": {
           "200": {
@@ -658,7 +782,9 @@
     },
     "/v1/standards": {
       "get": {
-        "tags": ["standards"],
+        "tags": [
+          "standards"
+        ],
         "summary": "GET /v1/standards",
         "responses": {
           "200": {
@@ -669,7 +795,9 @@
     },
     "/v1/standards/{type}": {
       "get": {
-        "tags": ["standards"],
+        "tags": [
+          "standards"
+        ],
         "summary": "GET /v1/standards/{type}",
         "responses": {
           "200": {
@@ -678,7 +806,9 @@
         }
       },
       "put": {
-        "tags": ["standards"],
+        "tags": [
+          "standards"
+        ],
         "summary": "PUT /v1/standards/{type}",
         "responses": {
           "200": {
@@ -689,7 +819,9 @@
     },
     "/v1/symphony/audit": {
       "get": {
-        "tags": ["symphony"],
+        "tags": [
+          "symphony"
+        ],
         "summary": "GET /v1/symphony/audit",
         "responses": {
           "200": {
@@ -698,7 +830,9 @@
         }
       },
       "post": {
-        "tags": ["symphony"],
+        "tags": [
+          "symphony"
+        ],
         "summary": "POST /v1/symphony/audit",
         "responses": {
           "200": {
@@ -709,7 +843,9 @@
     },
     "/v1/symphony/memory": {
       "get": {
-        "tags": ["symphony"],
+        "tags": [
+          "symphony"
+        ],
         "summary": "GET /v1/symphony/memory",
         "responses": {
           "200": {
@@ -718,7 +854,9 @@
         }
       },
       "put": {
-        "tags": ["symphony"],
+        "tags": [
+          "symphony"
+        ],
         "summary": "PUT /v1/symphony/memory",
         "responses": {
           "200": {
@@ -729,7 +867,9 @@
     },
     "/v1/symphony/runs": {
       "get": {
-        "tags": ["symphony"],
+        "tags": [
+          "symphony"
+        ],
         "summary": "GET /v1/symphony/runs",
         "responses": {
           "200": {
@@ -738,7 +878,9 @@
         }
       },
       "post": {
-        "tags": ["symphony"],
+        "tags": [
+          "symphony"
+        ],
         "summary": "POST /v1/symphony/runs",
         "responses": {
           "200": {
@@ -749,7 +891,9 @@
     },
     "/v1/task-workflows": {
       "get": {
-        "tags": ["task-workflows"],
+        "tags": [
+          "task-workflows"
+        ],
         "summary": "GET /v1/task-workflows",
         "responses": {
           "200": {
@@ -758,7 +902,9 @@
         }
       },
       "post": {
-        "tags": ["task-workflows"],
+        "tags": [
+          "task-workflows"
+        ],
         "summary": "POST /v1/task-workflows",
         "responses": {
           "200": {
@@ -769,7 +915,9 @@
     },
     "/v1/task-workflows/artifacts/{shareToken}": {
       "get": {
-        "tags": ["task-workflows"],
+        "tags": [
+          "task-workflows"
+        ],
         "summary": "GET /v1/task-workflows/artifacts/{shareToken}",
         "responses": {
           "200": {
@@ -780,7 +928,9 @@
     },
     "/v1/task-workflows/{id}": {
       "get": {
-        "tags": ["task-workflows"],
+        "tags": [
+          "task-workflows"
+        ],
         "summary": "GET /v1/task-workflows/{id}",
         "responses": {
           "200": {
@@ -789,7 +939,9 @@
         }
       },
       "patch": {
-        "tags": ["task-workflows"],
+        "tags": [
+          "task-workflows"
+        ],
         "summary": "PATCH /v1/task-workflows/{id}",
         "responses": {
           "200": {
@@ -800,7 +952,9 @@
     },
     "/v1/task-workflows/{id}/artifacts": {
       "post": {
-        "tags": ["task-workflows"],
+        "tags": [
+          "task-workflows"
+        ],
         "summary": "POST /v1/task-workflows/{id}/artifacts",
         "responses": {
           "200": {
@@ -811,7 +965,9 @@
     },
     "/v1/task-workflows/{id}/runs": {
       "post": {
-        "tags": ["task-workflows"],
+        "tags": [
+          "task-workflows"
+        ],
         "summary": "POST /v1/task-workflows/{id}/runs",
         "responses": {
           "200": {
@@ -822,7 +978,9 @@
     },
     "/v1/tasks": {
       "get": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "GET /v1/tasks",
         "responses": {
           "200": {
@@ -831,7 +989,9 @@
         }
       },
       "post": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "POST /v1/tasks",
         "responses": {
           "200": {
@@ -842,7 +1002,9 @@
     },
     "/v1/tasks/claim": {
       "post": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "POST /v1/tasks/claim",
         "responses": {
           "200": {
@@ -853,7 +1015,9 @@
     },
     "/v1/tasks/{id}": {
       "get": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "GET /v1/tasks/{id}",
         "responses": {
           "200": {
@@ -862,7 +1026,9 @@
         }
       },
       "patch": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "PATCH /v1/tasks/{id}",
         "responses": {
           "200": {
@@ -871,7 +1037,9 @@
         }
       },
       "delete": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "DELETE /v1/tasks/{id}",
         "responses": {
           "200": {
@@ -882,7 +1050,9 @@
     },
     "/v1/tasks/{id}/comments": {
       "get": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "GET /v1/tasks/{id}/comments",
         "responses": {
           "200": {
@@ -891,7 +1061,9 @@
         }
       },
       "post": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "POST /v1/tasks/{id}/comments",
         "responses": {
           "200": {
@@ -902,7 +1074,9 @@
     },
     "/v1/tasks/{id}/complete": {
       "post": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "POST /v1/tasks/{id}/complete",
         "responses": {
           "200": {
@@ -913,7 +1087,9 @@
     },
     "/v1/tasks/{id}/fail": {
       "post": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "POST /v1/tasks/{id}/fail",
         "responses": {
           "200": {
@@ -924,7 +1100,9 @@
     },
     "/v1/tasks/{id}/heartbeat": {
       "post": {
-        "tags": ["tasks"],
+        "tags": [
+          "tasks"
+        ],
         "summary": "POST /v1/tasks/{id}/heartbeat",
         "responses": {
           "200": {
@@ -935,7 +1113,9 @@
     },
     "/v1/testimonials": {
       "get": {
-        "tags": ["testimonials"],
+        "tags": [
+          "testimonials"
+        ],
         "summary": "GET /v1/testimonials",
         "responses": {
           "200": {
@@ -944,7 +1124,9 @@
         }
       },
       "post": {
-        "tags": ["testimonials"],
+        "tags": [
+          "testimonials"
+        ],
         "summary": "POST /v1/testimonials",
         "responses": {
           "200": {
@@ -955,7 +1137,9 @@
     },
     "/v1/testimonials/all": {
       "get": {
-        "tags": ["testimonials"],
+        "tags": [
+          "testimonials"
+        ],
         "summary": "GET /v1/testimonials/all",
         "responses": {
           "200": {
@@ -966,7 +1150,9 @@
     },
     "/v1/testimonials/by-project/{slug}": {
       "get": {
-        "tags": ["testimonials"],
+        "tags": [
+          "testimonials"
+        ],
         "summary": "GET /v1/testimonials/by-project/{slug}",
         "responses": {
           "200": {
@@ -975,7 +1161,9 @@
         }
       },
       "post": {
-        "tags": ["testimonials"],
+        "tags": [
+          "testimonials"
+        ],
         "summary": "POST /v1/testimonials/by-project/{slug}",
         "responses": {
           "200": {
@@ -986,7 +1174,9 @@
     },
     "/v1/testimonials/dashboard/{projectId}": {
       "post": {
-        "tags": ["testimonials"],
+        "tags": [
+          "testimonials"
+        ],
         "summary": "POST /v1/testimonials/dashboard/{projectId}",
         "responses": {
           "200": {
@@ -997,7 +1187,9 @@
     },
     "/v1/testimonials/{id}": {
       "patch": {
-        "tags": ["testimonials"],
+        "tags": [
+          "testimonials"
+        ],
         "summary": "PATCH /v1/testimonials/{id}",
         "responses": {
           "200": {
@@ -1006,7 +1198,9 @@
         }
       },
       "delete": {
-        "tags": ["testimonials"],
+        "tags": [
+          "testimonials"
+        ],
         "summary": "DELETE /v1/testimonials/{id}",
         "responses": {
           "200": {
@@ -1017,7 +1211,9 @@
     },
     "/v1/upload": {
       "post": {
-        "tags": ["upload"],
+        "tags": [
+          "upload"
+        ],
         "summary": "POST /v1/upload",
         "responses": {
           "200": {
@@ -1028,7 +1224,9 @@
     },
     "/v1/waitlist": {
       "get": {
-        "tags": ["waitlist"],
+        "tags": [
+          "waitlist"
+        ],
         "summary": "GET /v1/waitlist",
         "responses": {
           "200": {
@@ -1037,7 +1235,9 @@
         }
       },
       "post": {
-        "tags": ["waitlist"],
+        "tags": [
+          "waitlist"
+        ],
         "summary": "POST /v1/waitlist",
         "responses": {
           "200": {
@@ -1048,7 +1248,9 @@
     },
     "/v1/waitlist/count": {
       "get": {
-        "tags": ["waitlist"],
+        "tags": [
+          "waitlist"
+        ],
         "summary": "GET /v1/waitlist/count",
         "responses": {
           "200": {
@@ -1059,7 +1261,9 @@
     },
     "/v1/waitlist/{id}": {
       "delete": {
-        "tags": ["waitlist"],
+        "tags": [
+          "waitlist"
+        ],
         "summary": "DELETE /v1/waitlist/{id}",
         "responses": {
           "200": {


### PR DESCRIPTION
## Root cause
The Biome migration (`e605b4b`) reformatted the generated `openapi.json` files (collapsing single-element `tags` arrays inline), but `scripts/generate-openapi.mjs` emits expanded arrays via `JSON.stringify(…, null, 2)`. So `pnpm check:openapi` (`generate:openapi && git diff --exit-code`) failed on every push to main.

## Fix
- Exclude generated `openapi.json` from Biome (`!**/openapi.json`) — they are auto-generated artifacts, consistent with the existing excludes for `pnpm-lock.yaml`, `dist`, `packages/cli/templates`.
- Regenerate the three specs so committed == generator output.

Removes the drift vector permanently: `pnpm format` can no longer re-collapse them. Verified locally: `pnpm check:openapi` clean, `pnpm lint` no longer flags the specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)