### PR TITLE
Complete hosted Feedback as an agent-native service

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -25,6 +25,11 @@ Cockpit, CodeVetter, and App Health remain independent repositories.
 
 ## Timeline
 
+- **2026-08-22 — Feedback agent contract completed in source:** Hosted
+  submission now keeps page/Pinpoint evidence, accepts one multipart request,
+  issues read-only-by-default agent tokens, and records status mutations. The
+  private inbox copies structured records for agent workflows. Production D1
+  migration, DNS, deploy, and npm publication still need explicit approval.
 - **2026-08-22 — Standalone catalog boundary repaired:** Repointed public
   catalog synchronization to Site Health's canonical `projects.json`, retained
   the checked-in privacy-filtered projection for runtime use, and repointed the
@@ -91,6 +96,9 @@ Cockpit, CodeVetter, and App Health remain independent repositories.
 - Optional screenshots and page-element anchoring.
 - Private cross-product feedback inbox with type/status filters and status controls.
 - Machine-readable OpenAPI contract for submission, inbox, detail, and status updates.
+- Project-scoped agent tokens that default to read-only.
+- Immutable status-change audit records with actor identity.
+- Page URL, Pinpoint context, and screenshots stored as original customer evidence.
 - Project-key creation and management.
 - Blume package docs plus agent/search surfaces.
 - Backend-free AI assistant links with provider-specific prompt handoff.

--- a/STATUS.md
+++ b/STATUS.md
@@ -5,7 +5,8 @@ package docs, feedback API/inbox, and @saas-maker/feedback.
 
 Local feedback API tests, API typecheck, feedback package build, public
 projection drift check, showcase build, and narrowed Cockpit build/typecheck are
-green. Final docs/CI validation and source handoff are still in progress.
+the required source checks. Production D1 migration for the agent contract,
+live deploy, and npm publication remain explicit follow-up actions.
 
 No production deployment, migration, DNS change, npm action, or repository
 archival has been performed.

--- a/apps/cockpit/src/app/(app)/projects/[slug]/inbox-content.tsx
+++ b/apps/cockpit/src/app/(app)/projects/[slug]/inbox-content.tsx
@@ -31,7 +31,7 @@ export function InboxContent({ projectId }: InboxContentProps) {
       const qs = params.toString();
       const token = await getClientToken();
       const data = await apiFetchClient<{ data: FeedbackRecord[] }>(
-        `/v1/feedback/inbox/${projectId}${qs ? `?${qs}` : ''}`,
+        `/v1/feedback?project=${encodeURIComponent(projectId)}${qs ? `&${qs}` : ''}`,
         token
       );
       setFeedback(data.data ?? []);

--- a/apps/cockpit/src/app/(app)/projects/[slug]/page.tsx
+++ b/apps/cockpit/src/app/(app)/projects/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { PageHeader } from '@/components/page-header';
+import { ProjectCredentials } from '@/components/project-credentials';
 import { getAuthenticatedProject } from './get-project';
 import { InboxContent } from './inbox-content';
 
@@ -15,6 +16,7 @@ export default async function ProjectStatusPage({ params }: Props) {
   return (
     <div className="space-y-6">
       <PageHeader title={project.name} description={`Feedback for ${project.slug}`} />
+      <ProjectCredentials projectId={project.id} projectKey={project.api_key} />
       <InboxContent projectId={project.id} />
     </div>
   );

--- a/apps/cockpit/src/app/(app)/projects/feedback/feedback-board.tsx
+++ b/apps/cockpit/src/app/(app)/projects/feedback/feedback-board.tsx
@@ -32,7 +32,7 @@ export function FeedbackBoard() {
         if (type !== 'all') query.set('type', type);
         if (status !== 'all') query.set('status', status);
         const result = await apiFetchClient<{ data: InboxRecord[] }>(
-          `/v1/feedback/inbox?${query.toString()}`,
+          `/v1/feedback?${query.toString()}`,
           activeToken
         );
         setFeedback(result.data ?? []);
@@ -108,6 +108,7 @@ export function FeedbackBoard() {
             <SelectItem value="in_progress">In progress</SelectItem>
             <SelectItem value="resolved">Resolved</SelectItem>
             <SelectItem value="dismissed">Dismissed</SelectItem>
+            <SelectItem value="on_roadmap">On roadmap</SelectItem>
           </SelectContent>
         </Select>
         <Button

--- a/apps/cockpit/src/app/(app)/projects/page.tsx
+++ b/apps/cockpit/src/app/(app)/projects/page.tsx
@@ -73,7 +73,7 @@ export default async function ProjectsPage() {
           <CardHeader className="flex flex-row items-center gap-3">
             <AlertCircle className="h-5 w-5 text-destructive shrink-0" />
             <div>
-              <CardTitle className="text-base text-destructive">Failed to load fleet</CardTitle>
+              <CardTitle className="text-base text-destructive">Failed to load projects</CardTitle>
               <CardDescription className="mt-1 text-xs font-mono break-all">
                 {error}
               </CardDescription>

--- a/apps/cockpit/src/components/copy-button.tsx
+++ b/apps/cockpit/src/components/copy-button.tsx
@@ -6,9 +6,10 @@ import { Check, Copy } from 'lucide-react';
 
 interface CopyButtonProps {
   value: string;
+  label?: string;
 }
 
-export function CopyButton({ value }: CopyButtonProps) {
+export function CopyButton({ value, label }: CopyButtonProps) {
   const [copied, setCopied] = useState(false);
 
   async function handleCopy() {
@@ -18,8 +19,9 @@ export function CopyButton({ value }: CopyButtonProps) {
   }
 
   return (
-    <Button variant="outline" size="icon" onClick={handleCopy}>
+    <Button variant="outline" size={label ? 'sm' : 'icon'} onClick={handleCopy}>
       {copied ? <Check className="h-4 w-4 text-green-600" /> : <Copy className="h-4 w-4" />}
+      {label ? <span>{copied ? 'Copied' : label}</span> : null}
     </Button>
   );
 }

--- a/apps/cockpit/src/components/feedback-detail.tsx
+++ b/apps/cockpit/src/components/feedback-detail.tsx
@@ -17,6 +17,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from '@/components/ui/sheet';
+import { CopyButton } from '@/components/copy-button';
 import type { FeedbackRecord, AnyFeedbackStatus, FeedbackStatus } from '@saas-maker/contracts';
 
 const TYPE_STYLES: Record<
@@ -97,7 +98,39 @@ export function FeedbackDetail({ item, open, onClose, onStatusChange }: Feedback
             </p>
           </div>
 
-          {/* Image */}
+          {item.page?.url ? (
+            <div className="space-y-1">
+              <h4 className="text-sm font-medium text-muted-foreground">Page</h4>
+              <p className="text-sm">{item.page.title || 'Untitled page'}</p>
+              <a
+                href={item.page.url}
+                className="break-all text-xs text-muted-foreground underline"
+                target="_blank"
+                rel="noreferrer"
+              >
+                {item.page.url}
+              </a>
+            </div>
+          ) : null}
+
+          {item.pinpoint ? (
+            <div className="space-y-1">
+              <h4 className="text-sm font-medium text-muted-foreground">Pinpoint</h4>
+              <p className="text-sm">
+                {item.pinpoint.tag || 'element'}
+                {item.pinpoint.text ? `: ${item.pinpoint.text}` : ''}
+              </p>
+              <p className="break-all font-mono text-xs text-muted-foreground">
+                {item.pinpoint.selector}
+              </p>
+              {item.pinpoint.source ? (
+                <p className="break-all font-mono text-xs text-muted-foreground">
+                  {item.pinpoint.source}
+                </p>
+              ) : null}
+            </div>
+          ) : null}
+
           {item.image_url && (
             <div className="space-y-2">
               <h4 className="text-sm font-medium text-muted-foreground">Attachment</h4>
@@ -132,7 +165,6 @@ export function FeedbackDetail({ item, open, onClose, onStatusChange }: Feedback
             </p>
           </div>
 
-          {/* Status */}
           <div className="space-y-2">
             <h4 className="text-sm font-medium text-muted-foreground">Status</h4>
             <Select value={status} onValueChange={handleStatusChange} disabled={updating}>
@@ -147,6 +179,29 @@ export function FeedbackDetail({ item, open, onClose, onStatusChange }: Feedback
                 ))}
               </SelectContent>
             </Select>
+          </div>
+
+          <div className="space-y-2">
+            <h4 className="text-sm font-medium text-muted-foreground">Agent record</h4>
+            <CopyButton
+              label="Copy JSON"
+              value={JSON.stringify(
+                {
+                  id: item.id,
+                  project_id: item.project_id,
+                  type: item.type,
+                  status: item.status,
+                  title: item.title,
+                  description: item.description,
+                  page: item.page,
+                  pinpoint: item.pinpoint,
+                  image_url: item.image_url,
+                  created_at: item.created_at,
+                },
+                null,
+                2
+              )}
+            />
           </div>
         </SheetBody>
       </SheetContent>

--- a/apps/cockpit/src/components/feedback-table.tsx
+++ b/apps/cockpit/src/components/feedback-table.tsx
@@ -56,8 +56,8 @@ export function FeedbackTable({ feedback, onStatusChange }: FeedbackTableProps) 
           <TableBody>
             {feedback.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={5} className="h-24 text-center text-muted-foreground">
-                  No feedback items found.
+                <TableCell colSpan={5} className="h-28 text-center text-muted-foreground">
+                  No matching feedback. New submissions from the hosted widget appear here.
                 </TableCell>
               </TableRow>
             ) : (

--- a/apps/cockpit/src/components/onboarding/OnboardingFlow.tsx
+++ b/apps/cockpit/src/components/onboarding/OnboardingFlow.tsx
@@ -44,7 +44,7 @@ export function OnboardingFlow() {
   }
 
   if (apiKey) {
-    const example = `<FeedbackWidget projectId="${apiKey}" />`;
+    const example = `<FeedbackWidget projectKey="${apiKey}" />`;
     return (
       <Card className="mx-auto max-w-xl">
         <CardHeader>

--- a/apps/cockpit/src/components/project-credentials.tsx
+++ b/apps/cockpit/src/components/project-credentials.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import type { AgentTokenRecord } from '@saas-maker/contracts';
+import { useCallback, useEffect, useState, type FormEvent } from 'react';
+import { CopyButton } from '@/components/copy-button';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { apiFetchClient, getClientToken } from '@/lib/api-client';
+
+interface ProjectCredentialsProps {
+  projectId: string;
+  projectKey: string;
+}
+
+export function ProjectCredentials({ projectId, projectKey }: ProjectCredentialsProps) {
+  const [tokens, setTokens] = useState<AgentTokenRecord[]>([]);
+  const [name, setName] = useState('Inbox agent');
+  const [canWrite, setCanWrite] = useState(false);
+  const [plaintext, setPlaintext] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const token = await getClientToken();
+      const result = await apiFetchClient<{ data: AgentTokenRecord[] }>(
+        `/v1/projects/${projectId}/agent-tokens`,
+        token
+      );
+      setTokens(result.data ?? []);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'Failed to load agent tokens');
+    } finally {
+      setLoading(false);
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function createToken(event: FormEvent) {
+    event.preventDefault();
+    setError(null);
+    try {
+      const session = await getClientToken();
+      const created = await apiFetchClient<AgentTokenRecord & { token: string }>(
+        `/v1/projects/${projectId}/agent-tokens`,
+        session,
+        {
+          method: 'POST',
+          body: JSON.stringify({ name: name.trim(), can_write: canWrite }),
+        }
+      );
+      setPlaintext(created.token);
+      setTokens((current) => [created, ...current]);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'Failed to create agent token');
+    }
+  }
+
+  async function revokeToken(tokenId: string) {
+    setError(null);
+    try {
+      const session = await getClientToken();
+      await apiFetchClient(`/v1/projects/${projectId}/agent-tokens/${tokenId}`, session, {
+        method: 'DELETE',
+      });
+      setTokens((current) => current.filter((item) => item.id !== tokenId));
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'Failed to revoke token');
+    }
+  }
+
+  return (
+    <section className="space-y-4 rounded-lg border p-4">
+      <div>
+        <h2 className="text-sm font-medium">Project key</h2>
+        <p className="text-sm text-muted-foreground">
+          Publishable identifier for hosted widget submissions. It cannot read the inbox.
+        </p>
+        <div className="mt-2 flex items-start gap-2">
+          <code className="flex-1 break-all rounded-md border bg-muted/40 p-2 text-xs">
+            {projectKey}
+          </code>
+          <CopyButton value={projectKey} label="Copy key" />
+        </div>
+      </div>
+
+      <div className="space-y-3 border-t pt-4">
+        <div>
+          <h2 className="text-sm font-medium">Agent tokens</h2>
+          <p className="text-sm text-muted-foreground">
+            Scoped Bearer tokens for the same JSON API. New tokens are read-only unless write access
+            is enabled.
+          </p>
+        </div>
+        <form className="flex flex-wrap items-end gap-3" onSubmit={createToken}>
+          <div className="grid gap-1">
+            <Label htmlFor="agent-token-name">Name</Label>
+            <Input
+              id="agent-token-name"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              className="w-56"
+            />
+          </div>
+          <label className="flex items-center gap-2 text-sm">
+            <Switch checked={canWrite} onCheckedChange={setCanWrite} />
+            Allow status updates
+          </label>
+          <Button type="submit" size="sm" disabled={!name.trim()}>
+            Create token
+          </Button>
+        </form>
+        {plaintext ? (
+          <div className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/5 p-3">
+            <code className="flex-1 break-all text-xs">{plaintext}</code>
+            <CopyButton value={plaintext} label="Copy token" />
+          </div>
+        ) : null}
+        {error ? <p className="text-sm text-destructive">{error}</p> : null}
+        {loading ? (
+          <p className="text-sm text-muted-foreground">Loading tokens…</p>
+        ) : tokens.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No agent tokens yet.</p>
+        ) : (
+          <ul className="space-y-2">
+            {tokens.map((token) => (
+              <li key={token.id} className="flex items-center justify-between gap-3 text-sm">
+                <span>
+                  {token.name} · {token.token_prefix}… ·{' '}
+                  {token.can_write ? 'read/write' : 'read-only'}
+                </span>
+                <Button variant="outline" size="sm" onClick={() => void revokeToken(token.id)}>
+                  Revoke
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/showcase/src/pages/privacy.astro
+++ b/apps/showcase/src/pages/privacy.astro
@@ -20,6 +20,7 @@ import Footer from '../components/Footer.astro';
     <h2>What we may collect</h2>
     <ul>
       <li><strong>Analytics:</strong> Cloudflare may log standard request metadata (IP, user agent, path) at the edge.</li>
+      <li><strong>Hosted Feedback:</strong> Products that embed <code>@saas-maker/feedback</code> send submissions to api.sassmaker.com. That service stores the title, description, optional identity, page context, Pinpoint selector, and screenshot object reference. It is a separate product from this directory.</li>
       <li><strong>Third-party links:</strong> Individual products and package documentation have their own policies.</li>
     </ul>
 

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -5,14 +5,23 @@ description: The intentionally small SaaS Maker HTTP API.
 
 Base URL: https://api.sassmaker.com
 
+Machine-readable contract: [https://api.sassmaker.com/openapi.json](https://api.sassmaker.com/openapi.json)
+
+Errors are JSON objects of the form `{ "error": { "code", "message", "path" } }`.
+
 | Surface | Purpose | Auth |
 | --- | --- | --- |
 | GET /health | Liveness | None |
-| POST /v1/feedback | Submit feedback | X-Project-Key |
-| GET /v1/feedback | List one project's feedback | X-Project-Key |
-| GET /v1/feedback/by-project/:slug | Public feedback board | Optional session |
-| POST /v1/upload | Upload a feedback image | X-Project-Key |
+| GET /openapi.json | OpenAPI 3.1 document | None |
+| POST /v1/feedback | Submit feedback (JSON or multipart) | X-Project-Key |
+| GET /v1/feedback | List feedback with project, type, status, date, and cursor filters | Owner session or agent token |
+| GET /v1/feedback/:id | Read one record, including status events | Owner session or agent token |
+| PATCH /v1/feedback/:id | Update lifecycle status | Owner session or write-enabled agent token |
+| POST /v1/upload | Upload a screenshot for JSON clients | X-Project-Key |
 | /v1/projects | Manage project keys | Owner session |
+| /v1/projects/:id/agent-tokens | Create, list, and revoke agent tokens | Owner session |
 | /v1/auth/session | Resolve inbox session | Owner session |
+
+The publishable project key can only submit. Inbox reads and mutations use the owner's session or a separately issued `smk_` agent token. Agent tokens default to read-only.
 
 All other historical SaaS Maker service families are retired from this API.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -18,7 +18,7 @@ import '@saas-maker/feedback/dist/index.css';
 export function ProductFeedback() {
   return (
     <FeedbackWidget
-      projectId="pk_your_project_key"
+      projectKey="pk_your_project_key"
       userEmail="signed-in-user@example.com"
       theme="auto"
     />

--- a/docs/services/feedback.md
+++ b/docs/services/feedback.md
@@ -1,15 +1,30 @@
 ---
 title: Feedback service
-description: Submission, review, voting, and status behaviour.
+description: Hosted capture, review, and agent-readable lifecycle.
 ---
 
-Feedback can be a bug, feature request, or general feedback item. A submission
-requires a title, description, email address, and valid project key.
+Feedback is a bug, feature request, or general comment. A hosted submission
+needs a title, description, valid type, and publishable project key. Email,
+name, screenshots, page identity, and Pinpoint element context are optional.
 
-Public boards can list and vote on requests. The private inbox can update status
-or delete a request. The retained statuses support existing data:
-new, acknowledged, investigating, planned, in_progress, resolved, dismissed,
-and on_roadmap.
+The private inbox at app.sassmaker.com lists newest items first, filters by
+project, type, and status, and updates lifecycle. There is no public board,
+voting, or Fleet Console workflow.
+
+Retained statuses support existing data: new, acknowledged, investigating,
+planned, in_progress, resolved, dismissed, and on_roadmap.
+
+## Privacy and retention
+
+Submissions are stored in SaaS Maker's Feedback D1 database. Screenshot files
+are stored in a Feedback-owned R2 bucket; D1 keeps only the object URL.
+Page URL, page title, and Pinpoint selectors are stored as customer evidence
+and are never overwritten by later enrichment.
+
+Owner sessions and agent tokens can read the original title, description, page
+context, and submitter fields. Project keys cannot. SaaS Maker does not delete
+historical rows as part of ordinary review. Integrating products should
+disclose this collection in their own privacy policy.
 
 SaaS Maker does not turn feedback into tasks or marketing work. The owning
 product repository decides what to do after review.

--- a/docs/services/project-keys.md
+++ b/docs/services/project-keys.md
@@ -1,14 +1,19 @@
 ---
 title: Project keys
-description: How feedback projects and browser-safe keys work.
+description: How feedback projects, browser-safe keys, and agent tokens work.
 ---
 
 A project key routes feedback to one product. Create and manage keys in the
 private inbox at app.sassmaker.com.
 
-Send the key as the X-Project-Key header or as the FeedbackWidget projectId.
-The key is an identifier and submission credential, not an administrative
-session. Inbox reads and mutations require the owner's authenticated session.
+Send the key as the `X-Project-Key` header or as the FeedbackWidget
+`projectKey`. The key is an identifier and submission credential, not an
+administrative session. Inbox reads and mutations require the owner's
+authenticated session or a separately issued agent token.
+
+Agent tokens are Bearer credentials prefixed `smk_`. They are scoped to one
+project, default to read-only, and only mutate status when created with write
+permission. The plaintext token is shown once.
 
 Keep one key per product surface so feedback can be filtered and reviewed
 without inventing a second fleet registry.

--- a/docs/widgets/feedback.md
+++ b/docs/widgets/feedback.md
@@ -3,12 +3,15 @@ title: Feedback widget
 description: Configure the React feedback widget.
 ---
 
-FeedbackWidget accepts:
+FeedbackWidget accepts exactly one destination: hosted `projectKey`,
+`ingestionUrl`, or `onSubmit`.
 
 | Prop | Purpose |
 | --- | --- |
-| projectId | Required public project key |
-| apiBaseUrl | Optional API override; defaults to api.sassmaker.com |
+| projectKey | Public project key for the hosted SaaS Maker service |
+| apiBaseUrl | Optional API override; defaults to https://api.sassmaker.com |
+| ingestionUrl | Caller-owned multipart endpoint |
+| onSubmit | Product-owned submission callback |
 | userEmail | Pre-fill and lock the submitter email |
 | userName | Pre-fill the submitter name |
 | types | Allow bug, feature, feedback, or a subset |
@@ -23,7 +26,7 @@ the host application.
 
 ~~~tsx
 <FeedbackWidget
-  projectId="pk_example"
+  projectKey="pk_example"
   types={['bug', 'feature']}
   position="bottom-left"
   accentColor="#7c3aed"
@@ -31,4 +34,5 @@ the host application.
 />
 ~~~
 
-Screenshots accept JPEG, PNG, GIF, and WebP files up to 5 MB.
+Hosted mode sends one multipart POST to `/v1/feedback`. Screenshots accept
+JPEG, PNG, GIF, and WebP files up to 5 MB.

--- a/internal/contracts/index.ts
+++ b/internal/contracts/index.ts
@@ -10,8 +10,22 @@ export type FeedbackStatus =
   | 'resolved'
   | 'dismissed'
   | 'on_roadmap';
-export type AnyFeedbackStatus = FeedbackStatus;
+export type LegacyFeedbackStatus = 'done' | 'shipped' | 'cancelled' | 'reviewing' | 'closed';
+export type AnyFeedbackStatus = FeedbackStatus | LegacyFeedbackStatus;
 export type FeedbackVote = 'up' | 'down' | null;
+
+export interface FeedbackPageContext {
+  url: string;
+  title: string;
+}
+
+export interface FeedbackPinpoint {
+  selector: string;
+  tag: string | null;
+  text: string;
+  source: string | null;
+  url: string;
+}
 
 export interface UserRecord {
   id: string;
@@ -33,6 +47,16 @@ export interface ProjectRecord {
   created_at: string;
 }
 
+export interface FeedbackStatusEvent {
+  id: string;
+  feedback_id: string;
+  from_status: AnyFeedbackStatus | null;
+  to_status: AnyFeedbackStatus;
+  actor_id: string;
+  actor_kind: 'owner' | 'agent';
+  created_at: string;
+}
+
 export interface FeedbackRecord {
   id: string;
   project_id: string;
@@ -46,7 +70,14 @@ export interface FeedbackRecord {
   upvote_count: number;
   downvote_count: number;
   viewer_vote?: FeedbackVote;
+  page: FeedbackPageContext | null;
+  pinpoint: FeedbackPinpoint | null;
+  client_version: string | null;
+  source: string | null;
+  updated_at: string | null;
+  updated_by: string | null;
   created_at: string;
+  status_events?: FeedbackStatusEvent[];
 }
 
 export interface UpvoteRecord {
@@ -62,6 +93,28 @@ export interface SubmitFeedbackRequest {
   title: string;
   description: string;
   image_url?: string;
-  submitter_email: string;
+  submitter_email?: string;
   submitter_name?: string;
+  page?: FeedbackPageContext;
+  anchor?: FeedbackPinpoint;
+  client_version?: string;
+  source?: string;
+}
+
+export interface AgentTokenRecord {
+  id: string;
+  project_id: string;
+  name: string;
+  can_write: boolean;
+  token_prefix: string;
+  created_at: string;
+  last_used_at: string | null;
+}
+
+export interface ApiErrorBody {
+  error: {
+    code: string;
+    message: string;
+    path?: string;
+  };
 }

--- a/packages/widgets/feedback-widget/README.md
+++ b/packages/widgets/feedback-widget/README.md
@@ -1,8 +1,8 @@
 # @saas-maker/feedback
 
 A React feedback widget with optional screenshots and Pinpoint page-element
-context. Use SaaS Maker's hosted submission service or connect a destination
-your application already owns.
+context. The default SaaS Maker path is the hosted submission service; callback
+and URL ingestion remain explicit escape hatches.
 
 ## Install
 
@@ -10,7 +10,28 @@ your application already owns.
 pnpm add @saas-maker/feedback
 ```
 
+## Quick start: hosted service
+
+Create a project in the private feedback inbox at app.sassmaker.com, then use
+its public submission key in the browser:
+
+```tsx
+import { FeedbackWidget } from '@saas-maker/feedback'
+import '@saas-maker/feedback/dist/index.css'
+
+export function AppFeedback() {
+  return <FeedbackWidget projectKey="feedback_public_example" />
+}
+```
+
+The public key can only identify the destination project. It is not a secret
+and must not grant inbox access. The widget sends one `POST` to
+`https://api.sassmaker.com/v1/feedback` with the key in `X-Project-Key` and a
+multipart body (`feedback` JSON plus an optional `screenshot` file).
+
 ## Quick start: callback
+
+Use `onSubmit` when your product already owns storage:
 
 ```tsx
 import { FeedbackWidget } from '@saas-maker/feedback'
@@ -38,24 +59,6 @@ export function AppFeedback() {
 
 `onSubmit` may send an email, create an issue, call an authenticated API, or
 write to any system your product already uses.
-
-## Quick start: hosted service
-
-Create a project in the private feedback inbox, then use its public submission
-key in the browser:
-
-```tsx
-import { FeedbackWidget } from '@saas-maker/feedback'
-import '@saas-maker/feedback/dist/index.css'
-
-export function AppFeedback() {
-  return <FeedbackWidget projectKey="feedback_public_example" />
-}
-```
-
-The public key can only identify the destination project. It is not a secret
-and must not grant inbox access. The widget submits to `api.sassmaker.com` and
-uploads an optional screenshot before creating the feedback record.
 
 ## Quick start: ingestion URL
 
@@ -87,9 +90,10 @@ URL mode sends one `POST` with a `FormData` body:
 | `feedback` | JSON string containing the submission without `screenshot` |
 | `screenshot` | Original image file when supplied; otherwise omitted |
 
-The widget displays success only after a 2xx response. A network failure or
-non-2xx response keeps the form data available and shows an error. Requests are
-never retried automatically.
+Hosted mode uses the same multipart fields against `/v1/feedback`, plus the
+publishable `X-Project-Key` header. The widget displays success only after a 2xx
+response. A network failure or non-2xx response keeps the form data available
+and shows an error. Requests are never retried automatically.
 
 ## Payload
 
@@ -146,8 +150,8 @@ explicitly sends the form.
 ## Screenshots
 
 JPEG, PNG, GIF, and WebP files up to 5 MB can be attached. Callback mode receives
-the original `File`; URL mode uploads it in the `screenshot` multipart field.
-The package does not retain it.
+the original `File`; hosted and URL modes send it in the `screenshot` multipart
+field. The package does not retain it.
 
 ## Privacy
 

--- a/packages/widgets/feedback-widget/src/ingestion.ts
+++ b/packages/widgets/feedback-widget/src/ingestion.ts
@@ -49,6 +49,7 @@ export async function submitFeedbackToUrl(
 }
 
 const DEFAULT_API_BASE = 'https://api.sassmaker.com';
+const CLIENT_VERSION = '0.4.0';
 
 export async function submitFeedbackToProject(
   projectKey: string,
@@ -59,36 +60,35 @@ export async function submitFeedbackToProject(
   if (!key) throw new Error('Feedback project key cannot be empty.');
 
   const base = validateIngestionUrl(apiBaseUrl).replace(/\/$/, '');
-  let imageUrl: string | undefined;
+  const { screenshot, ...feedback } = submission;
+  const body = new FormData();
+  body.append(
+    'feedback',
+    JSON.stringify({
+      type: feedback.type,
+      title: feedback.title,
+      description: feedback.description,
+      submitter_email: feedback.email ?? '',
+      submitter_name: feedback.name,
+      page: feedback.page,
+      anchor: feedback.anchor,
+      source: 'widget',
+      client_version: CLIENT_VERSION,
+    })
+  );
+  if (screenshot) body.append('screenshot', screenshot);
 
-  if (submission.screenshot) {
-    const upload = new FormData();
-    upload.append('file', submission.screenshot);
-    const response = await fetch(`${base}/v1/upload`, {
+  let response: Response;
+  try {
+    response = await fetch(`${base}/v1/feedback`, {
       method: 'POST',
       headers: { 'X-Project-Key': key },
       credentials: 'omit',
-      body: upload,
+      body,
     });
-    if (!response.ok) throw new Error(`Feedback image upload returned HTTP ${response.status}.`);
-    const result = (await response.json()) as { url?: string };
-    imageUrl = result.url;
+  } catch (error) {
+    const detail = error instanceof Error && error.message ? `: ${error.message}` : '';
+    throw new Error(`Unable to reach the feedback service${detail}`, { cause: error });
   }
-
-  const response = await fetch(`${base}/v1/feedback`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'X-Project-Key': key },
-    credentials: 'omit',
-    body: JSON.stringify({
-      type: submission.type,
-      title: submission.title,
-      description: submission.description,
-      submitter_email: submission.email ?? '',
-      submitter_name: submission.name,
-      image_url: imageUrl,
-      page: submission.page,
-      anchor: submission.anchor,
-    }),
-  });
   if (!response.ok) throw new Error(`Feedback service returned HTTP ${response.status}.`);
 }

--- a/packages/widgets/feedback-widget/test/ingestion.test.mjs
+++ b/packages/widgets/feedback-widget/test/ingestion.test.mjs
@@ -114,7 +114,7 @@ test('turns network failures into actionable endpoint errors without retrying', 
   assert.equal(requests, 1);
 });
 
-test('hosted mode uploads an image and creates one project-scoped record', async (t) => {
+test('hosted mode sends one multipart request with the project key', async (t) => {
   const originalFetch = globalThis.fetch;
   t.after(() => {
     globalThis.fetch = originalFetch;
@@ -123,12 +123,6 @@ test('hosted mode uploads an image and creates one project-scoped record', async
   const requests = [];
   globalThis.fetch = async (url, init) => {
     requests.push({ url, init });
-    if (url.endsWith('/v1/upload')) {
-      return Response.json(
-        { url: 'https://images.sassmaker.com/feedback/screen.png' },
-        { status: 201 }
-      );
-    }
     return Response.json({ id: 'feedback_1' }, { status: 201 });
   };
 
@@ -139,12 +133,13 @@ test('hosted mode uploads an image and creates one project-scoped record', async
     'https://feedback.example/'
   );
 
-  assert.equal(requests.length, 2);
-  assert.equal(requests[0].url, 'https://feedback.example/v1/upload');
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0].url, 'https://feedback.example/v1/feedback');
   assert.equal(requests[0].init.headers['X-Project-Key'], 'feedback_public_example');
-  assert.equal(requests[1].url, 'https://feedback.example/v1/feedback');
-  const body = JSON.parse(requests[1].init.body);
-  assert.equal(body.submitter_email, 'person@example.com');
-  assert.equal(body.image_url, 'https://images.sassmaker.com/feedback/screen.png');
-  assert.deepEqual(body.page, submission().page);
+  assert.equal(requests[0].init.body instanceof FormData, true);
+  const payload = JSON.parse(requests[0].init.body.get('feedback'));
+  assert.equal(payload.submitter_email, 'person@example.com');
+  assert.equal(payload.source, 'widget');
+  assert.deepEqual(payload.page, submission().page);
+  assert.equal(requests[0].init.body.get('screenshot').name, 'screen.png');
 });

--- a/tests/api/feedback-agent.test.ts
+++ b/tests/api/feedback-agent.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockDb = {
+  getProjectByApiKey: vi.fn(),
+  getProjectById: vi.fn(),
+  getProjectBySlug: vi.fn(),
+  getFeedbackById: vi.fn(),
+  listFeedback: vi.fn(),
+  listFeedbackStatusEvents: vi.fn(),
+  updateFeedbackStatus: vi.fn(),
+  getAgentTokenByHash: vi.fn(),
+  touchAgentToken: vi.fn(),
+  listProjectsByOwner: vi.fn(),
+  upsertUser: vi.fn(),
+};
+
+vi.mock('../../workers/api/src/db', () => ({
+  getDb: () => mockDb,
+  createDatabase: () => mockDb,
+}));
+
+import { request } from './helpers';
+
+const PROJECT = {
+  id: 'proj-1',
+  owner_id: 'user-1',
+  name: 'Acme',
+  slug: 'acme',
+  api_key: 'pk_test',
+};
+
+const RECORD = {
+  id: 'fb-1',
+  project_id: 'proj-1',
+  type: 'bug',
+  status: 'new',
+  title: 'Broken CTA',
+  description: 'Cannot click save',
+  image_url: null,
+  submitter_email: '',
+  submitter_name: null,
+  upvote_count: 0,
+  downvote_count: 0,
+  page: { url: 'https://product.example/settings', title: 'Settings' },
+  pinpoint: null,
+  client_version: '0.4.0',
+  source: 'widget',
+  updated_at: null,
+  updated_by: null,
+  created_at: '2026-08-20T00:00:00Z',
+};
+
+beforeEach(() => {
+  Object.values(mockDb).forEach((fn) => fn.mockReset());
+  mockDb.getProjectById.mockResolvedValue(PROJECT);
+  mockDb.listFeedback.mockResolvedValue({ data: [RECORD], total: 1, next_cursor: null });
+  mockDb.getFeedbackById.mockResolvedValue(RECORD);
+  mockDb.listFeedbackStatusEvents.mockResolvedValue([]);
+  mockDb.updateFeedbackStatus.mockImplementation(async (_id, status) => ({ ...RECORD, status }));
+  mockDb.touchAgentToken.mockResolvedValue(undefined);
+});
+
+describe('Read-only agent tokens', () => {
+  it('GET /v1/feedback returns structured records for a read-only agent', async () => {
+    mockDb.getAgentTokenByHash.mockResolvedValue({
+      id: 'tok-1',
+      project_id: 'proj-1',
+      name: 'reader',
+      can_write: false,
+      token_prefix: 'smk_abcd',
+      created_at: '2026-08-20T00:00:00Z',
+      last_used_at: null,
+    });
+
+    const res = await request('/v1/feedback?status=new', {
+      headers: { Authorization: 'Bearer smk_readonly_example_token' },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data[0].id).toBe('fb-1');
+    expect(body.data[0].page.url).toBe('https://product.example/settings');
+    expect(mockDb.listFeedback).toHaveBeenCalledWith(
+      'proj-1',
+      expect.objectContaining({ status: 'new' }),
+      'user-1'
+    );
+  });
+
+  it('PATCH /v1/feedback/:id is rejected for a read-only agent', async () => {
+    mockDb.getAgentTokenByHash.mockResolvedValue({
+      id: 'tok-1',
+      project_id: 'proj-1',
+      name: 'reader',
+      can_write: false,
+      token_prefix: 'smk_abcd',
+      created_at: '2026-08-20T00:00:00Z',
+      last_used_at: null,
+    });
+
+    const res = await request('/v1/feedback/fb-1', {
+      method: 'PATCH',
+      headers: {
+        Authorization: 'Bearer smk_readonly_example_token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ status: 'reviewing' }),
+    });
+
+    expect(res.status).toBe(403);
+    expect((await res.json()).error.code).toBe('forbidden');
+    expect(mockDb.updateFeedbackStatus).not.toHaveBeenCalled();
+  });
+
+  it('PATCH /v1/feedback/:id records actor identity for a write-enabled agent', async () => {
+    mockDb.getAgentTokenByHash.mockResolvedValue({
+      id: 'tok-write',
+      project_id: 'proj-1',
+      name: 'writer',
+      can_write: true,
+      token_prefix: 'smk_efgh',
+      created_at: '2026-08-20T00:00:00Z',
+      last_used_at: null,
+    });
+
+    const res = await request('/v1/feedback/fb-1', {
+      method: 'PATCH',
+      headers: {
+        Authorization: 'Bearer smk_write_example_token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ status: 'acknowledged' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockDb.updateFeedbackStatus).toHaveBeenCalledWith('fb-1', 'acknowledged', {
+      actor_id: 'tok-write',
+      actor_kind: 'agent',
+    });
+  });
+});

--- a/tests/api/feedback-flow.test.ts
+++ b/tests/api/feedback-flow.test.ts
@@ -24,7 +24,10 @@ describe('Agent contract', () => {
     const body = await res.json();
     expect(body.openapi).toBe('3.1.0');
     expect(body.paths['/v1/feedback'].post).toBeDefined();
+    expect(body.paths['/v1/feedback'].get).toBeDefined();
     expect(body.paths['/v1/feedback/inbox'].get).toBeDefined();
+    expect(body.paths['/v1/projects/{id}/agent-tokens'].post).toBeDefined();
+    expect(body.components.securitySchemes.agentToken).toBeDefined();
   });
 });
 
@@ -42,7 +45,7 @@ describe('Feedback submission validation', () => {
     });
     expect(res.status).toBe(401);
     const body = await res.json();
-    expect(body.error).toMatch(/X-Project-Key/i);
+    expect(body.error.message).toMatch(/X-Project-Key/i);
   });
 });
 
@@ -51,7 +54,7 @@ describe('Project routes require auth', () => {
     const res = await request('/v1/projects');
     expect(res.status).toBe(401);
     const body = await res.json();
-    expect(body.error).toBe('Unauthorized');
+    expect(body.error.message).toBe('Unauthorized');
   });
 
   it('POST /v1/projects without auth returns 401', async () => {
@@ -62,7 +65,7 @@ describe('Project routes require auth', () => {
     });
     expect(res.status).toBe(401);
     const body = await res.json();
-    expect(body.error).toBe('Unauthorized');
+    expect(body.error.message).toBe('Unauthorized');
   });
 
   it('PATCH /v1/projects/123 without auth returns 401', async () => {
@@ -73,23 +76,30 @@ describe('Project routes require auth', () => {
     });
     expect(res.status).toBe(401);
     const body = await res.json();
-    expect(body.error).toBe('Unauthorized');
+    expect(body.error.message).toBe('Unauthorized');
   });
 
   it('DELETE /v1/projects/123 without auth returns 401', async () => {
     const res = await request('/v1/projects/123', { method: 'DELETE' });
     expect(res.status).toBe(401);
     const body = await res.json();
-    expect(body.error).toBe('Unauthorized');
+    expect(body.error.message).toBe('Unauthorized');
   });
 });
 
 describe('Dashboard feedback routes require auth', () => {
+  it('GET /v1/feedback without auth returns 401', async () => {
+    const res = await request('/v1/feedback');
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error.message).toBe('Unauthorized');
+  });
+
   it('GET /v1/feedback/inbox/123 without auth returns 401', async () => {
     const res = await request('/v1/feedback/inbox/123');
     expect(res.status).toBe(401);
     const body = await res.json();
-    expect(body.error).toBe('Unauthorized');
+    expect(body.error.message).toBe('Unauthorized');
   });
 
   it('PATCH /v1/feedback/123 without auth returns 401', async () => {
@@ -100,14 +110,14 @@ describe('Dashboard feedback routes require auth', () => {
     });
     expect(res.status).toBe(401);
     const body = await res.json();
-    expect(body.error).toBe('Unauthorized');
+    expect(body.error.message).toBe('Unauthorized');
   });
 
   it('GET /v1/feedback/123 without auth returns 401', async () => {
     const res = await request('/v1/feedback/123');
     expect(res.status).toBe(401);
     const body = await res.json();
-    expect(body.error).toBe('Unauthorized');
+    expect(body.error.message).toBe('Unauthorized');
   });
 });
 
@@ -116,7 +126,7 @@ describe('Upload validation', () => {
     const res = await request('/v1/upload', { method: 'POST' });
     expect(res.status).toBe(401);
     const body = await res.json();
-    expect(body.error).toMatch(/X-Project-Key/i);
+    expect(body.error.message).toMatch(/X-Project-Key/i);
   });
 });
 

--- a/tests/api/feedback-validation.test.ts
+++ b/tests/api/feedback-validation.test.ts
@@ -6,6 +6,12 @@ const mockDb = {
   getProjectById: vi.fn(),
   getUserById: vi.fn(),
   listFeedback: vi.fn(),
+  listFeedbackStatusEvents: vi.fn(),
+  updateFeedbackStatus: vi.fn(),
+  getFeedbackById: vi.fn(),
+  getAgentTokenByHash: vi.fn(),
+  touchAgentToken: vi.fn(),
+  listProjectsByOwner: vi.fn(),
 };
 
 vi.mock('../../workers/api/src/db', () => ({
@@ -60,7 +66,7 @@ describe('Feedback route validation with a mocked DB', () => {
     });
 
     expect(res.status).toBe(400);
-    expect((await res.json()).error).toMatch(/Title is required/i);
+    expect((await res.json()).error.message).toMatch(/Title is required/i);
     expect(mockDb.createFeedback).not.toHaveBeenCalled();
   });
 
@@ -81,6 +87,67 @@ describe('Feedback route validation with a mocked DB', () => {
     );
   });
 
+  it('POST /v1/feedback stores page and pinpoint context', async () => {
+    const res = await request('/v1/feedback', {
+      method: 'POST',
+      headers: apiKeyHeaders(),
+      body: JSON.stringify({
+        title: 'Broken CTA',
+        description: 'Cannot click save',
+        type: 'bug',
+        page: { url: 'https://product.example/settings', title: 'Settings' },
+        anchor: {
+          selector: '#save',
+          tag: 'button',
+          text: 'Save',
+          source: null,
+          url: '/settings',
+        },
+        client_version: '0.4.0',
+        source: 'widget',
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.id).toBeDefined();
+    expect(body.status).toBe('new');
+    expect(body.title).toBeUndefined();
+    expect(mockDb.createFeedback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        page: { url: 'https://product.example/settings', title: 'Settings' },
+        pinpoint: expect.objectContaining({ selector: '#save', tag: 'button' }),
+        source: 'widget',
+      })
+    );
+  });
+
+  it('POST /v1/feedback accepts multipart screenshot submissions', async () => {
+    const form = new FormData();
+    form.append(
+      'feedback',
+      JSON.stringify({
+        title: 'Screenshot bug',
+        description: 'See image',
+        type: 'bug',
+      })
+    );
+    form.append('screenshot', new File(['image-bytes'], 'screen.png', { type: 'image/png' }));
+
+    const res = await request('/v1/feedback', {
+      method: 'POST',
+      headers: { 'X-Project-Key': PROJECT.api_key },
+      body: form,
+    });
+
+    expect(res.status).toBe(201);
+    expect(mockDb.createFeedback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        image_url: expect.stringMatching(/^https:\/\/images\.sassmaker\.com\/feedback\//),
+      })
+    );
+  });
+
   it('POST /v1/feedback with key but invalid type returns 400', async () => {
     const res = await request('/v1/feedback', {
       method: 'POST',
@@ -94,7 +161,7 @@ describe('Feedback route validation with a mocked DB', () => {
     });
 
     expect(res.status).toBe(400);
-    expect((await res.json()).error).toMatch(/Invalid type/i);
+    expect((await res.json()).error.message).toMatch(/Invalid type/i);
     expect(mockDb.createFeedback).not.toHaveBeenCalled();
   });
 });

--- a/tests/api/helpers.ts
+++ b/tests/api/helpers.ts
@@ -9,7 +9,7 @@ export function request(path: string, init?: RequestInit, env?: Record<string, u
     APP_BASE_URL: 'http://localhost:3000',
     CORS_ORIGIN: '*',
     DATABASE_URL: 'postgresql://localhost:26257/test',
-    FEEDBACK_IMAGES: {} as any,
+    FEEDBACK_IMAGES: { put: async () => undefined } as any,
     RESEND_API_KEY: 'test',
     NOTIFICATION_FROM_EMAIL: 'test@test.com',
     ...env,

--- a/tests/api/migration-0025.test.ts
+++ b/tests/api/migration-0025.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { toFeedbackRecord } from '../../workers/api/src/db';
+
+describe('0025 feedback agent contract migration', () => {
+  const sql = readFileSync(
+    new URL('../../workers/api/migrations/0025_feedback_agent_contract.sql', import.meta.url),
+    'utf8'
+  );
+
+  it('copies existing feedback rows before replacing the table', () => {
+    expect(sql).toMatch(/INSERT INTO feedback_new/i);
+    expect(sql).toMatch(/SELECT[\s\S]*FROM feedback/i);
+    expect(sql).toMatch(/DROP TABLE feedback/i);
+    expect(sql.indexOf('INSERT INTO feedback_new')).toBeLessThan(
+      sql.indexOf('DROP TABLE feedback')
+    );
+  });
+
+  it('adds provenance columns, audit, and agent tokens without deleting unrelated tables', () => {
+    expect(sql).toMatch(/page_url/);
+    expect(sql).toMatch(/pinpoint_json/);
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS feedback_status_events/);
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS feedback_agent_tokens/);
+    expect(sql).not.toMatch(/DELETE FROM feedback/i);
+    expect(sql).not.toMatch(/DROP TABLE projects/i);
+  });
+});
+
+describe('Preserved feedback rows remain readable without new columns', () => {
+  it('maps a legacy row with original identifiers and customer fields', () => {
+    const record = toFeedbackRecord({
+      id: 'legacy-1',
+      project_id: 'proj-1',
+      type: 'feedback',
+      status: 'done',
+      title: 'Old title',
+      description: 'Old description',
+      image_url: null,
+      submitter_email: 'person@example.com',
+      submitter_name: 'Person',
+      upvote_count: 0,
+      downvote_count: 0,
+      created_at: '2026-01-01T00:00:00Z',
+    });
+
+    expect(record.id).toBe('legacy-1');
+    expect(record.title).toBe('Old title');
+    expect(record.description).toBe('Old description');
+    expect(record.submitter_email).toBe('person@example.com');
+    expect(record.page).toBeNull();
+    expect(record.pinpoint).toBeNull();
+  });
+});

--- a/workers/api/migrations/0025_feedback_agent_contract.sql
+++ b/workers/api/migrations/0025_feedback_agent_contract.sql
@@ -1,0 +1,76 @@
+-- Forward-only Feedback contract: page/pinpoint provenance, status audit, and
+-- project-scoped agent tokens. Existing feedback rows are copied, not rewritten.
+
+PRAGMA foreign_keys = OFF;
+
+CREATE TABLE feedback_new (
+  id TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  type TEXT NOT NULL CHECK (type IN ('bug','feature','feedback')),
+  status TEXT NOT NULL DEFAULT 'new' CHECK (status IN (
+    'new','acknowledged','investigating','planned','in_progress','resolved','dismissed','on_roadmap',
+    'done','shipped','cancelled','reviewing','closed'
+  )),
+  title TEXT NOT NULL,
+  description TEXT NOT NULL,
+  image_url TEXT,
+  submitter_email TEXT NOT NULL,
+  submitter_name TEXT,
+  upvote_count INTEGER NOT NULL DEFAULT 0,
+  downvote_count INTEGER NOT NULL DEFAULT 0,
+  page_url TEXT,
+  page_title TEXT,
+  pinpoint_json TEXT,
+  client_version TEXT,
+  source TEXT,
+  updated_at TEXT,
+  updated_by TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+INSERT INTO feedback_new (
+  id, project_id, type, status, title, description, image_url,
+  submitter_email, submitter_name, upvote_count, downvote_count, created_at
+)
+SELECT
+  id, project_id, type, status, title, description, image_url,
+  submitter_email, submitter_name, upvote_count, downvote_count, created_at
+FROM feedback;
+
+DROP TABLE feedback;
+ALTER TABLE feedback_new RENAME TO feedback;
+
+CREATE INDEX idx_feedback_project ON feedback(project_id);
+CREATE INDEX idx_feedback_project_status ON feedback(project_id, status);
+CREATE INDEX idx_feedback_project_upvotes ON feedback(project_id, upvote_count DESC);
+CREATE INDEX idx_feedback_project_type_status ON feedback(project_id, type, status);
+CREATE INDEX idx_feedback_created ON feedback(created_at DESC, id DESC);
+
+CREATE TABLE IF NOT EXISTS feedback_status_events (
+  id TEXT PRIMARY KEY,
+  feedback_id TEXT NOT NULL REFERENCES feedback(id) ON DELETE CASCADE,
+  from_status TEXT,
+  to_status TEXT NOT NULL,
+  actor_id TEXT NOT NULL,
+  actor_kind TEXT NOT NULL CHECK (actor_kind IN ('owner','agent')),
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_feedback_status_events_feedback
+  ON feedback_status_events(feedback_id, created_at);
+
+CREATE TABLE IF NOT EXISTS feedback_agent_tokens (
+  id TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  token_hash TEXT NOT NULL UNIQUE,
+  token_prefix TEXT NOT NULL,
+  name TEXT NOT NULL,
+  can_write INTEGER NOT NULL DEFAULT 0 CHECK (can_write IN (0, 1)),
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  last_used_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_feedback_agent_tokens_project
+  ON feedback_agent_tokens(project_id, created_at DESC);
+
+PRAGMA foreign_keys = ON;

--- a/workers/api/src/db.ts
+++ b/workers/api/src/db.ts
@@ -1,6 +1,10 @@
 import type {
+  AgentTokenRecord,
   AnyFeedbackStatus,
+  FeedbackPageContext,
+  FeedbackPinpoint,
   FeedbackRecord,
+  FeedbackStatusEvent,
   FeedbackType,
   FeedbackVote,
   ProjectRecord,
@@ -11,9 +15,12 @@ import type {
 type FeedbackQuery = {
   type?: FeedbackType;
   status?: AnyFeedbackStatus;
+  since?: string;
+  until?: string;
   sort?: 'newest' | 'upvotes';
   page?: number;
   limit?: number;
+  cursor?: string;
 };
 
 type ProjectInput = {
@@ -26,10 +33,23 @@ type ProjectInput = {
   git_url?: string | null;
 };
 
-type FeedbackInput = Omit<
-  FeedbackRecord,
-  'upvote_count' | 'downvote_count' | 'viewer_vote' | 'created_at'
->;
+type FeedbackInput = {
+  id: string;
+  project_id: string;
+  type: FeedbackType;
+  status: AnyFeedbackStatus;
+  title: string;
+  description: string;
+  image_url: string | null;
+  submitter_email: string;
+  submitter_name: string | null;
+  page?: FeedbackPageContext | null;
+  pinpoint?: FeedbackPinpoint | null;
+  client_version?: string | null;
+  source?: string | null;
+};
+
+export type AgentTokenRow = AgentTokenRecord & { token_hash: string; can_write_flag: number };
 
 export interface FeedbackDatabase {
   upsertUser(input: Omit<UserRecord, 'created_at'>): Promise<UserRecord>;
@@ -50,8 +70,13 @@ export interface FeedbackDatabase {
     projectId: string,
     query: FeedbackQuery,
     userId?: string
-  ): Promise<{ data: FeedbackRecord[]; total: number }>;
-  updateFeedbackStatus(id: string, status: AnyFeedbackStatus): Promise<FeedbackRecord | null>;
+  ): Promise<{ data: FeedbackRecord[]; total: number; next_cursor: string | null }>;
+  listFeedbackStatusEvents(feedbackId: string): Promise<FeedbackStatusEvent[]>;
+  updateFeedbackStatus(
+    id: string,
+    status: AnyFeedbackStatus,
+    actor: { actor_id: string; actor_kind: 'owner' | 'agent' }
+  ): Promise<FeedbackRecord | null>;
   deleteFeedback(id: string): Promise<boolean>;
   setVote(input: {
     id: string;
@@ -61,6 +86,18 @@ export interface FeedbackDatabase {
   }): Promise<UpvoteRecord>;
   removeVote(feedbackId: string, userId: string): Promise<boolean>;
   getUserVote(feedbackId: string, userId: string): Promise<FeedbackVote>;
+  createAgentToken(input: {
+    id: string;
+    project_id: string;
+    token_hash: string;
+    token_prefix: string;
+    name: string;
+    can_write: boolean;
+  }): Promise<AgentTokenRecord>;
+  listAgentTokens(projectId: string): Promise<AgentTokenRecord[]>;
+  getAgentTokenByHash(tokenHash: string): Promise<AgentTokenRow | null>;
+  touchAgentToken(id: string): Promise<void>;
+  deleteAgentToken(id: string, projectId: string): Promise<boolean>;
 }
 
 function mapRow<T>(row: Record<string, unknown> | null | undefined): T | null {
@@ -73,10 +110,66 @@ function parseViewerVote(value: unknown): FeedbackVote {
   return null;
 }
 
-function toFeedbackRecord(row: Record<string, unknown>): FeedbackRecord {
+function parsePinpoint(value: unknown): FeedbackPinpoint | null {
+  if (!value || typeof value !== 'string') return null;
+  try {
+    const parsed = JSON.parse(value) as FeedbackPinpoint;
+    if (!parsed || typeof parsed.selector !== 'string') return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function encodeCursor(createdAt: string, id: string): string {
+  return btoa(`${createdAt}|${id}`);
+}
+
+export function decodeCursor(cursor: string): { created_at: string; id: string } | null {
+  try {
+    const [created_at, id] = atob(cursor).split('|');
+    if (!created_at || !id) return null;
+    return { created_at, id };
+  } catch {
+    return null;
+  }
+}
+
+function toAgentToken(row: Record<string, unknown>): AgentTokenRecord {
   return {
-    ...(row as unknown as FeedbackRecord),
+    id: String(row.id),
+    project_id: String(row.project_id),
+    name: String(row.name),
+    can_write: Number(row.can_write) === 1,
+    token_prefix: String(row.token_prefix),
+    created_at: String(row.created_at),
+    last_used_at: row.last_used_at ? String(row.last_used_at) : null,
+  };
+}
+
+export function toFeedbackRecord(row: Record<string, unknown>): FeedbackRecord {
+  const pageUrl = typeof row.page_url === 'string' ? row.page_url : null;
+  const pageTitle = typeof row.page_title === 'string' ? row.page_title : null;
+  return {
+    id: String(row.id),
+    project_id: String(row.project_id),
+    type: row.type as FeedbackType,
+    status: row.status as AnyFeedbackStatus,
+    title: String(row.title),
+    description: String(row.description),
+    image_url: row.image_url ? String(row.image_url) : null,
+    submitter_email: row.submitter_email ? String(row.submitter_email) : '',
+    submitter_name: row.submitter_name ? String(row.submitter_name) : null,
+    upvote_count: Number(row.upvote_count ?? 0),
+    downvote_count: Number(row.downvote_count ?? 0),
     viewer_vote: parseViewerVote(row.viewer_vote),
+    page: pageUrl || pageTitle ? { url: pageUrl || '', title: pageTitle || '' } : null,
+    pinpoint: parsePinpoint(row.pinpoint_json),
+    client_version: row.client_version ? String(row.client_version) : null,
+    source: row.source ? String(row.source) : null,
+    updated_at: row.updated_at ? String(row.updated_at) : null,
+    updated_by: row.updated_by ? String(row.updated_by) : null,
+    created_at: String(row.created_at),
   };
 }
 
@@ -195,8 +288,9 @@ export function getDb(d1: D1Database): FeedbackDatabase {
       await d1
         .prepare(
           `INSERT INTO feedback
-             (id, project_id, type, status, title, description, image_url, submitter_email, submitter_name)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+             (id, project_id, type, status, title, description, image_url, submitter_email, submitter_name,
+              page_url, page_title, pinpoint_json, client_version, source)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
         )
         .bind(
           input.id,
@@ -207,7 +301,12 @@ export function getDb(d1: D1Database): FeedbackDatabase {
           input.description,
           input.image_url,
           input.submitter_email,
-          input.submitter_name
+          input.submitter_name,
+          input.page?.url ?? null,
+          input.page?.title ?? null,
+          input.pinpoint ? JSON.stringify(input.pinpoint) : null,
+          input.client_version ?? null,
+          input.source ?? 'api'
         )
         .run();
       const row = await d1
@@ -226,8 +325,7 @@ export function getDb(d1: D1Database): FeedbackDatabase {
     },
 
     async listFeedback(projectId, query, userId) {
-      const { type, status, sort = 'newest', page = 1, limit = 20 } = query;
-      const offset = (page - 1) * limit;
+      const { type, status, since, until, sort = 'newest', page = 1, limit = 20, cursor } = query;
       const conditions = ['f.project_id = ?'];
       const values: unknown[] = [projectId];
       if (type) {
@@ -238,9 +336,25 @@ export function getDb(d1: D1Database): FeedbackDatabase {
         conditions.push('f.status = ?');
         values.push(status);
       }
+      if (since) {
+        conditions.push('f.created_at >= ?');
+        values.push(since);
+      }
+      if (until) {
+        conditions.push('f.created_at <= ?');
+        values.push(until);
+      }
+      const decoded = cursor ? decodeCursor(cursor) : null;
+      if (decoded) {
+        conditions.push('(f.created_at < ? OR (f.created_at = ? AND f.id < ?))');
+        values.push(decoded.created_at, decoded.created_at, decoded.id);
+      }
       const where = conditions.join(' AND ');
       const orderBy =
-        sort === 'upvotes' ? 'f.upvote_count DESC, f.created_at DESC' : 'f.created_at DESC';
+        sort === 'upvotes'
+          ? 'f.upvote_count DESC, f.created_at DESC'
+          : 'f.created_at DESC, f.id DESC';
+      const offset = decoded ? 0 : (page - 1) * limit;
       const countStatement = d1
         .prepare(`SELECT COUNT(*) AS total FROM feedback f WHERE ${where}`)
         .bind(...values);
@@ -269,14 +383,69 @@ export function getDb(d1: D1Database): FeedbackDatabase {
         countStatement.first<{ total: number }>(),
         dataStatement.all(),
       ]);
+      const data = (dataResult.results as Record<string, unknown>[]).map(toFeedbackRecord);
+      const next_cursor =
+        data.length === limit
+          ? encodeCursor(data[data.length - 1].created_at, data[data.length - 1].id)
+          : null;
       return {
-        data: (dataResult.results as Record<string, unknown>[]).map(toFeedbackRecord),
+        data,
         total: Number(countRow?.total ?? 0),
+        next_cursor,
       };
     },
 
-    async updateFeedbackStatus(id, status) {
-      await d1.prepare('UPDATE feedback SET status = ? WHERE id = ?').bind(status, id).run();
+    async listFeedbackStatusEvents(feedbackId) {
+      const { results } = await d1
+        .prepare(
+          `SELECT * FROM feedback_status_events
+           WHERE feedback_id = ?
+           ORDER BY created_at ASC`
+        )
+        .bind(feedbackId)
+        .all();
+      return (results as Record<string, unknown>[]).map((row) => ({
+        id: String(row.id),
+        feedback_id: String(row.feedback_id),
+        from_status: row.from_status ? (row.from_status as AnyFeedbackStatus) : null,
+        to_status: row.to_status as AnyFeedbackStatus,
+        actor_id: String(row.actor_id),
+        actor_kind: row.actor_kind as 'owner' | 'agent',
+        created_at: String(row.created_at),
+      }));
+    },
+
+    async updateFeedbackStatus(id, status, actor) {
+      const existing = await d1
+        .prepare('SELECT *, NULL AS viewer_vote FROM feedback WHERE id = ?')
+        .bind(id)
+        .first<Record<string, unknown>>();
+      if (!existing) return null;
+
+      await d1
+        .prepare(
+          `UPDATE feedback
+           SET status = ?, updated_at = datetime('now'), updated_by = ?
+           WHERE id = ?`
+        )
+        .bind(status, actor.actor_id, id)
+        .run();
+      await d1
+        .prepare(
+          `INSERT INTO feedback_status_events
+             (id, feedback_id, from_status, to_status, actor_id, actor_kind)
+           VALUES (?, ?, ?, ?, ?, ?)`
+        )
+        .bind(
+          crypto.randomUUID(),
+          id,
+          existing.status ?? null,
+          status,
+          actor.actor_id,
+          actor.actor_kind
+        )
+        .run();
+
       const row = await d1
         .prepare('SELECT *, NULL AS viewer_vote FROM feedback WHERE id = ?')
         .bind(id)
@@ -359,6 +528,69 @@ export function getDb(d1: D1Database): FeedbackDatabase {
         .bind(feedbackId, userId)
         .first();
       return parseViewerVote(row?.vote);
+    },
+
+    async createAgentToken(input) {
+      await d1
+        .prepare(
+          `INSERT INTO feedback_agent_tokens
+             (id, project_id, token_hash, token_prefix, name, can_write)
+           VALUES (?, ?, ?, ?, ?, ?)`
+        )
+        .bind(
+          input.id,
+          input.project_id,
+          input.token_hash,
+          input.token_prefix,
+          input.name,
+          input.can_write ? 1 : 0
+        )
+        .run();
+      const row = await d1
+        .prepare('SELECT * FROM feedback_agent_tokens WHERE id = ?')
+        .bind(input.id)
+        .first();
+      return toAgentToken(row as Record<string, unknown>);
+    },
+
+    async listAgentTokens(projectId) {
+      const { results } = await d1
+        .prepare(
+          `SELECT * FROM feedback_agent_tokens
+           WHERE project_id = ?
+           ORDER BY created_at DESC`
+        )
+        .bind(projectId)
+        .all();
+      return (results as Record<string, unknown>[]).map(toAgentToken);
+    },
+
+    async getAgentTokenByHash(tokenHash) {
+      const row = await d1
+        .prepare('SELECT * FROM feedback_agent_tokens WHERE token_hash = ?')
+        .bind(tokenHash)
+        .first<Record<string, unknown>>();
+      if (!row) return null;
+      return {
+        ...toAgentToken(row),
+        token_hash: String(row.token_hash),
+        can_write_flag: Number(row.can_write),
+      };
+    },
+
+    async touchAgentToken(id) {
+      await d1
+        .prepare(`UPDATE feedback_agent_tokens SET last_used_at = datetime('now') WHERE id = ?`)
+        .bind(id)
+        .run();
+    },
+
+    async deleteAgentToken(id, projectId) {
+      const { meta } = await d1
+        .prepare('DELETE FROM feedback_agent_tokens WHERE id = ? AND project_id = ?')
+        .bind(id, projectId)
+        .run();
+      return (meta.changes ?? 0) > 0;
     },
   };
 }

--- a/workers/api/src/index.ts
+++ b/workers/api/src/index.ts
@@ -6,16 +6,37 @@ import { projects } from './routes/projects';
 import { feedback } from './routes/feedback';
 import { upload } from './routes/upload';
 import { rateLimit } from './middleware/rate-limit';
+import { openApiDocument } from './openapi';
 
 const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 
 app.onError((err, c) => {
   console.error(`[${c.get('requestId') || 'unknown'}] Unhandled error:`, err.message, err.stack);
-  return c.json({ error: 'Internal server error' }, 500);
+  return c.json(
+    {
+      error: {
+        code: 'internal_error',
+        message: 'Internal server error',
+        path: c.req.path,
+      },
+    },
+    500
+  );
 });
 
 // Structured JSON for unmatched routes (Hono's default is plain text).
-app.notFound((c) => c.json({ error: 'Not found' }, 404));
+app.notFound((c) =>
+  c.json(
+    {
+      error: {
+        code: 'not_found',
+        message: `No API endpoint matches '${c.req.path}'. See https://api.sassmaker.com/openapi.json for the available endpoints.`,
+        path: c.req.path,
+      },
+    },
+    404
+  )
+);
 
 const ALLOWED_ORIGINS = new Set([
   'https://app.sassmaker.com',
@@ -53,51 +74,7 @@ app.use('*', async (c, next) => {
 
 app.get('/health', (c) => c.json({ status: 'ok' }));
 
-app.get('/openapi.json', (c) =>
-  c.json({
-    openapi: '3.1.0',
-    info: {
-      title: 'SaaS Maker Feedback API',
-      version: '1.0.0',
-      description: 'Submit feedback publicly and review it through an authenticated private inbox.',
-    },
-    servers: [{ url: 'https://api.sassmaker.com' }],
-    paths: {
-      '/v1/feedback': {
-        post: {
-          summary: 'Submit feedback',
-          security: [{ projectKey: [] }],
-          responses: { '201': { description: 'Feedback created' } },
-        },
-      },
-      '/v1/feedback/inbox': {
-        get: {
-          summary: 'List feedback across owned projects',
-          security: [{ bearerSession: [] }],
-          responses: { '200': { description: 'Newest-first feedback page' } },
-        },
-      },
-      '/v1/feedback/{id}': {
-        get: {
-          summary: 'Read one feedback item',
-          security: [{ bearerSession: [] }],
-          responses: { '200': { description: 'Feedback record' } },
-        },
-        patch: {
-          summary: 'Update feedback status',
-          security: [{ bearerSession: [] }],
-          responses: { '200': { description: 'Updated feedback record' } },
-        },
-      },
-    },
-    components: {
-      securitySchemes: {
-        projectKey: { type: 'apiKey', in: 'header', name: 'X-Project-Key' },
-        bearerSession: { type: 'http', scheme: 'bearer' },
-      },
-    },
-  })
-);
+app.get('/openapi.json', (c) => c.json(openApiDocument));
 
 app.use('/v1/*', rateLimit({ limit: 100, period: 60 }));
 

--- a/workers/api/src/lib/crypto.ts
+++ b/workers/api/src/lib/crypto.ts
@@ -1,0 +1,15 @@
+export async function sha256Hex(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value));
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+export function randomToken(prefix: string, bytes = 24): string {
+  const entropy = new Uint8Array(bytes);
+  crypto.getRandomValues(entropy);
+  return (
+    prefix +
+    Array.from(entropy)
+      .map((byte) => byte.toString(16).padStart(2, '0'))
+      .join('')
+  );
+}

--- a/workers/api/src/lib/errors.ts
+++ b/workers/api/src/lib/errors.ts
@@ -1,0 +1,27 @@
+import type { Context } from 'hono';
+
+export type ErrorCode =
+  | 'unauthorized'
+  | 'forbidden'
+  | 'not_found'
+  | 'invalid_request'
+  | 'rate_limited'
+  | 'internal_error';
+
+export function apiError(
+  c: Context,
+  status: 400 | 401 | 403 | 404 | 409 | 413 | 415 | 429 | 500,
+  code: ErrorCode,
+  message: string
+) {
+  return c.json(
+    {
+      error: {
+        code,
+        message,
+        path: c.req.path,
+      },
+    },
+    status
+  );
+}

--- a/workers/api/src/lib/screenshots.ts
+++ b/workers/api/src/lib/screenshots.ts
@@ -1,0 +1,21 @@
+import { apiError } from './errors';
+import type { AppContext } from '../types';
+
+export const MAX_SCREENSHOT_BYTES = 5 * 1024 * 1024;
+export const ALLOWED_SCREENSHOT_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+
+export async function storeScreenshot(c: AppContext, file: File): Promise<string | Response> {
+  if (!ALLOWED_SCREENSHOT_TYPES.includes(file.type)) {
+    return apiError(c, 415, 'invalid_request', 'Invalid file type. Allowed: jpeg, png, gif, webp');
+  }
+  if (file.size > MAX_SCREENSHOT_BYTES) {
+    return apiError(c, 413, 'invalid_request', 'File too large. Max 5MB');
+  }
+
+  const ext = file.type.split('/')[1];
+  const key = `feedback/${crypto.randomUUID()}.${ext}`;
+  await c.env.FEEDBACK_IMAGES.put(key, file.stream(), {
+    httpMetadata: { contentType: file.type },
+  });
+  return `https://images.sassmaker.com/${key}`;
+}

--- a/workers/api/src/middleware/auth.ts
+++ b/workers/api/src/middleware/auth.ts
@@ -1,6 +1,8 @@
 import { createMiddleware } from 'hono/factory';
-import { Bindings, Variables } from '../types';
 import { getDb } from '../db';
+import { sha256Hex } from '../lib/crypto';
+import { apiError } from '../lib/errors';
+import { Bindings, Variables } from '../types';
 
 const DEFAULT_LOCAL_SESSION_TOKEN = 'local-dev-session';
 
@@ -76,13 +78,48 @@ export const requireSession = createMiddleware<{ Bindings: Bindings; Variables: 
   async (c, next) => {
     const authHeader = c.req.header('Authorization');
     if (!authHeader?.startsWith('Bearer ')) {
-      return c.json({ error: 'Unauthorized' }, 401);
+      return apiError(c, 401, 'unauthorized', 'Unauthorized');
     }
 
     const userId = await resolveBearerUserId(c, authHeader.slice(7));
-    if (!userId) return c.json({ error: 'Unauthorized' }, 401);
+    if (!userId) return apiError(c, 401, 'unauthorized', 'Unauthorized');
 
     c.set('userId', userId);
+    c.set('actorKind', 'owner');
+    c.set('canWrite', true);
+    await next();
+  }
+);
+
+export const requireInboxAuth = createMiddleware<{ Bindings: Bindings; Variables: Variables }>(
+  async (c, next) => {
+    const authHeader = c.req.header('Authorization');
+    if (!authHeader?.startsWith('Bearer ')) {
+      return apiError(c, 401, 'unauthorized', 'Unauthorized');
+    }
+
+    const token = authHeader.slice(7);
+    if (token.startsWith('smk_')) {
+      const db = getDb(c.env.DB);
+      const agent = await db.getAgentTokenByHash(await sha256Hex(token));
+      if (!agent) return apiError(c, 401, 'unauthorized', 'Unauthorized');
+      const project = await db.getProjectById(agent.project_id);
+      if (!project) return apiError(c, 401, 'unauthorized', 'Unauthorized');
+      await db.touchAgentToken(agent.id);
+      c.set('userId', project.owner_id);
+      c.set('projectId', project.id);
+      c.set('project', project);
+      c.set('actorKind', 'agent');
+      c.set('canWrite', agent.can_write);
+      c.set('agentTokenId', agent.id);
+      return next();
+    }
+
+    const userId = await resolveBearerUserId(c, token);
+    if (!userId) return apiError(c, 401, 'unauthorized', 'Unauthorized');
+    c.set('userId', userId);
+    c.set('actorKind', 'owner');
+    c.set('canWrite', true);
     await next();
   }
 );
@@ -95,7 +132,7 @@ export const requireApiKeyOrSession = createMiddleware<{
   if (apiKey) {
     const db = getDb(c.env.DB);
     const project = await db.getProjectByApiKey(apiKey);
-    if (!project) return c.json({ error: 'Invalid API key' }, 401);
+    if (!project) return apiError(c, 401, 'unauthorized', 'Invalid API key');
     c.set('projectId', project.id);
     c.set('project', project);
     return next();
@@ -103,11 +140,11 @@ export const requireApiKeyOrSession = createMiddleware<{
 
   const authHeader = c.req.header('Authorization');
   if (!authHeader?.startsWith('Bearer ')) {
-    return c.json({ error: 'Unauthorized' }, 401);
+    return apiError(c, 401, 'unauthorized', 'Unauthorized');
   }
 
   const userId = await resolveBearerUserId(c, authHeader.slice(7));
-  if (!userId) return c.json({ error: 'Unauthorized' }, 401);
+  if (!userId) return apiError(c, 401, 'unauthorized', 'Unauthorized');
 
   c.set('userId', userId);
   await next();
@@ -116,11 +153,11 @@ export const requireApiKeyOrSession = createMiddleware<{
 export const requireApiKey = createMiddleware<{ Bindings: Bindings; Variables: Variables }>(
   async (c, next) => {
     const apiKey = c.req.header('X-Project-Key');
-    if (!apiKey) return c.json({ error: 'Missing X-Project-Key header' }, 401);
+    if (!apiKey) return apiError(c, 401, 'unauthorized', 'Missing X-Project-Key header');
 
     const db = getDb(c.env.DB);
     const project = await db.getProjectByApiKey(apiKey);
-    if (!project) return c.json({ error: 'Invalid API key' }, 401);
+    if (!project) return apiError(c, 401, 'unauthorized', 'Invalid API key');
 
     c.set('projectId', project.id);
     c.set('project', project);

--- a/workers/api/src/middleware/rate-limit.ts
+++ b/workers/api/src/middleware/rate-limit.ts
@@ -21,7 +21,16 @@ export const rateLimit = (options: { limit: number; period: number; skipPrefixes
       const { success } = await c.env.RATE_LIMITER.limit({ key });
 
       if (!success) {
-        return c.json({ error: 'Rate limit exceeded' }, 429);
+        return c.json(
+          {
+            error: {
+              code: 'rate_limited',
+              message: 'Rate limit exceeded',
+              path: c.req.path,
+            },
+          },
+          429
+        );
       }
     } catch (err) {
       console.error('Rate limiter error:', err);

--- a/workers/api/src/openapi.ts
+++ b/workers/api/src/openapi.ts
@@ -1,0 +1,177 @@
+export const openApiDocument = {
+  openapi: '3.1.0',
+  info: {
+    title: 'SaaS Maker Feedback API',
+    version: '1.0.0',
+    description:
+      'Submit customer feedback with a publishable project key and review it through the same authenticated JSON contract used by the private inbox and agents.',
+  },
+  servers: [{ url: 'https://api.sassmaker.com' }],
+  paths: {
+    '/health': {
+      get: {
+        summary: 'Liveness',
+        security: [],
+        responses: { '200': { description: 'Service is up' } },
+      },
+    },
+    '/openapi.json': {
+      get: {
+        summary: 'This OpenAPI document',
+        security: [],
+        responses: { '200': { description: 'OpenAPI 3.1 JSON' } },
+      },
+    },
+    '/v1/feedback': {
+      post: {
+        summary: 'Submit feedback',
+        security: [{ projectKey: [] }],
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/SubmitFeedback' },
+            },
+            'multipart/form-data': {
+              schema: {
+                type: 'object',
+                required: ['feedback'],
+                properties: {
+                  feedback: {
+                    type: 'string',
+                    description: 'JSON string matching SubmitFeedback',
+                  },
+                  screenshot: { type: 'string', format: 'binary' },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          '201': { description: 'Feedback created' },
+          '400': { description: 'Invalid payload' },
+          '401': { description: 'Missing or invalid project key' },
+          '429': { description: 'Rate limited' },
+        },
+      },
+      get: {
+        summary: 'List feedback the caller is authorized to read',
+        security: [{ bearerSession: [] }, { agentToken: [] }],
+        parameters: [
+          { name: 'project', in: 'query', schema: { type: 'string' } },
+          {
+            name: 'type',
+            in: 'query',
+            schema: { type: 'string', enum: ['bug', 'feature', 'feedback'] },
+          },
+          { name: 'status', in: 'query', schema: { type: 'string' } },
+          { name: 'since', in: 'query', schema: { type: 'string', format: 'date-time' } },
+          { name: 'until', in: 'query', schema: { type: 'string', format: 'date-time' } },
+          { name: 'cursor', in: 'query', schema: { type: 'string' } },
+          { name: 'page', in: 'query', schema: { type: 'integer', minimum: 1 } },
+        ],
+        responses: { '200': { description: 'Newest-first feedback page' } },
+      },
+    },
+    '/v1/feedback/inbox': {
+      get: {
+        summary: 'Alias of GET /v1/feedback for the owner inbox',
+        security: [{ bearerSession: [] }, { agentToken: [] }],
+        responses: { '200': { description: 'Newest-first feedback page' } },
+      },
+    },
+    '/v1/feedback/{id}': {
+      get: {
+        summary: 'Read one feedback item',
+        security: [{ bearerSession: [] }, { agentToken: [] }],
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+        responses: { '200': { description: 'Feedback record with status events' } },
+      },
+      patch: {
+        summary: 'Update feedback status',
+        security: [{ bearerSession: [] }, { agentToken: [] }],
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['status'],
+                properties: { status: { type: 'string' } },
+              },
+            },
+          },
+        },
+        responses: {
+          '200': { description: 'Updated feedback record' },
+          '403': { description: 'Read-only agent token' },
+        },
+      },
+    },
+    '/v1/upload': {
+      post: {
+        summary: 'Upload a screenshot for hosted JSON clients',
+        security: [{ projectKey: [] }],
+        responses: { '201': { description: 'Object URL' } },
+      },
+    },
+    '/v1/projects': {
+      get: {
+        summary: 'List owned projects',
+        security: [{ bearerSession: [] }],
+        responses: { '200': { description: 'Project keys' } },
+      },
+      post: {
+        summary: 'Create a project and publishable submission key',
+        security: [{ bearerSession: [] }],
+        responses: { '201': { description: 'Created project' } },
+      },
+    },
+    '/v1/projects/{id}/agent-tokens': {
+      get: {
+        summary: 'List agent tokens for a project',
+        security: [{ bearerSession: [] }],
+        responses: { '200': { description: 'Token metadata; plaintext is never returned again' } },
+      },
+      post: {
+        summary: 'Create a project-scoped agent token',
+        description: 'Tokens default to read-only. Set can_write=true for lifecycle mutations.',
+        security: [{ bearerSession: [] }],
+        responses: { '201': { description: 'Token metadata plus one-time plaintext token' } },
+      },
+    },
+  },
+  components: {
+    securitySchemes: {
+      projectKey: { type: 'apiKey', in: 'header', name: 'X-Project-Key' },
+      bearerSession: { type: 'http', scheme: 'bearer' },
+      agentToken: {
+        type: 'http',
+        scheme: 'bearer',
+        description: 'Project-scoped smk_ token. Defaults to read-only.',
+      },
+    },
+    schemas: {
+      SubmitFeedback: {
+        type: 'object',
+        required: ['type', 'title', 'description'],
+        properties: {
+          type: { type: 'string', enum: ['bug', 'feature', 'feedback'] },
+          title: { type: 'string' },
+          description: { type: 'string' },
+          submitter_email: { type: 'string' },
+          submitter_name: { type: 'string' },
+          image_url: { type: 'string' },
+          page: {
+            type: 'object',
+            properties: { url: { type: 'string' }, title: { type: 'string' } },
+          },
+          anchor: { type: 'object' },
+          client_version: { type: 'string' },
+          source: { type: 'string' },
+        },
+      },
+    },
+  },
+} as const;

--- a/workers/api/src/routes/feedback.ts
+++ b/workers/api/src/routes/feedback.ts
@@ -1,5 +1,6 @@
 import type {
   AnyFeedbackStatus,
+  FeedbackPinpoint,
   FeedbackRecord,
   FeedbackStatus,
   FeedbackType,
@@ -7,7 +8,9 @@ import type {
 } from '@saas-maker/contracts';
 import { Hono, type Context } from 'hono';
 import { getDb } from '../db';
-import { requireApiKey, requireSession } from '../middleware/auth';
+import { apiError } from '../lib/errors';
+import { storeScreenshot } from '../lib/screenshots';
+import { requireApiKey, requireInboxAuth } from '../middleware/auth';
 import type { Bindings, Variables } from '../types';
 
 const feedback = new Hono<{ Bindings: Bindings; Variables: Variables }>();
@@ -28,72 +31,134 @@ function isValidStatus(status: string): status is FeedbackStatus {
   return VALID_STATUSES.includes(status as FeedbackStatus);
 }
 
+function isValidType(type: string): type is FeedbackType {
+  return VALID_TYPES.includes(type as FeedbackType);
+}
+
 function queryOptions(c: Context<{ Bindings: Bindings; Variables: Variables }>) {
   const type = c.req.query('type') as FeedbackType | undefined;
   const status = c.req.query('status') as AnyFeedbackStatus | undefined;
+  const since = c.req.query('since') || undefined;
+  const until = c.req.query('until') || undefined;
+  const cursor = c.req.query('cursor') || undefined;
   const page = Number.parseInt(c.req.query('page') || '1', 10);
-  return { type, status, page: Number.isFinite(page) && page > 0 ? page : 1 };
+  return {
+    type,
+    status,
+    since,
+    until,
+    cursor,
+    page: Number.isFinite(page) && page > 0 ? page : 1,
+  };
 }
 
-// Public submission endpoint. A project key identifies the destination but
-// never authorizes inbox reads.
-feedback.post('/', requireApiKey, async (c) => {
-  const projectId = c.get('projectId')!;
-  const body = (await c.req.json()) as SubmitFeedbackRequest;
+function parsePinpoint(value: unknown): FeedbackPinpoint | null {
+  if (!value || typeof value !== 'object') return null;
+  const anchor = value as FeedbackPinpoint;
+  if (typeof anchor.selector !== 'string' || !anchor.selector.trim()) return null;
+  return {
+    selector: anchor.selector.trim(),
+    tag: typeof anchor.tag === 'string' ? anchor.tag : null,
+    text: typeof anchor.text === 'string' ? anchor.text : '',
+    source: typeof anchor.source === 'string' ? anchor.source : null,
+    url: typeof anchor.url === 'string' ? anchor.url : '',
+  };
+}
 
-  if (!body.title?.trim()) return c.json({ error: 'Title is required' }, 400);
-  if (!body.description?.trim()) return c.json({ error: 'Description is required' }, 400);
-  if (!VALID_TYPES.includes(body.type)) return c.json({ error: 'Invalid type' }, 400);
+async function readSubmission(
+  c: Context<{ Bindings: Bindings; Variables: Variables }>
+): Promise<{ body: SubmitFeedbackRequest; screenshot: File | null } | Response> {
+  const contentType = c.req.header('content-type') || '';
+  if (contentType.includes('multipart/form-data')) {
+    const form = await c.req.formData();
+    const raw = form.get('feedback');
+    if (typeof raw !== 'string' || !raw.trim()) {
+      return apiError(c, 400, 'invalid_request', 'feedback JSON field is required');
+    }
+    try {
+      const body = JSON.parse(raw) as SubmitFeedbackRequest;
+      const screenshot = form.get('screenshot');
+      return { body, screenshot: screenshot instanceof File ? screenshot : null };
+    } catch {
+      return apiError(c, 400, 'invalid_request', 'feedback field must be valid JSON');
+    }
+  }
 
-  const record = await getDb(c.env.DB).createFeedback({
-    id: crypto.randomUUID(),
-    project_id: projectId,
-    type: body.type,
-    status: 'new',
-    title: body.title.trim(),
-    description: body.description.trim(),
-    image_url: body.image_url || null,
-    submitter_email: body.submitter_email?.trim() || '',
-    submitter_name: body.submitter_name?.trim() || null,
-  });
+  try {
+    const body = (await c.req.json()) as SubmitFeedbackRequest;
+    return { body, screenshot: null };
+  } catch {
+    return apiError(c, 400, 'invalid_request', 'Request body must be JSON');
+  }
+}
 
-  return c.json(record, 201);
-});
-
-// Private project inbox for the dashboard and authenticated agents.
-feedback.get('/inbox/:projectId', requireSession, async (c) => {
+async function listAuthorizedFeedback(
+  c: Context<{ Bindings: Bindings; Variables: Variables }>,
+  projectHint?: string
+) {
   const userId = c.get('userId')!;
-  const projectId = c.req.param('projectId');
-  const { type, status, page } = queryOptions(c);
-  if (type && !VALID_TYPES.includes(type)) return c.json({ error: 'Invalid type filter' }, 400);
-  if (status && !isValidStatus(status)) return c.json({ error: 'Invalid status filter' }, 400);
+  const actorKind = c.get('actorKind') || 'owner';
+  const { type, status, since, until, cursor, page } = queryOptions(c);
+  if (type && !isValidType(type)) return apiError(c, 400, 'invalid_request', 'Invalid type filter');
+  if (
+    status &&
+    !isValidStatus(status) &&
+    status !== 'done' &&
+    status !== 'shipped' &&
+    status !== 'cancelled'
+  ) {
+    return apiError(c, 400, 'invalid_request', 'Invalid status filter');
+  }
 
   const db = getDb(c.env.DB);
-  const project = await db.getProjectById(projectId);
-  if (!project || project.owner_id !== userId) return c.json({ error: 'Forbidden' }, 403);
-  const result = await db.listFeedback(
-    projectId,
-    { type, status, sort: 'newest', page, limit: PAGE_SIZE },
-    userId
-  );
-  return c.json({ data: result.data, total: result.total, page, limit: PAGE_SIZE });
-});
+  const requestedProject = projectHint || c.req.query('project') || undefined;
 
-// Cross-project private inbox. This is deliberately a flat newest-first list,
-// not a public feature board or voting system.
-feedback.get('/inbox', requireSession, async (c) => {
-  const userId = c.get('userId')!;
-  const { type, status, page } = queryOptions(c);
-  if (type && !VALID_TYPES.includes(type)) return c.json({ error: 'Invalid type filter' }, 400);
-  if (status && !isValidStatus(status)) return c.json({ error: 'Invalid status filter' }, 400);
+  if (actorKind === 'agent') {
+    const agentProjectId = c.get('projectId')!;
+    if (requestedProject && requestedProject !== agentProjectId) {
+      const named = await db.getProjectBySlug(requestedProject);
+      if (!named || named.id !== agentProjectId) {
+        return apiError(c, 403, 'forbidden', 'Forbidden');
+      }
+    }
+    const result = await db.listFeedback(
+      agentProjectId,
+      { type, status, since, until, cursor, sort: 'newest', page, limit: PAGE_SIZE },
+      userId
+    );
+    return c.json({
+      data: result.data,
+      total: result.total,
+      page,
+      limit: PAGE_SIZE,
+      next_cursor: result.next_cursor,
+    });
+  }
 
-  const db = getDb(c.env.DB);
+  if (requestedProject) {
+    const project =
+      (await db.getProjectById(requestedProject)) ?? (await db.getProjectBySlug(requestedProject));
+    if (!project || project.owner_id !== userId) return apiError(c, 403, 'forbidden', 'Forbidden');
+    const result = await db.listFeedback(
+      project.id,
+      { type, status, since, until, cursor, sort: 'newest', page, limit: PAGE_SIZE },
+      userId
+    );
+    return c.json({
+      data: result.data,
+      total: result.total,
+      page,
+      limit: PAGE_SIZE,
+      next_cursor: result.next_cursor,
+    });
+  }
+
   const projects = await db.listProjectsByOwner(userId, 'dashboard');
   const perProject = await Promise.all(
     projects.map((project) =>
       db.listFeedback(
         project.id,
-        { type, status, sort: 'newest', page: 1, limit: PAGE_SIZE * page },
+        { type, status, since, until, sort: 'newest', page: 1, limit: PAGE_SIZE * page },
         userId
       )
     )
@@ -106,37 +171,124 @@ feedback.get('/inbox', requireSession, async (c) => {
   });
   data.sort((left, right) => Date.parse(right.created_at) - Date.parse(left.created_at));
   const offset = (page - 1) * PAGE_SIZE;
+  const pageData = data.slice(offset, offset + PAGE_SIZE);
   return c.json({
-    data: data.slice(offset, offset + PAGE_SIZE),
+    data: pageData,
     total: data.length,
     page,
     limit: PAGE_SIZE,
+    next_cursor: null,
   });
+}
+
+// Public submission endpoint. A project key identifies the destination but
+// never authorizes inbox reads.
+feedback.post('/', requireApiKey, async (c) => {
+  const projectId = c.get('projectId')!;
+  const parsed = await readSubmission(c);
+  if (parsed instanceof Response) return parsed;
+  const { body, screenshot } = parsed;
+
+  if (!body.title?.trim()) return apiError(c, 400, 'invalid_request', 'Title is required');
+  if (!body.description?.trim())
+    return apiError(c, 400, 'invalid_request', 'Description is required');
+  if (!VALID_TYPES.includes(body.type)) return apiError(c, 400, 'invalid_request', 'Invalid type');
+
+  let imageUrl = body.image_url || null;
+  if (screenshot) {
+    const stored = await storeScreenshot(c, screenshot);
+    if (stored instanceof Response) return stored;
+    imageUrl = stored;
+  }
+
+  const page =
+    body.page && typeof body.page.url === 'string'
+      ? { url: body.page.url, title: typeof body.page.title === 'string' ? body.page.title : '' }
+      : null;
+
+  const record = await getDb(c.env.DB).createFeedback({
+    id: crypto.randomUUID(),
+    project_id: projectId,
+    type: body.type,
+    status: 'new',
+    title: body.title.trim(),
+    description: body.description.trim(),
+    image_url: imageUrl,
+    submitter_email: body.submitter_email?.trim() || '',
+    submitter_name: body.submitter_name?.trim() || null,
+    page,
+    pinpoint: parsePinpoint(body.anchor),
+    client_version: body.client_version?.trim() || null,
+    source: body.source?.trim() || 'api',
+  });
+
+  return c.json(
+    {
+      id: record.id,
+      project_id: record.project_id,
+      type: record.type,
+      status: record.status,
+      created_at: record.created_at,
+    },
+    201
+  );
 });
 
-feedback.get('/:id', requireSession, async (c) => {
+feedback.get('/inbox/:projectId', requireInboxAuth, async (c) => {
+  return listAuthorizedFeedback(c, c.req.param('projectId'));
+});
+
+feedback.get('/inbox', requireInboxAuth, async (c) => {
+  return listAuthorizedFeedback(c);
+});
+
+feedback.get('/', requireInboxAuth, async (c) => {
+  return listAuthorizedFeedback(c);
+});
+
+feedback.get('/:id', requireInboxAuth, async (c) => {
   const userId = c.get('userId')!;
   const db = getDb(c.env.DB);
   const record = await db.getFeedbackById(c.req.param('id'));
-  if (!record) return c.json({ error: 'Feedback not found' }, 404);
+  if (!record) return apiError(c, 404, 'not_found', 'Feedback not found');
   const project = await db.getProjectById(record.project_id);
-  if (!project || project.owner_id !== userId) return c.json({ error: 'Forbidden' }, 403);
-  return c.json(record);
+  if (!project || project.owner_id !== userId) return apiError(c, 403, 'forbidden', 'Forbidden');
+  if (c.get('actorKind') === 'agent' && record.project_id !== c.get('projectId')) {
+    return apiError(c, 403, 'forbidden', 'Forbidden');
+  }
+  const status_events = await db.listFeedbackStatusEvents(record.id);
+  return c.json({ ...record, status_events });
 });
 
-feedback.patch('/:id', requireSession, async (c) => {
+feedback.patch('/:id', requireInboxAuth, async (c) => {
+  if (!c.get('canWrite')) {
+    return apiError(c, 403, 'forbidden', 'Agent token is read-only');
+  }
   const userId = c.get('userId')!;
   const feedbackId = c.req.param('id');
-  const body = (await c.req.json()) as { status: AnyFeedbackStatus };
-  if (!body.status || !isValidStatus(body.status)) return c.json({ error: 'Invalid status' }, 400);
+  let body: { status?: AnyFeedbackStatus };
+  try {
+    body = (await c.req.json()) as { status?: AnyFeedbackStatus };
+  } catch {
+    return apiError(c, 400, 'invalid_request', 'Request body must be JSON');
+  }
+  if (!body.status || !isValidStatus(body.status)) {
+    return apiError(c, 400, 'invalid_request', 'Invalid status');
+  }
 
   const db = getDb(c.env.DB);
   const existing = await db.getFeedbackById(feedbackId);
-  if (!existing) return c.json({ error: 'Feedback not found' }, 404);
+  if (!existing) return apiError(c, 404, 'not_found', 'Feedback not found');
   const project = await db.getProjectById(existing.project_id);
-  if (!project || project.owner_id !== userId) return c.json({ error: 'Forbidden' }, 403);
+  if (!project || project.owner_id !== userId) return apiError(c, 403, 'forbidden', 'Forbidden');
+  if (c.get('actorKind') === 'agent' && existing.project_id !== c.get('projectId')) {
+    return apiError(c, 403, 'forbidden', 'Forbidden');
+  }
 
-  const updated = await db.updateFeedbackStatus(feedbackId, body.status);
+  const updated = await db.updateFeedbackStatus(feedbackId, body.status, {
+    actor_id: c.get('agentTokenId') || userId,
+    actor_kind: c.get('actorKind') || 'owner',
+  });
   return c.json(updated);
 });
 

--- a/workers/api/src/routes/projects.ts
+++ b/workers/api/src/routes/projects.ts
@@ -1,10 +1,12 @@
-import { Hono } from 'hono';
-import { Bindings, Variables } from '../types';
-import { requireSession } from '../middleware/auth';
-import { getDb } from '../db';
-import { trace, capture } from '../lib/telemetry';
-import { buildCacheKey, tryCacheMatch, withCachePut } from '../edge-cache';
 import type { ProjectRecord } from '@saas-maker/contracts';
+import { Hono } from 'hono';
+import { getDb } from '../db';
+import { buildCacheKey, tryCacheMatch, withCachePut } from '../edge-cache';
+import { randomToken, sha256Hex } from '../lib/crypto';
+import { apiError } from '../lib/errors';
+import { capture, trace } from '../lib/telemetry';
+import { requireSession } from '../middleware/auth';
+import { Bindings, type AppContext, Variables } from '../types';
 
 const projects = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 projects.use('*', requireSession);
@@ -68,11 +70,16 @@ const VALID_SOURCES = ['dashboard', 'linkchat'];
 projects.post('/', async (c) => {
   const userId = c.get('userId')!;
   const body = (await c.req.json()) as { name: string; source?: string; git_url?: string };
-  if (!body.name?.trim()) return c.json({ error: 'Project name is required' }, 400);
+  if (!body.name?.trim()) return apiError(c, 400, 'invalid_request', 'Project name is required');
 
   const source = body.source || 'dashboard';
   if (!VALID_SOURCES.includes(source)) {
-    return c.json({ error: `Invalid source. Must be one of: ${VALID_SOURCES.join(', ')}` }, 400);
+    return apiError(
+      c,
+      400,
+      'invalid_request',
+      `Invalid source. Must be one of: ${VALID_SOURCES.join(', ')}`
+    );
   }
 
   const gitUrl = body.git_url?.trim() || null;
@@ -102,7 +109,7 @@ projects.get('/by-slug/:slug', async (c) => {
   const slug = c.req.param('slug');
   const db = getDb(c.env.DB);
   const project = await db.getProjectBySlug(slug);
-  if (!project || project.owner_id !== userId) return c.json({ error: 'Not found' }, 404);
+  if (!project || project.owner_id !== userId) return apiError(c, 404, 'not_found', 'Not found');
   return c.json(toPublicProject(project));
 });
 
@@ -119,8 +126,8 @@ projects.patch('/:id', async (c) => {
 
   // Verify ownership
   const existing = await db.getProjectById(projectId);
-  if (!existing) return c.json({ error: 'Project not found' }, 404);
-  if (existing.owner_id !== userId) return c.json({ error: 'Forbidden' }, 403);
+  if (!existing) return apiError(c, 404, 'not_found', 'Project not found');
+  if (existing.owner_id !== userId) return apiError(c, 403, 'forbidden', 'Forbidden');
 
   const gitUrl = body.git_url === undefined ? undefined : body.git_url?.trim?.() || null;
 
@@ -129,7 +136,7 @@ projects.patch('/:id', async (c) => {
     readme: body.readme,
     git_url: gitUrl,
   });
-  if (!updated) return c.json({ error: 'Project not found' }, 404);
+  if (!updated) return apiError(c, 404, 'not_found', 'Project not found');
   capture({ distinctId: userId, event: 'project_updated', properties: { project_id: projectId } });
   return c.json(toPublicProject(updated));
 });
@@ -142,8 +149,8 @@ projects.delete('/:id', async (c) => {
 
   // Verify ownership
   const existing = await db.getProjectById(projectId);
-  if (!existing) return c.json({ error: 'Project not found' }, 404);
-  if (existing.owner_id !== userId) return c.json({ error: 'Forbidden' }, 403);
+  if (!existing) return apiError(c, 404, 'not_found', 'Project not found');
+  if (existing.owner_id !== userId) return apiError(c, 403, 'forbidden', 'Forbidden');
 
   await db.deleteProject(projectId);
   capture({
@@ -151,6 +158,53 @@ projects.delete('/:id', async (c) => {
     event: 'project_deleted',
     properties: { project_id: projectId, project_name: existing.name },
   });
+  return c.json({ ok: true });
+});
+
+async function ownedProject(c: AppContext, projectId: string) {
+  const db = getDb(c.env.DB);
+  const project = await db.getProjectById(projectId);
+  if (!project) return { error: apiError(c, 404, 'not_found', 'Project not found') };
+  if (project.owner_id !== c.get('userId'))
+    return { error: apiError(c, 403, 'forbidden', 'Forbidden') };
+  return { project, db };
+}
+
+projects.get('/:id/agent-tokens', async (c) => {
+  const owned = await ownedProject(c, c.req.param('id'));
+  if ('error' in owned) return owned.error;
+  return c.json({ data: await owned.db.listAgentTokens(owned.project.id) });
+});
+
+projects.post('/:id/agent-tokens', async (c) => {
+  const owned = await ownedProject(c, c.req.param('id'));
+  if ('error' in owned) return owned.error;
+  let body: { name?: string; can_write?: boolean };
+  try {
+    body = (await c.req.json()) as { name?: string; can_write?: boolean };
+  } catch {
+    return apiError(c, 400, 'invalid_request', 'Request body must be JSON');
+  }
+  const name = body.name?.trim();
+  if (!name) return apiError(c, 400, 'invalid_request', 'Token name is required');
+
+  const plaintext = randomToken('smk_');
+  const token = await owned.db.createAgentToken({
+    id: crypto.randomUUID(),
+    project_id: owned.project.id,
+    token_hash: await sha256Hex(plaintext),
+    token_prefix: plaintext.slice(0, 8),
+    name,
+    can_write: body.can_write === true,
+  });
+  return c.json({ ...token, token: plaintext }, 201);
+});
+
+projects.delete('/:id/agent-tokens/:tokenId', async (c) => {
+  const owned = await ownedProject(c, c.req.param('id'));
+  if ('error' in owned) return owned.error;
+  const deleted = await owned.db.deleteAgentToken(c.req.param('tokenId'), owned.project.id);
+  if (!deleted) return apiError(c, 404, 'not_found', 'Token not found');
   return c.json({ ok: true });
 });
 

--- a/workers/api/src/routes/upload.ts
+++ b/workers/api/src/routes/upload.ts
@@ -1,30 +1,19 @@
 import { Hono } from 'hono';
-import { Bindings, Variables } from '../types';
 import { requireApiKey } from '../middleware/auth';
+import { apiError } from '../lib/errors';
+import { storeScreenshot } from '../lib/screenshots';
+import { Bindings, Variables } from '../types';
 
 const upload = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 
-const MAX_FILE_SIZE = 5 * 1024 * 1024;
-const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
-
 upload.post('/', requireApiKey, async (c) => {
   const formData = await c.req.formData();
-  const file = formData.get('file') as File | null;
+  const file = formData.get('file');
+  if (!(file instanceof File)) return apiError(c, 400, 'invalid_request', 'No file provided');
 
-  if (!file) return c.json({ error: 'No file provided' }, 400);
-  if (!ALLOWED_TYPES.includes(file.type))
-    return c.json({ error: 'Invalid file type. Allowed: jpeg, png, gif, webp' }, 400);
-  if (file.size > MAX_FILE_SIZE) return c.json({ error: 'File too large. Max 5MB' }, 400);
-
-  const ext = file.type.split('/')[1];
-  const key = `feedback/${crypto.randomUUID()}.${ext}`;
-
-  await c.env.FEEDBACK_IMAGES.put(key, file.stream(), {
-    httpMetadata: { contentType: file.type },
-  });
-
-  const imageUrl = `https://images.sassmaker.com/${key}`;
-  return c.json({ url: imageUrl }, 201);
+  const stored = await storeScreenshot(c, file);
+  if (stored instanceof Response) return stored;
+  return c.json({ url: stored }, 201);
 });
 
 export { upload };

--- a/workers/api/src/types.ts
+++ b/workers/api/src/types.ts
@@ -15,6 +15,9 @@ export type Variables = {
   userId?: string;
   projectId?: string;
   project?: any;
+  actorKind?: 'owner' | 'agent';
+  canWrite?: boolean;
+  agentTokenId?: string;
 };
 
 export type AppContext = Context<{ Bindings: Bindings; Variables: Variables }>;


### PR DESCRIPTION
Part of #46

Completes the remaining hosted Feedback contract in source. Capture, submit, store, review, and status update already existed; this fills the agent-native gaps without deploying.

## What landed
- Page URL, Pinpoint context, client version, and source persist with each submission
- `POST /v1/feedback` accepts JSON or one multipart request (`feedback` + optional `screenshot`)
- Authenticated `GET /v1/feedback` with project, type, status, date, and cursor filters
- Project-scoped `smk_` agent tokens default to read-only; write is explicit
- Status changes write immutable audit events with actor identity
- Inbox shows page/Pinpoint context, copies structured JSON, and surfaces project keys plus agent tokens
- Docs describe hosted setup as the primary path and drop public-board/voting language

## Verification
- `pnpm test` — 28 API tests
- `@saas-maker/feedback` package tests after rebuild
- `pnpm -F @saas-maker/api typecheck`
- `pnpm -F @saas-maker/dashboard typecheck`
- `pnpm lint`
- `pnpm check:docs`

## Still gated (task 11)
Do not merge into a production action without explicit approval:
- D1 migration `0025_feedback_agent_contract.sql`
- API/inbox deploy
- npm publication of `@saas-maker/feedback` (published 0.4.0 still lacks `projectKey`)

Anime List consumer change is a separate PR in Significant-Hobbies/anime-list.