### PR TITLE
seo: include docs in landing sitemap

### DIFF
--- a/apps/showcase/astro.config.mjs
+++ b/apps/showcase/astro.config.mjs
@@ -18,7 +18,7 @@ export default defineConfig({
     format: 'file',
     inlineStylesheets: 'always',
   },
-  integrations: [sitemap()],
+  integrations: [sitemap({ customPages: ['https://sassmaker.com/docs/'] })],
   vite: {
     css: { transformer: 'lightningcss' },
     build: { cssMinify: 'lightningcss' },


### PR DESCRIPTION
Add the canonical Blume docs root to the generated landing sitemap so search engines discover the docs surface as well as the docs-owned sitemap.