### PR TITLE
spec: adopt Postiz as the sole distribution engine

### DIFF
--- a/openspec/changes/adopt-postiz-distribution/.openspec.yaml
+++ b/openspec/changes/adopt-postiz-distribution/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-20

--- a/openspec/changes/adopt-postiz-distribution/design.md
+++ b/openspec/changes/adopt-postiz-distribution/design.md
@@ -1,0 +1,169 @@
+## Context
+
+Reel Pipeline was imported into the SaaS Maker monorepo as
+`services/reel-pipeline`. It contains valuable generation and rendering code,
+but it also owns direct YouTube and Instagram OAuth, scheduling, retries,
+posting, and metric synchronization. Foundry separately owns campaign context,
+two-stage approval, and the marketing queue. This creates overlapping state
+machines and provider-specific maintenance.
+
+Postiz already supplies channel connections, draft/schedule/now states,
+provider validation, publishing workflows, and social analytics through a
+public API. Its official self-hosted deployment is a stateful Docker stack using
+PostgreSQL, Redis, Temporal, and persistent media storage. It is AGPL-3.0.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make Postiz the sole scheduler and publisher for social channels.
+- Separate generation/building from distribution.
+- Keep Foundry as the source of product context, approvals, attribution, and
+  normalized outcome evidence.
+- Prevent duplicate publication across retries, host failover, and migration.
+- Preserve an explicit owner gate before anything is scheduled or published.
+- Make Postiz replaceable through a narrow provider-neutral boundary even
+  though it is the selected implementation.
+
+**Non-Goals:**
+
+- Forking, embedding, or modifying the Postiz source tree.
+- Using Postiz's AI generation as the Fleet's creative system.
+- Exposing the Postiz UI as a second public Foundry dashboard.
+- Moving product direction or feature implementation into Foundry automation.
+- Activating accounts, production schedules, DNS, or secrets in the source-only
+  implementation phase.
+
+## Decisions
+
+### 1. Postiz is an external service, not a monorepo package
+
+Run an official Postiz container image pinned to a tested version and digest on
+the designated operations machine. Keep its compose overlay and non-secret
+configuration contract in Foundry, but keep the runtime checkout, credentials,
+database, Redis, Temporal state, and uploads outside git. Prefer Cloudflare R2
+for durable media once the deployment is activated.
+
+This avoids copying AGPL code into SaaS Maker, keeps upstream upgrades possible,
+and prevents Postiz's large application stack from becoming a Foundry build
+dependency. Building a custom scheduler was rejected because that is the
+duplication this change removes. Postiz Cloud remains a fallback, not the
+default, because the designated host already exists and the owner is the only
+user.
+
+### 2. Three systems own three distinct records
+
+- Foundry owns campaign intent, project attribution, content approval,
+  distribution approval, and normalized measurement evidence.
+- Content Factory owns generation attempts, quality evidence, immutable asset
+  manifests, and render receipts.
+- Postiz owns connected channel configuration, drafts, schedules, publication
+  attempts, release IDs, and native social analytics.
+
+Foundry stores Postiz identifiers and normalized receipts, not a second mutable
+copy of Postiz's scheduling state. `catalog/foundry.json` remains the only
+hand-edited product/deployment catalog.
+
+### 3. Content Factory is the retained creative boundary
+
+Move generation-only behavior toward `services/content-factory`. Existing Reel
+Pipeline render engines remain adapters during migration. Each accepted input
+produces a versioned artifact manifest containing source provenance, content
+hash, asset locations, variants, quality result, and approval state. No Content
+Factory module receives social provider credentials or calls Postiz directly.
+
+A single large rewrite was rejected. The migration first introduces the
+boundary and tests, then moves or removes one engine/path at a time while
+preserving git history.
+
+### 4. Foundry owns one server-side Postiz adapter
+
+The adapter uses Postiz's public API to list integrations, create drafts or
+schedules, list posts, change draft/schedule status, and read post/platform
+analytics. The API key and base URL remain server-side. Cockpit never receives
+them.
+
+The adapter accepts provider-neutral distribution requests and translates them
+to platform-specific Postiz settings. It batches compatible posts because the
+Postiz create endpoint has an instance-wide hourly request limit. Transient
+errors use bounded retry with jitter; validation and auth failures do not retry.
+
+### 5. Idempotency is enforced before Postiz
+
+Foundry persists a delivery mapping keyed by the immutable distribution request
+ID plus content hash and integration ID. A retry returns the existing Postiz
+post ID unless the prior attempt is explicitly terminal and the owner approves
+a replacement. Host lease ownership and the mapping are checked before every
+create call. This is necessary because duplicate prevention cannot depend on an
+undocumented upstream idempotency contract.
+
+### 6. Existing two-stage approval remains authoritative
+
+Content acceptance allows generation. Distribution approval, given only after
+a render receipt exists, allows creation of a Postiz draft or schedule. A draft
+may be created for review, but promotion to scheduled/now still requires the
+recorded approval. Postiz UI changes are reconciled back as evidence; they do
+not silently manufacture Foundry approval.
+
+### 7. Evidence synchronization is bounded polling
+
+Use bounded polling initially because the documented public API supports post
+listing and analytics while no required webhook contract is assumed. Poll only
+known active/recent Postiz IDs, persist a cursor and freshness timestamp, and
+emit `fresh`, `stale`, `failed`, or `unmeasured`. Store aggregate metrics and
+provider receipts, not comments, DMs, access tokens, or unrelated account data.
+
+### 8. Cockpit remains the operator surface
+
+Cockpit shows Content Factory generation state, approvals, Postiz scheduling
+state, release receipts, and normalized performance. The Postiz UI remains a
+private operational escape hatch for account setup and provider-specific
+troubleshooting.
+
+## Risks / Trade-offs
+
+- **Postiz is operationally heavy** → Pin versions, use the official compose
+  topology, add health/backups, and keep activation on the designated machine.
+- **AGPL obligations or upgrade friction** → Run upstream unmodified as a
+  separate service; do not copy source or link it into proprietary packages.
+- **Duplicate posts during retries or failover** → Enforce Foundry idempotency,
+  host lease ownership, and explicit replacement approval.
+- **Public API drift** → Contract-test against a pinned container and isolate all
+  payload translation in one adapter.
+- **Platform metrics differ** → Preserve provider/metric labels and normalize
+  only stable aggregate concepts; show unknown rather than inventing parity.
+- **Postiz outage blocks distribution** → Generation and approval continue;
+  approved requests remain queued and no direct publisher fallback runs after
+  final cutover.
+- **Two UIs can diverge** → Cockpit is authoritative for approvals; Postiz is
+  authoritative for provider execution and is private.
+
+## Migration Plan
+
+1. Add contracts, fixture-backed adapter tests, idempotency storage, and Cockpit
+   read models with all production calls disabled.
+2. Add a pinned Postiz host manifest and readiness doctor; do not commit secrets
+   or activate services.
+3. Run Postiz locally with fake/test integrations and prove draft creation,
+   reconciliation, retries, and analytics normalization.
+4. On explicit approval, install Postiz on the designated operations machine,
+   configure backups/storage, connect one non-critical channel, and run in
+   draft-only shadow mode.
+5. Schedule and publish one approved canary; verify release ID and metrics round
+   trip into Foundry.
+6. Disable direct Reel Pipeline publishers and schedulers, then observe a
+   rollback window with their credentials removed from active runtime.
+7. Remove obsolete OAuth/posting/retry/metrics code and rename the retained
+   generation boundary to Content Factory.
+
+Rollback before step 6 routes no new work to Postiz and leaves existing Postiz
+drafts cancelled manually. Rollback after step 6 requires explicit owner action;
+the old publisher is not automatically re-enabled.
+
+## Open Questions
+
+- Choose the private operator hostname, if any, during host activation. A
+  Tailscale-only URL is the default; no public `*.sassmaker.com` hostname is
+  required.
+- Select the first canary channel after account availability is inspected.
+- Decide the retention window for Postiz database backups before activation.

--- a/openspec/changes/adopt-postiz-distribution/proposal.md
+++ b/openspec/changes/adopt-postiz-distribution/proposal.md
@@ -1,0 +1,62 @@
+## Why
+
+The imported Reel Pipeline currently combines creative generation, rendering,
+approval, scheduling, social OAuth, publishing, retries, and metrics. That
+duplicates a mature scheduler and makes the Foundry responsible for too many
+provider-specific failure modes. Postiz should become the sole distribution
+engine while Foundry keeps product context, approvals, measurement, and
+feedback understanding, and a separate Content Factory owns asset generation.
+
+## What Changes
+
+- Introduce a provider-neutral Content Factory handoff for approved briefs,
+  generated variants, rendered assets, quality evidence, and immutable artifact
+  receipts.
+- Integrate a pinned, independently deployed Postiz instance through its public
+  API for channel discovery, drafts, scheduling, publishing, and social metrics.
+- Keep Postiz outside the SaaS Maker source tree and deployment artifact. Its
+  AGPL service runs unmodified as a separately operated dependency; Foundry
+  contains only its own adapter and contracts.
+- Preserve the two-stage owner gate: content approval remains separate from
+  distribution approval. No generated asset can become a Postiz schedule
+  without explicit distribution approval.
+- Normalize Postiz post IDs, channel IDs, release state, failures, and analytics
+  into Foundry evidence so marketing outcomes feed the post-ship learning loop.
+- **BREAKING:** retire the Reel Pipeline YouTube/Instagram scheduler, OAuth,
+  posting, retry, and metrics paths after Postiz parity is verified. Reel code
+  retained for generation must not publish directly.
+- Rename and narrow the retained generation surface toward Content Factory;
+  keep existing render engines as adapters until each is either proven useful
+  or removed.
+- Keep production deployment, account connection, DNS, secret setup, and final
+  publisher cutover behind explicit owner approval and rollback evidence.
+
+## Capabilities
+
+### New Capabilities
+
+- `content-factory-handoff`: Versioned contracts and state transitions for
+  brief intake, generation, quality review, approval, and artifact handoff.
+- `postiz-distribution-adapter`: One idempotent Foundry adapter for Postiz
+  integrations, drafts, schedules, publishing state, and provider errors.
+- `distribution-evidence-sync`: Bounded synchronization of Postiz release IDs
+  and analytics into Foundry's measurement and feedback evidence.
+
+### Modified Capabilities
+
+None. The repository has no established main specs; existing marketing behavior
+is captured by code and archived changes and will be superseded through the new
+capabilities above.
+
+## Impact
+
+- SaaS Maker Cockpit marketing/distribution UI and API contracts.
+- `services/reel-pipeline`, which will be separated into generation-only code
+  plus transitional compatibility adapters.
+- The operations host, which will run the pinned Postiz deployment and the
+  bounded evidence synchronizer.
+- Foundry catalog, observability inventory, deployment runbooks, and host
+  readiness checks.
+- External dependency: self-hosted Postiz with PostgreSQL, Redis, Temporal, and
+  persistent object storage. Credentials and provider OAuth remain
+  machine-local and are never committed.

--- a/openspec/changes/adopt-postiz-distribution/specs/content-factory-handoff/spec.md
+++ b/openspec/changes/adopt-postiz-distribution/specs/content-factory-handoff/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Versioned generation input
+The Content Factory SHALL accept a versioned brief containing project identity,
+source provenance, requested formats, channel intent, and content approval. It
+MUST reject unapproved or unsupported input without rendering or distribution.
+
+#### Scenario: Approved brief enters generation
+- **WHEN** Foundry submits a supported brief with recorded content approval
+- **THEN** Content Factory creates one idempotent generation run tied to that brief version
+
+#### Scenario: Unapproved brief is rejected
+- **WHEN** a brief lacks content approval
+- **THEN** Content Factory records a validation failure and produces no asset
+
+### Requirement: Immutable artifact manifest
+Every completed generation run SHALL emit an immutable manifest containing the
+input hash, renderer and version, generated variants, asset checksums and
+locations, quality evidence, provenance, and review state.
+
+#### Scenario: Render passes quality review
+- **WHEN** a renderer completes and the configured quality gate passes
+- **THEN** the manifest records the verified assets and becomes eligible for owner review
+
+#### Scenario: Render fails quality review
+- **WHEN** a required quality check fails or is unavailable
+- **THEN** the manifest remains in review or failed state and cannot enter distribution
+
+### Requirement: Generation cannot publish
+Content Factory SHALL NOT receive social-provider credentials, create schedules,
+or publish content. Its only outbound distribution action SHALL be returning a
+verified artifact manifest to Foundry.
+
+#### Scenario: Provider credentials are absent
+- **WHEN** Content Factory runs in any environment
+- **THEN** its runtime contract requires no Instagram, YouTube, TikTok, or Postiz credential
+
+### Requirement: Existing renderer migration
+Existing Reel Pipeline renderers SHALL remain usable only through the Content
+Factory adapter boundary until individually retained or removed with evidence.
+
+#### Scenario: Legacy renderer is invoked
+- **WHEN** a retained legacy renderer processes a supported brief
+- **THEN** its output is normalized into the same artifact manifest as every other renderer
+

--- a/openspec/changes/adopt-postiz-distribution/specs/distribution-evidence-sync/spec.md
+++ b/openspec/changes/adopt-postiz-distribution/specs/distribution-evidence-sync/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Bounded Postiz reconciliation
+The synchronizer SHALL query only configured integrations and known recent or
+active Postiz post IDs, with a persisted cursor, time budget, and item limit.
+
+#### Scenario: Scheduled poll completes
+- **WHEN** the operations host runs the evidence synchronizer
+- **THEN** it processes a bounded page, persists its cursor, and emits a receipt
+
+### Requirement: Explicit evidence freshness
+Every distribution and analytics record SHALL include source, observed time,
+and one of `fresh`, `stale`, `failed`, or `unmeasured`. Last-known-good values
+MUST retain their original observation time.
+
+#### Scenario: Postiz is unavailable
+- **WHEN** synchronization cannot reach Postiz
+- **THEN** existing values become stale according to policy and are not reported as fresh
+
+### Requirement: Provider provenance
+Foundry SHALL preserve the Postiz post ID, integration ID, platform identifier,
+release status, release identifier when available, and original metric labels
+needed to explain normalized values.
+
+#### Scenario: Metrics differ by platform
+- **WHEN** one platform reports impressions and another reports views
+- **THEN** Foundry preserves both labels and applies only documented normalization
+
+### Requirement: Privacy-minimized collection
+The synchronizer MUST NOT ingest access tokens, comments, direct messages,
+follower identities, unpublished unrelated content, or full account payloads.
+
+#### Scenario: Upstream response contains extra fields
+- **WHEN** Postiz returns fields outside the evidence allowlist
+- **THEN** the synchronizer discards them before persistence or logging
+
+### Requirement: Feedback-loop output
+Distribution evidence SHALL be attributable to the originating project,
+campaign, brief, artifact, and experiment so Foundry can compare outcomes and
+produce evidence-backed recommendations.
+
+#### Scenario: Published post gains engagement
+- **WHEN** fresh analytics arrive for a mapped Postiz post
+- **THEN** Foundry updates the campaign evidence without creating product work automatically
+

--- a/openspec/changes/adopt-postiz-distribution/specs/postiz-distribution-adapter/spec.md
+++ b/openspec/changes/adopt-postiz-distribution/specs/postiz-distribution-adapter/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: Postiz is the sole publisher
+After cutover, the system SHALL execute all social drafts, schedules, immediate
+publications, retries, and provider connections through one Foundry-owned Postiz adapter.
+Direct Reel Pipeline publisher paths MUST be disabled.
+
+#### Scenario: Approved distribution is scheduled
+- **WHEN** a verified artifact has explicit distribution approval and a valid connected integration
+- **THEN** the adapter creates or promotes exactly one Postiz post for the requested time
+
+#### Scenario: Direct legacy publishing is attempted
+- **WHEN** a legacy Reel Pipeline publisher is invoked after cutover
+- **THEN** it fails closed without making a provider request
+
+### Requirement: Two-stage approval
+The adapter SHALL require both content approval and distribution approval.
+Creating a Postiz draft for review MUST NOT imply permission to schedule or
+publish it.
+
+#### Scenario: Draft without distribution approval
+- **WHEN** approved content has a verified artifact but no distribution approval
+- **THEN** the system may create a Postiz draft but MUST NOT schedule or publish it
+
+### Requirement: Idempotent delivery mapping
+The adapter SHALL persist a unique mapping from distribution request, content
+hash, and integration to the Postiz post ID before treating creation as
+successful. Retries MUST reuse the mapping unless replacement is explicitly
+approved.
+
+#### Scenario: Retry after ambiguous response
+- **WHEN** a create request times out and the same distribution request retries
+- **THEN** the adapter reconciles known Postiz state before creating any replacement
+
+#### Scenario: Host failover repeats work
+- **WHEN** another host receives a request already mapped to a Postiz post
+- **THEN** it returns the existing mapping and does not create a duplicate
+
+### Requirement: Server-side credentials
+Postiz base URL, API key, provider configuration, and OAuth material SHALL remain
+outside git and server-side. Logs, receipts, and Cockpit responses MUST redact
+credential-shaped values.
+
+#### Scenario: Cockpit reads distribution state
+- **WHEN** an authenticated operator opens a marketing item
+- **THEN** Cockpit receives normalized state and identifiers but no Postiz credential
+
+### Requirement: Classified bounded failures
+The adapter SHALL classify validation, authentication, throttling, provider,
+network, and unknown failures. Only transient classes MAY receive bounded retry
+with jitter.
+
+#### Scenario: Postiz rejects platform settings
+- **WHEN** Postiz returns a deterministic validation error
+- **THEN** Foundry marks the request blocked for review and does not retry automatically

--- a/openspec/changes/adopt-postiz-distribution/tasks.md
+++ b/openspec/changes/adopt-postiz-distribution/tasks.md
@@ -1,0 +1,51 @@
+## 1. Contracts and boundaries
+
+- [ ] 1.1 Add versioned Content Factory brief, artifact-manifest, quality, and approval contracts with fixture-backed validation tests.
+- [ ] 1.2 Add provider-neutral distribution request, delivery mapping, provider receipt, and analytics evidence contracts.
+- [ ] 1.3 Add catalog declarations for Content Factory, the external Postiz service, privacy allowlists, ownership, and evidence freshness.
+- [ ] 1.4 Add architecture tests proving Content Factory imports no social publisher or provider credential modules.
+
+## 2. Postiz adapter
+
+- [ ] 2.1 Implement a server-only Postiz client for health, integrations, post creation/listing/status, and post/platform analytics.
+- [ ] 2.2 Implement platform payload translation and fixture tests for the initial Instagram Reels and YouTube Shorts formats.
+- [ ] 2.3 Implement classified errors, timeouts, bounded retries, redaction, and instance-rate-budget handling.
+- [ ] 2.4 Add an inert fake-Postiz integration harness that proves draft, schedule, list, status, and analytics flows without credentials or external writes.
+
+## 3. Idempotency and approval
+
+- [ ] 3.1 Add the delivery-mapping persistence migration and repository keyed by distribution request, content hash, and integration.
+- [ ] 3.2 Enforce content approval, verified artifact receipt, distribution approval, host lease, and delivery mapping before every Postiz create call.
+- [ ] 3.3 Implement ambiguous-result reconciliation and explicit replacement approval.
+- [ ] 3.4 Extend the Cockpit distribution view to show generation, approval, Postiz draft/schedule/release, retry, and evidence freshness states.
+
+## 4. Content Factory separation
+
+- [ ] 4.1 Inventory Reel Pipeline modules as generation, distribution, mixed, or obsolete and lock the inventory with a static test.
+- [ ] 4.2 Establish `services/content-factory` with the generation-only contract and migrate the canonical render/package entrypoints while preserving history.
+- [ ] 4.3 Route existing render engines through Content Factory manifests and verify current local generation smoke cases.
+- [ ] 4.4 Add fail-closed compatibility shims for direct Reel scheduling, posting, OAuth, and metrics commands; keep them disabled until final deletion.
+
+## 5. Evidence and feedback loop
+
+- [ ] 5.1 Implement bounded Postiz post and analytics synchronization with cursor, freshness, and allowlisted persistence.
+- [ ] 5.2 Link every normalized receipt to project, campaign, brief, artifact, integration, and experiment identifiers.
+- [ ] 5.3 Add Cockpit marketing outcome views for platform metrics, freshness, failures, and evidence-backed recommendations without automatic product-task creation.
+- [ ] 5.4 Add synthetic/fake evidence tests proving unavailable Postiz state renders stale or unmeasured rather than green.
+
+## 6. Host readiness
+
+- [ ] 6.1 Add a pinned official Postiz image/digest manifest and non-secret compose overlay for Postiz, PostgreSQL, Redis, Temporal, and persistent storage.
+- [ ] 6.2 Extend the Foundry host doctor for resources, persistent paths, backups, health endpoints, API compatibility, and private-network reachability.
+- [ ] 6.3 Add backup/restore and upgrade rehearsal runbooks; verify them against disposable local state.
+- [ ] 6.4 Add inert schedules for evidence synchronization and queued distribution; do not install or activate them.
+
+## 7. Verification and owner-gated cutover
+
+- [ ] 7.1 Run unit, integration, typecheck, lint, build, catalog, host, and fake-Postiz acceptance checks.
+- [ ] 7.2 Obtain owner approval for host identity, private hostname, backup retention, initial channel, credentials, migration, and production activation.
+- [ ] 7.3 Install the pinned Postiz stack on the designated host and verify health, persistence, backup, private access, and rollback without exposing secrets.
+- [ ] 7.4 Connect one non-critical channel and complete draft-only shadow parity with Foundry.
+- [ ] 7.5 Publish one separately approved canary and verify release plus analytics evidence round-trips into Cockpit.
+- [ ] 7.6 Disable all direct Reel publisher/scheduler runtime paths, verify no duplicate execution, and observe the rollback window.
+- [ ] 7.7 Remove obsolete direct OAuth, posting, retry, and metrics code; archive this OpenSpec change and update `PROJECT_STATUS.md`.


### PR DESCRIPTION
## Summary

- define Postiz as the sole scheduler, publisher, and channel connector
- separate generation/building into a Content Factory contract
- keep approvals, attribution, and normalized evidence in Foundry
- specify idempotency, failure handling, private hosting, canary migration, and rollback

## Validation

- `openspec validate adopt-postiz-distribution`
- `git diff --check`

## Owner decisions before implementation

- first canary channel/account
- private-only access versus a protected hostname
- backup retention window

No runtime behavior or production configuration changes in this PR.