### PR TITLE
smoke: update tinygpt landing assertion to rebranded copy

### DIFF
--- a/scripts/fleet-production-smoke.mjs
+++ b/scripts/fleet-production-smoke.mjs
@@ -91,7 +91,7 @@ const TARGETS = {
   starboard: [{ label: 'web', url: 'https://starboard.sarthakagrawal927.workers.dev' }],
   'swe-interview-prep': [{ label: 'web', url: 'https://swe-interview-prep.pages.dev' }],
   tinygpt: [
-    { label: 'web', url: 'https://tinygpt.pages.dev', expectText: ['trains a real transformer'] },
+    { label: 'web', url: 'https://tinygpt.pages.dev', expectText: ['open-source LLM factory'] },
     { label: 'devlog', url: 'https://tinygpt.pages.dev/devlog.html', expectText: ['Devlog'] },
   ],
   'today-little-log': [{ label: 'web', url: 'https://today-little-log.pages.dev' }],


### PR DESCRIPTION
The Fleet Production Smoke asserted tinygpt's landing contains "trains a real transformer", but the landing was rebranded ("An open-source LLM factory for one Mac."). Updated the assertion to the current distinctive phrase `open-source LLM factory`, verified present in the live body text at https://tinygpt.pages.dev/.

Scope: smoke script only — no hub infra/contract changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)