### PR TITLE
Publish the complete Fleet project directory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,5 +39,11 @@ from Site Health's canonical private `projects.json` and consumed here through
 the checked-in `catalog/generated/public.json`; SaaS Maker never reads private
 Fleet state at runtime.
 
+The public directory labels each entry's curated `technologies` as “Prominent
+tools.” When a product's material stack changes, update the canonical
+`publicDirectory.projects[<id>].technologies` entry in Site Health and run
+`pnpm catalog:sync-public` here in the same task. Never hand-edit the generated
+catalog or expand this field into a dependency inventory.
+
 Do not deploy, migrate, publish/deprecate npm packages, change DNS, or archive
 repositories without explicit approval.

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -25,6 +25,13 @@ Cockpit, CodeVetter, and App Health remain independent repositories.
 
 ## Timeline
 
+- **2026-08-22 — Complete Fleet directory published:** Expanded the public,
+  privacy-filtered projection from the maintained subset to all 58 retained
+  Fleet identities. The new `/projects` register separates current,
+  supporting/parked, and past work; exposes public destinations, deployment
+  classification, platforms, curated technology, and first/latest retained Git
+  commit dates; and keeps the HTML, JSON, Markdown, sitemap, and agent surfaces
+  aligned without runtime access to Site Health.
 - **2026-08-22 — Feedback agent contract completed in source:** Hosted
   submission now keeps page/Pinpoint evidence, accepts one multipart request,
   issues read-only-by-default agent tokens, and records status mutations. The
@@ -90,8 +97,14 @@ Cockpit, CodeVetter, and App Health remain independent repositories.
 
 ## Features (shipped)
 
-- Deterministic 31-product public projection consumed without private Fleet
-  runtime access.
+- Deterministic 58-identity public projection consumed without private Fleet
+  runtime access, with deny-by-default field validation.
+- Searchable `/projects` register grouped by current, supporting/parked, and
+  past work, with form-family and platform filters, mobile filter return,
+  deployment context, public links, technology labels, and retained Git-history
+  bounds.
+- Matching human, JSON, Markdown, sitemap, and agent-readable directory
+  surfaces.
 - Feedback submission for bug, feature, and general feedback.
 - Optional screenshots and page-element anchoring.
 - Private cross-product feedback inbox with type/status filters and status controls.

--- a/apps/showcase/.fleet/design-review.json
+++ b/apps/showcase/.fleet/design-review.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "fleet.design-review.v1",
+  "version": 1,
+  "project": "showcase",
+  "target": "/projects public directory",
+  "mode": "preserve",
+  "register": "brand",
+  "context": {
+    "product": "PRODUCT.md",
+    "design": "DESIGN.md"
+  },
+  "direction": {
+    "references": [],
+    "probes": [],
+    "selected": "existing-design",
+    "approval": "not-required",
+    "before": "artifacts/design/before.png"
+  },
+  "evidence": {
+    "screenshots": [
+      {
+        "width": 390,
+        "path": "artifacts/design/after-390.png"
+      },
+      {
+        "width": 768,
+        "path": "artifacts/design/after-768.png"
+      },
+      {
+        "width": 1440,
+        "path": "artifacts/design/after-1440.png"
+      }
+    ],
+    "projectCheck": {
+      "command": "pnpm lint && pnpm typecheck && pnpm test && pnpm build:showcase && pnpm catalog:validate-public && pnpm catalog:check-public",
+      "status": "pass"
+    },
+    "critique": {
+      "score": 34,
+      "maximum": 40
+    },
+    "audit": {
+      "score": 19,
+      "maximum": 20
+    },
+    "unresolved": {
+      "p0": 0,
+      "p1": 0
+    },
+    "detector": {
+      "posture": "advisory",
+      "findings": []
+    }
+  },
+  "ownerFeedback": {
+    "decision": "delegated",
+    "note": "Owner explicitly requested the complete build and production deployment, and asked to review the finished surface at its deployed URL."
+  }
+}

--- a/apps/showcase/.impeccable/surfaces/apps-showcase-src-pages-projects-astro.md
+++ b/apps/showcase/.impeccable/surfaces/apps-showcase-src-pages-projects-astro.md
@@ -1,0 +1,18 @@
+---
+version: 1
+slug: "apps-showcase-src-pages-projects-astro"
+primary_target: "apps/showcase/src/pages/projects.astro"
+related_targets: ["apps/showcase/src/pages/projects.json.ts"]
+---
+
+# Complete project directory
+
+- Scope: `/projects`; Read/Explore mode.
+- Audience: visitors and agents trying to understand the complete Fleet inventory, not only promoted products.
+- Job: find a project, understand its form, purpose, deployment, public destinations, technology, lifecycle, and retained Git span.
+- Primary action: open a canonical product destination; secondary actions are source, changelog, issues, and the JSON directory.
+- Content boundary: all 58 canonical identities from the privacy-safe Site Health projection; no private repositories, local paths, priorities, controls, health metrics, or operational notes.
+- Direction: extend the established workshop wall as lifecycle bays crossed by platform, technology, deployment, and history rails.
+- Memorable moment: the cobalt 58-identity pane gives way immediately to a filterable, server-rendered register.
+- Interaction: search plus group, form, and platform filters; all content remains present without JavaScript.
+- Provenance: Git dates are explicitly first/latest retained commits, not launch or retirement claims.

--- a/apps/showcase/package.json
+++ b/apps/showcase/package.json
@@ -10,7 +10,7 @@
     "start": "astro dev",
     "build": "astro build",
     "build:showcase-only": "astro build",
-    "deploy": "pnpm build && wrangler pages deploy dist --project-name saas-maker-home --branch main && node ../../scripts/smoke-prod.mjs",
+    "deploy": "pnpm build && wrangler pages deploy dist --project-name saas-maker-home --branch main && node ../../scripts/smoke-prod.mjs --directory-only",
     "preview": "astro preview",
     "astro": "astro",
     "typecheck": "astro sync && tsc --noEmit"

--- a/apps/showcase/src/components/Fleet.astro
+++ b/apps/showcase/src/components/Fleet.astro
@@ -1,6 +1,7 @@
 ---
 import { ACTIVE_GROUPS, PAST_PROJECTS, PROJECT_COUNT } from '../data/projects';
 import { LEARNINGS } from '../data/learnings';
+import { DIRECTORY_COUNT } from '../data/directory';
 
 const latestLearning = LEARNINGS[0];
 ---
@@ -13,7 +14,7 @@ const latestLearning = LEARNINGS[0];
         Each product keeps its own domain, roadmap, changelog, and release
         boundary. Nothing here is a concept render.
       </p>
-      <a href="#latest-learning">Skip to latest learning <span aria-hidden="true">↓</span></a>
+      <a href="/projects">Browse the complete {DIRECTORY_COUNT}-project directory <span aria-hidden="true">→</span></a>
     </div>
   </header>
 

--- a/apps/showcase/src/components/Nav.astro
+++ b/apps/showcase/src/components/Nav.astro
@@ -2,6 +2,7 @@
 import { GITHUB_ORG_URL } from '../data/links';
 
 const isLearnings = Astro.url.pathname.startsWith('/learnings');
+const isProjects = Astro.url.pathname.startsWith('/projects');
 ---
 <nav class="nav" aria-label="Primary navigation">
   <a href="/" class="brand">
@@ -9,7 +10,7 @@ const isLearnings = Astro.url.pathname.startsWith('/learnings');
     <span class="brand-name">SaaS Maker</span>
   </a>
   <div class="nav-links">
-    <a href="/#products">Products</a>
+    <a href="/projects" aria-current={isProjects ? 'page' : undefined}>Products</a>
     <a href="/learnings" aria-current={isLearnings ? 'page' : undefined}>Learnings</a>
     <a href="/#package">Package</a>
     <a class="nav-source" href={GITHUB_ORG_URL} target="_blank" rel="noopener noreferrer">Public source index ↗</a>

--- a/apps/showcase/src/data/directory.ts
+++ b/apps/showcase/src/data/directory.ts
@@ -1,0 +1,92 @@
+import publicCatalog from '../../../../catalog/generated/public.json';
+
+export type DirectoryGroupId = 'current' | 'supporting' | 'past';
+
+export interface DirectoryProject {
+  id: string;
+  name: string;
+  description: string;
+  kind: 'product' | 'platform' | 'experiment';
+  form: string;
+  platforms: string[];
+  technologies: string[];
+  group: DirectoryGroupId;
+  lifecycle: string;
+  deployed: boolean;
+  deploymentProviders: string[];
+  domains: string[];
+  url?: string;
+  repositoryUrl?: string;
+  changelogUrl?: string;
+  roadmapUrl?: string;
+  firstCommitAt: string | null;
+  latestCommitAt: string | null;
+}
+
+export const DIRECTORY_PROJECTS = publicCatalog.directory as DirectoryProject[];
+
+const GROUP_COPY: Record<DirectoryGroupId, { label: string; description: string }> = {
+  current: {
+    label: 'Current work',
+    description: 'Products and platforms inside the current Fleet working set.',
+  },
+  supporting: {
+    label: 'Supporting and parked',
+    description: 'Useful tools, local surfaces, and retained work outside the current focus set.',
+  },
+  past: {
+    label: 'Past projects',
+    description:
+      'Archived experiments and source history, kept visible without implying maintenance.',
+  },
+};
+
+export const DIRECTORY_GROUPS = (['current', 'supporting', 'past'] as const).map((id) => ({
+  id,
+  ...GROUP_COPY[id],
+  projects: DIRECTORY_PROJECTS.filter((project) => project.group === id),
+}));
+
+export const DIRECTORY_FORMS = [
+  'Web',
+  'Apple native',
+  'Desktop and local',
+  'API and backend',
+  'Package and library',
+  'Research and data',
+  'Media and game',
+] as const;
+
+export function directoryFormFamilies(project: DirectoryProject) {
+  const form = project.form.toLocaleLowerCase();
+  const families = new Set<(typeof DIRECTORY_FORMS)[number]>();
+
+  if (form.includes('web') || project.platforms.includes('Web')) families.add('Web');
+  if (project.platforms.some((platform) => platform === 'iOS' || platform === 'watchOS')) {
+    families.add('Apple native');
+  }
+  if (
+    form.match(/desktop|local|tool|platform|cli/) ||
+    project.platforms.some((platform) =>
+      ['macOS', 'Windows', 'Linux', 'Local', 'CLI'].includes(platform)
+    )
+  ) {
+    families.add('Desktop and local');
+  }
+  if (form.match(/api|backend|service|worker/) || project.platforms.includes('API')) {
+    families.add('API and backend');
+  }
+  if (form.match(/package|library|connector/)) families.add('Package and library');
+  if (form.match(/research|dataset|benchmark|observatory/)) families.add('Research and data');
+  if (form.match(/video|game|media|animation/)) families.add('Media and game');
+  if (families.size === 0) families.add('Desktop and local');
+
+  return [...families];
+}
+
+export const DIRECTORY_PLATFORMS = [
+  ...new Set(DIRECTORY_PROJECTS.flatMap((project) => project.platforms)),
+].sort((left, right) => left.localeCompare(right));
+
+export const DIRECTORY_COUNT = DIRECTORY_PROJECTS.length;
+export const HISTORY_SEMANTICS = publicCatalog.historySemantics;

--- a/apps/showcase/src/data/publicRoutes.ts
+++ b/apps/showcase/src/data/publicRoutes.ts
@@ -114,6 +114,48 @@ function homeMarkdown(): string {
   ].join('\n');
 }
 
+function directoryMarkdown(): string {
+  const groups = [
+    ['current', 'Current work'],
+    ['supporting', 'Supporting and parked'],
+    ['past', 'Past projects'],
+  ] as const;
+  const entries = groups.flatMap(([group, label]) => [
+    `# ${label}`,
+    '',
+    ...publicCatalog.directory
+      .filter((project) => project.group === group)
+      .flatMap((project) => [
+        `## ${project.name}`,
+        '',
+        project.description,
+        '',
+        `- Form: ${project.form}`,
+        `- Platforms: ${project.platforms.join(', ')}`,
+        `- Uses: ${project.technologies.join(', ')}`,
+        `- Deployment: ${project.deployed ? 'deployed' : 'not deployed'}`,
+        ...(project.deploymentProviders.length > 0
+          ? [`- Providers: ${project.deploymentProviders.join(', ')}`]
+          : []),
+        ...project.domains.map((domain) => `- Public destination: https://${domain}`),
+        ...(project.repositoryUrl ? [`- Public source: ${project.repositoryUrl}`] : []),
+        `- First retained commit: ${project.firstCommitAt ?? 'not retained'}`,
+        `- Latest retained commit: ${project.latestCommitAt ?? 'not retained'}`,
+        '',
+      ]),
+  ]);
+
+  return [
+    '# SaaS Maker complete project directory',
+    '',
+    `${publicCatalog.directory.length} Fleet identities, including current, supporting, parked, and past work. Inclusion is inventory, not a maintenance or deployment claim.`,
+    '',
+    publicCatalog.historySemantics,
+    '',
+    ...entries,
+  ].join('\n');
+}
+
 const fixedRoutes: PublicRoute[] = [
   {
     id: 'directory',
@@ -121,6 +163,13 @@ const fixedRoutes: PublicRoute[] = [
     description: 'Software as a specialized service: a living studio of focused products',
     kind: 'collection',
     markdown: homeMarkdown(),
+  },
+  {
+    id: 'projects',
+    path: '/projects',
+    description: 'Complete public directory of all Fleet project identities',
+    kind: 'collection',
+    markdown: directoryMarkdown(),
   },
   {
     id: 'privacy',

--- a/apps/showcase/src/lib/portfolio-projects.ts
+++ b/apps/showcase/src/lib/portfolio-projects.ts
@@ -26,3 +26,5 @@ export const portfolioProjects = (publicCatalog.products as PublicProject[]).map
     domains: [new URL(url).hostname],
   })
 );
+
+export const directoryProjects = publicCatalog.directory;

--- a/apps/showcase/src/pages/api/ai.ts
+++ b/apps/showcase/src/pages/api/ai.ts
@@ -40,6 +40,8 @@ export function GET() {
           ...tokenWorld,
         },
         products: publicCatalog.products,
+        directory: publicCatalog.directory,
+        historySemantics: publicCatalog.historySemantics,
         pastProjects: publicCatalog.pastProjects,
         learnings: LEARNINGS.map((learning) => ({
           ...learning,

--- a/apps/showcase/src/pages/llms-full.txt.ts
+++ b/apps/showcase/src/pages/llms-full.txt.ts
@@ -2,30 +2,22 @@ import publicCatalog from '../../../../catalog/generated/public.json';
 import { LEARNINGS } from '../data/learnings';
 export const prerender = true;
 export function GET() {
-  const products = publicCatalog.products.flatMap((product) => {
-    const links = product as typeof product & {
-      changelogUrl?: string;
-      roadmapUrl?: string;
-      repositoryUrl?: string;
-    };
+  const projects = publicCatalog.directory.flatMap((project) => {
     return [
-      `## ${product.name}`,
-      product.description,
-      `Product: ${product.url}`,
-      `Pillar: ${product.pillarId}`,
-      ...(links.changelogUrl ? [`Changelog: ${links.changelogUrl}`] : []),
-      ...(links.roadmapUrl ? [`Roadmap: ${links.roadmapUrl}`] : []),
-      ...(links.repositoryUrl ? [`Source: ${links.repositoryUrl}`] : []),
+      `## ${project.name}`,
+      project.description,
+      `Group: ${project.group}`,
+      `Form: ${project.form}`,
+      `Platforms: ${project.platforms.join(', ')}`,
+      `Uses: ${project.technologies.join(', ')}`,
+      `Deployment: ${project.deployed ? 'deployed' : 'not deployed'}`,
+      ...project.domains.map((domain) => `Destination: https://${domain}`),
+      ...(project.repositoryUrl ? [`Source: ${project.repositoryUrl}`] : []),
+      `First retained commit: ${project.firstCommitAt ?? 'not retained'}`,
+      `Latest retained commit: ${project.latestCommitAt ?? 'not retained'}`,
       '',
     ];
   });
-  const pastProjects = publicCatalog.pastProjects.flatMap((project) => [
-    `## ${project.name}`,
-    project.description,
-    'Lifecycle: past project',
-    `Source: ${project.repositoryUrl}`,
-    '',
-  ]);
   const body = [
     '# SaaS Maker — full product index',
     '',
@@ -41,10 +33,11 @@ export function GET() {
       `Author: ${learning.author}`,
       '',
     ]),
-    ...products,
-    '# Past public repositories',
+    '# Complete project directory',
     '',
-    ...pastProjects,
+    publicCatalog.historySemantics,
+    '',
+    ...projects,
   ].join('\n');
   return new Response(body, { headers: { 'Content-Type': 'text/plain; charset=utf-8' } });
 }

--- a/apps/showcase/src/pages/llms.txt.ts
+++ b/apps/showcase/src/pages/llms.txt.ts
@@ -16,7 +16,8 @@ export function GET() {
     '',
     '## Core surfaces',
     '',
-    '- [Directory](https://sassmaker.com)',
+    '- [Studio home](https://sassmaker.com)',
+    `- [Complete project directory](https://sassmaker.com/projects): ${publicCatalog.directory.length} current, supporting, parked, and past identities`,
     '- [Learnings](https://sassmaker.com/learnings): first-party notes from building products and agent workflows',
     ...LEARNINGS.map(
       (learning) =>
@@ -35,6 +36,8 @@ export function GET() {
     '## Machine surfaces',
     '',
     '- https://sassmaker.com/api/ai',
+    '- https://sassmaker.com/projects.json',
+    '- https://sassmaker.com/projects.md',
     '- https://sassmaker.com/index.md',
     '- https://sassmaker.com/llms-full.txt',
     '',

--- a/apps/showcase/src/pages/projects.astro
+++ b/apps/showcase/src/pages/projects.astro
@@ -211,7 +211,7 @@ const pastCount = DIRECTORY_GROUPS.find((group) => group.id === 'past')?.project
                   </dl>
 
                   <div class="directory-stack">
-                    <span>Uses</span>
+                    <span>Prominent tools</span>
                     <ul>
                       {project.technologies.map((technology) => <li>{technology}</li>)}
                     </ul>

--- a/apps/showcase/src/pages/projects.astro
+++ b/apps/showcase/src/pages/projects.astro
@@ -1,0 +1,960 @@
+---
+import Footer from '../components/Footer.astro';
+import Nav from '../components/Nav.astro';
+import {
+  DIRECTORY_COUNT,
+  DIRECTORY_FORMS,
+  DIRECTORY_GROUPS,
+  DIRECTORY_PLATFORMS,
+  HISTORY_SEMANTICS,
+  directoryFormFamilies,
+  type DirectoryProject,
+} from '../data/directory';
+import Layout from '../layouts/Layout.astro';
+
+const formatDate = (date: string | null) =>
+  date
+    ? new Intl.DateTimeFormat('en', {
+        day: 'numeric',
+        month: 'short',
+        year: 'numeric',
+        timeZone: 'UTC',
+      }).format(new Date(`${date}T00:00:00Z`))
+    : 'Not retained';
+
+const deploymentLabel = (project: DirectoryProject) => {
+  if (project.group === 'past' && project.deployed) return 'Live archive';
+  if (project.deployed) return 'Deployed';
+  if (project.lifecycle === 'local-only' || project.platforms.includes('Local')) return 'Local only';
+  return 'Not deployed';
+};
+
+const searchableText = (project: DirectoryProject) =>
+  [
+    project.name,
+    project.description,
+    project.form,
+    project.kind,
+    ...project.platforms,
+    ...project.technologies,
+    ...project.deploymentProviders,
+    ...project.domains,
+  ]
+    .join(' ')
+    .toLocaleLowerCase();
+
+const currentCount = DIRECTORY_GROUPS.find((group) => group.id === 'current')?.projects.length ?? 0;
+const supportingCount = DIRECTORY_GROUPS.find((group) => group.id === 'supporting')?.projects.length ?? 0;
+const pastCount = DIRECTORY_GROUPS.find((group) => group.id === 'past')?.projects.length ?? 0;
+---
+
+<Layout
+  title={`${DIRECTORY_COUNT} projects — SaaS Maker directory`}
+  description="The complete public Fleet project directory: current products, supporting tools, parked work, and past experiments with platforms, technology, deployment links, and Git history."
+>
+  <!--
+  THESIS: A complete portfolio is clearest as a working register, not a promotional card grid.
+  OWN-WORLD: Limestone panes, matte-black mullions, seeded metadata bays, and one cobalt index pane extend the SaaS Maker workshop wall.
+  STORY: Understand the 58-project boundary, narrow it by form or platform, then inspect purpose, deployment, public links, stack, and Git span.
+  FIRST VIEWPORT: A wide identity pane and cobalt count pane sit above a black filter rail; the first current-project rows begin without a marketing detour.
+  FORM: Lifecycle bays crossed by platform and technology rails; fourth grounded structure, seed 2aaa2e62.
+  -->
+  <div class="workshop-world directory-world">
+    <Nav />
+    <main id="main-content" class="directory-shell">
+      <header class="directory-intro">
+        <div class="directory-intro-copy">
+          <p class="directory-kicker">The complete register</p>
+          <h1>Everything in Fleet.<br />Nothing hidden by focus.</h1>
+          <p>
+            Current products, supporting tools, local work, and past experiments—each shown once
+            with what it is, where it runs, what it uses, and the public evidence available.
+          </p>
+        </div>
+        <div class="directory-count-pane" aria-label={`${DIRECTORY_COUNT} project identities`}>
+          <strong>{DIRECTORY_COUNT}</strong>
+          <span>project identities</span>
+          <small>{currentCount} current · {supportingCount} supporting · {pastCount} past</small>
+        </div>
+      </header>
+
+      <section
+        id="directory-filters"
+        class="directory-controls"
+        data-directory-controls
+        hidden
+        aria-label="Filter the project directory"
+      >
+        <div class="directory-search">
+          <label for="directory-search">Search name, purpose, stack, or domain</label>
+          <input
+            id="directory-search"
+            name="query"
+            type="search"
+            inputmode="search"
+            autocomplete="off"
+            placeholder="Try SwiftUI, Cloudflare, video…"
+          />
+        </div>
+
+        <div class="directory-selects">
+          <label>
+            <span>Form family</span>
+            <select id="directory-form" name="form">
+              <option value="">Every form family</option>
+              {DIRECTORY_FORMS.map((form) => <option value={form}>{form}</option>)}
+            </select>
+          </label>
+          <label>
+            <span>Platform</span>
+            <select id="directory-platform" name="platform">
+              <option value="">Every platform</option>
+              {DIRECTORY_PLATFORMS.map((platform) => <option value={platform}>{platform}</option>)}
+            </select>
+          </label>
+        </div>
+
+        <div class="directory-groups" role="group" aria-label="Project lifecycle">
+          <button type="button" data-group-filter="all" aria-pressed="true">All</button>
+          {DIRECTORY_GROUPS.map((group) => (
+            <button type="button" data-group-filter={group.id} aria-pressed="false">
+              {group.label}
+            </button>
+          ))}
+        </div>
+
+        <div class="directory-result-line">
+          <p id="directory-result-count" aria-live="polite">Showing all {DIRECTORY_COUNT} identities</p>
+          <button id="directory-reset" type="button">Reset filters</button>
+        </div>
+      </section>
+
+      <div class="directory-sections" data-directory-root>
+        {DIRECTORY_GROUPS.map((group) => (
+          <section class="directory-section" data-directory-section={group.id} aria-labelledby={`directory-${group.id}`}>
+            <header class="directory-section-head">
+              <div>
+                <p>{group.projects.length} identities</p>
+                <h2 id={`directory-${group.id}`}>{group.label}</h2>
+              </div>
+              <p>{group.description}</p>
+            </header>
+
+            <div class="directory-rows">
+              {group.projects.map((project) => (
+                <article
+                  class="directory-row"
+                  data-directory-row
+                  data-group={project.group}
+                  data-form={directoryFormFamilies(project).join('|')}
+                  data-platforms={project.platforms.join('|')}
+                  data-search={searchableText(project)}
+                >
+                  <div class="directory-identity">
+                    <div class="directory-row-heading">
+                      <h3>{project.name}</h3>
+                      <span>{project.kind}</span>
+                    </div>
+                    <p>{project.description}</p>
+                    <div class="directory-links" aria-label={`${project.name} public links`}>
+                      {project.domains.map((domain, index) => (
+                        <a
+                          class:list={{ 'directory-link--primary': index === 0 }}
+                          href={`https://${domain}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          {domain} <span aria-hidden="true">↗</span>
+                        </a>
+                      ))}
+                      {project.repositoryUrl && (
+                        <a href={project.repositoryUrl} target="_blank" rel="noopener noreferrer">
+                          Source <span aria-hidden="true">↗</span>
+                        </a>
+                      )}
+                      {project.changelogUrl && (
+                        <a href={project.changelogUrl} target="_blank" rel="noopener noreferrer">
+                          Changelog <span aria-hidden="true">↗</span>
+                        </a>
+                      )}
+                      {project.roadmapUrl && (
+                        <a href={project.roadmapUrl} target="_blank" rel="noopener noreferrer">
+                          Issues <span aria-hidden="true">↗</span>
+                        </a>
+                      )}
+                      {project.domains.length === 0 && !project.repositoryUrl && (
+                        <span>No public destination</span>
+                      )}
+                    </div>
+                  </div>
+
+                  <dl class="directory-anatomy">
+                    <div>
+                      <dt>Form</dt>
+                      <dd>{project.form}</dd>
+                    </div>
+                    <div>
+                      <dt>Platforms</dt>
+                      <dd>{project.platforms.join(' · ')}</dd>
+                    </div>
+                    <div>
+                      <dt>Deployment</dt>
+                      <dd>
+                        <span class:list={['deployment-state', { 'deployment-state--live': project.deployed }]}>
+                          {deploymentLabel(project)}
+                        </span>
+                        {project.deploymentProviders.length > 0 && (
+                          <small>{project.deploymentProviders.join(' · ')}</small>
+                        )}
+                      </dd>
+                    </div>
+                  </dl>
+
+                  <div class="directory-stack">
+                    <span>Uses</span>
+                    <ul>
+                      {project.technologies.map((technology) => <li>{technology}</li>)}
+                    </ul>
+                  </div>
+
+                  <dl class="directory-history">
+                    <div>
+                      <dt>First retained commit</dt>
+                      <dd>{formatDate(project.firstCommitAt)}</dd>
+                    </div>
+                    <div>
+                      <dt>Latest retained commit</dt>
+                      <dd>{formatDate(project.latestCommitAt)}</dd>
+                    </div>
+                  </dl>
+                </article>
+              ))}
+            </div>
+          </section>
+        ))}
+      </div>
+
+      <section class="directory-empty" data-directory-empty hidden aria-live="polite">
+        <strong>No identities match those filters.</strong>
+        <p>Clear the filters to return to the complete register.</p>
+        <button type="button" data-empty-reset>Show all {DIRECTORY_COUNT}</button>
+      </section>
+
+      <aside class="directory-provenance" aria-labelledby="directory-provenance-title">
+        <div>
+          <p class="directory-kicker">How to read this</p>
+          <h2 id="directory-provenance-title">Inventory is not promotion.</h2>
+        </div>
+        <div>
+          <p>
+            Inclusion means the identity remains accounted for. “Current” is the working set;
+            supporting and past projects stay visible so the portfolio does not become revisionist.
+          </p>
+          <p>Deployment labels reflect catalog ownership, not a real-time availability check.</p>
+          <p>{HISTORY_SEMANTICS}</p>
+          <a href="/projects.json">Open the machine-readable directory <span aria-hidden="true">→</span></a>
+        </div>
+      </aside>
+
+      <button class="directory-filter-return" data-directory-filter-return hidden type="button">
+        <span data-filter-return-count>{DIRECTORY_COUNT}</span> results · Filters
+      </button>
+    </main>
+    <Footer />
+  </div>
+</Layout>
+
+<script>
+  const root = document.querySelector<HTMLElement>('[data-directory-root]');
+  const controls = document.querySelector<HTMLElement>('[data-directory-controls]');
+  const filterReturn = document.querySelector<HTMLButtonElement>('[data-directory-filter-return]');
+  const filterReturnCount = document.querySelector<HTMLElement>('[data-filter-return-count]');
+  const search = document.querySelector<HTMLInputElement>('#directory-search');
+  const form = document.querySelector<HTMLSelectElement>('#directory-form');
+  const platform = document.querySelector<HTMLSelectElement>('#directory-platform');
+  const resultCount = document.querySelector<HTMLElement>('#directory-result-count');
+  const reset = document.querySelector<HTMLButtonElement>('#directory-reset');
+  const empty = document.querySelector<HTMLElement>('[data-directory-empty]');
+  const rows = [...document.querySelectorAll<HTMLElement>('[data-directory-row]')];
+  const sections = [...document.querySelectorAll<HTMLElement>('[data-directory-section]')];
+  const groupButtons = [...document.querySelectorAll<HTMLButtonElement>('[data-group-filter]')];
+  let activeGroup = 'all';
+
+  if (controls) controls.hidden = false;
+  if (filterReturn) filterReturn.hidden = false;
+
+  if (controls && filterReturn) {
+    const updateFilterReturnVisibility = () => {
+      filterReturn.classList.toggle(
+        'directory-filter-return--hidden',
+        controls.getBoundingClientRect().bottom > 0
+      );
+    };
+    updateFilterReturnVisibility();
+    window.addEventListener('scroll', updateFilterReturnVisibility, { passive: true });
+  }
+
+  const normalize = (value: string) => value.trim().toLocaleLowerCase();
+
+  function updateDirectory() {
+    const query = normalize(search?.value ?? '');
+    const selectedForm = form?.value ?? '';
+    const selectedPlatform = platform?.value ?? '';
+    let visible = 0;
+
+    for (const row of rows) {
+      const matches =
+        (activeGroup === 'all' || row.dataset.group === activeGroup) &&
+        (!selectedForm || (row.dataset.form ?? '').split('|').includes(selectedForm)) &&
+        (!selectedPlatform || (row.dataset.platforms ?? '').split('|').includes(selectedPlatform)) &&
+        (!query || (row.dataset.search ?? '').includes(query));
+      row.hidden = !matches;
+      if (matches) visible += 1;
+    }
+
+    for (const section of sections) {
+      section.hidden = !section.querySelector('[data-directory-row]:not([hidden])');
+    }
+
+    if (resultCount) {
+      resultCount.textContent =
+        visible === rows.length ? `Showing all ${visible} identities` : `Showing ${visible} of ${rows.length} identities`;
+    }
+    if (filterReturnCount) filterReturnCount.textContent = String(visible);
+    if (empty) empty.hidden = visible !== 0;
+    if (root) root.hidden = visible === 0;
+  }
+
+  function resetDirectory() {
+    if (search) search.value = '';
+    if (form) form.value = '';
+    if (platform) platform.value = '';
+    activeGroup = 'all';
+    for (const button of groupButtons) {
+      button.setAttribute('aria-pressed', String(button.dataset.groupFilter === 'all'));
+    }
+    updateDirectory();
+    search?.focus();
+  }
+
+  search?.addEventListener('input', updateDirectory);
+  form?.addEventListener('change', updateDirectory);
+  platform?.addEventListener('change', updateDirectory);
+  reset?.addEventListener('click', resetDirectory);
+  filterReturn?.addEventListener('click', () => {
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    controls?.scrollIntoView({ behavior: reduceMotion ? 'auto' : 'smooth', block: 'start' });
+    window.setTimeout(() => search?.focus({ preventScroll: true }), reduceMotion ? 0 : 350);
+  });
+  document.querySelector('[data-empty-reset]')?.addEventListener('click', resetDirectory);
+
+  for (const button of groupButtons) {
+    button.addEventListener('click', () => {
+      activeGroup = button.dataset.groupFilter ?? 'all';
+      for (const candidate of groupButtons) {
+        candidate.setAttribute('aria-pressed', String(candidate === button));
+      }
+      updateDirectory();
+    });
+  }
+</script>
+
+<style>
+  .directory-world {
+    min-height: 100vh;
+    --directory-line: rgba(20, 21, 17, 0.2);
+    --directory-pane: rgba(250, 247, 239, 0.97);
+    --directory-quiet: #494842;
+    background: var(--workshop-ground);
+    color: var(--workshop-ink);
+  }
+
+  .directory-world :global(:focus-visible) {
+    outline: 2px solid #fff;
+    outline-offset: 2px;
+    box-shadow: 0 0 0 5px var(--workshop-cobalt);
+  }
+
+  .directory-shell {
+    width: min(92rem, calc(100% - 2rem));
+    margin-inline: auto;
+    padding-bottom: 1rem;
+  }
+
+  .directory-intro {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(16rem, 0.3fr);
+    gap: 6px;
+    padding-top: 6px;
+    background: var(--workshop-steel);
+  }
+
+  .directory-intro > *,
+  .directory-controls > *,
+  .directory-row > * {
+    min-width: 0;
+  }
+
+  .directory-intro-copy,
+  .directory-count-pane {
+    min-height: 27rem;
+    padding: clamp(2rem, 6vw, 5.5rem);
+  }
+
+  .directory-intro-copy {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    background: var(--workshop-pane);
+  }
+
+  .directory-kicker {
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+
+  .directory-intro h1 {
+    max-width: 14ch;
+    margin-top: 1.25rem;
+    font-size: clamp(3rem, 7vw, 6rem);
+    font-weight: 600;
+    letter-spacing: -0.04em;
+    line-height: 0.96;
+    text-wrap: balance;
+  }
+
+  .directory-intro-copy > p:last-child {
+    max-width: 64ch;
+    margin-top: 2rem;
+    color: var(--workshop-muted);
+    font-size: clamp(1rem, 1.5vw, 1.2rem);
+  }
+
+  .directory-count-pane {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    background: var(--workshop-cobalt);
+    color: #fff;
+  }
+
+  .directory-count-pane strong {
+    font-size: clamp(5rem, 11vw, 10rem);
+    font-weight: 600;
+    letter-spacing: -0.04em;
+    line-height: 0.8;
+  }
+
+  .directory-count-pane span {
+    max-width: 9ch;
+    font-size: clamp(1.7rem, 3vw, 3rem);
+    font-weight: 600;
+    letter-spacing: -0.03em;
+    line-height: 0.95;
+  }
+
+  .directory-count-pane small {
+    font-size: 0.82rem;
+    font-weight: 600;
+  }
+
+  .directory-controls {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    display: grid;
+    grid-template-columns: minmax(16rem, 1.3fr) minmax(18rem, 1fr);
+    gap: 1.5rem 3rem;
+    padding: 1.5rem clamp(1rem, 3vw, 2.5rem);
+    background: var(--workshop-steel);
+    color: #fff;
+  }
+
+  .directory-search label,
+  .directory-selects label > span {
+    display: block;
+    margin-bottom: 0.4rem;
+    color: #c9c4b8;
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  .directory-search input,
+  .directory-selects select {
+    width: 100%;
+    min-height: 3rem;
+    border: 1px solid var(--workshop-muted);
+    border-radius: 0;
+    background: var(--workshop-steel);
+    color: #fff;
+    font: inherit;
+  }
+
+  .directory-search input {
+    padding: 0 0.9rem;
+  }
+
+  .directory-search input::placeholder {
+    color: #aaa69c;
+  }
+
+  .directory-selects {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem;
+  }
+
+  .directory-selects select {
+    padding: 0 2.2rem 0 0.75rem;
+  }
+
+  .directory-groups {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+  }
+
+  .directory-groups button,
+  .directory-result-line button,
+  .directory-empty button {
+    min-height: 2.75rem;
+    border: 1px solid var(--workshop-muted);
+    border-radius: 999px;
+    padding: 0.55rem 0.9rem;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    font-size: 0.82rem;
+    font-weight: 650;
+    cursor: pointer;
+  }
+
+  .directory-groups button[aria-pressed='true'] {
+    border-color: #fff;
+    background: #fff;
+    color: #11120f;
+  }
+
+  .directory-result-line {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    color: #c9c4b8;
+    font-size: 0.82rem;
+  }
+
+  .directory-result-line button {
+    border: 0;
+    padding-inline: 0;
+    color: #fff;
+    text-decoration: underline;
+    text-underline-offset: 0.25em;
+  }
+
+  .directory-section {
+    padding-top: 6px;
+    background: var(--workshop-steel);
+  }
+
+  .directory-section-head {
+    display: grid;
+    grid-template-columns: minmax(15rem, 0.65fr) minmax(18rem, 1fr);
+    gap: 2rem;
+    align-items: end;
+    padding: clamp(2.25rem, 4vw, 3.5rem) clamp(1.25rem, 4vw, 3.5rem);
+    background: var(--workshop-seeded);
+  }
+
+  .directory-section-head > div > p {
+    margin-bottom: 0.5rem;
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+  }
+
+  .directory-section-head h2 {
+    font-size: clamp(2.5rem, 5vw, 5rem);
+    font-weight: 600;
+    letter-spacing: -0.04em;
+    line-height: 0.95;
+  }
+
+  .directory-section-head > p {
+    max-width: 52ch;
+    color: var(--workshop-muted);
+    font-size: 1.05rem;
+  }
+
+  .directory-rows {
+    display: grid;
+    gap: 1px;
+    background: rgba(20, 21, 17, 0.32);
+  }
+
+  .directory-row {
+    display: grid;
+    grid-template-columns: minmax(19rem, 1.25fr) minmax(14rem, 0.72fr) minmax(12rem, 0.58fr) minmax(10rem, 0.46fr);
+    min-height: 15rem;
+    background: var(--directory-pane);
+  }
+
+  .directory-row > * {
+    padding: clamp(1.25rem, 2.5vw, 2rem);
+  }
+
+  .directory-row > * + * {
+    border-left: 1px solid var(--directory-line);
+  }
+
+  .directory-row-heading {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  .directory-row-heading h3 {
+    font-size: clamp(1.55rem, 2.4vw, 2.25rem);
+    font-weight: 600;
+    letter-spacing: -0.035em;
+    line-height: 1;
+  }
+
+  .directory-row-heading span {
+    color: var(--workshop-muted);
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+  }
+
+  .directory-identity > p {
+    max-width: 58ch;
+    margin-top: 1rem;
+    color: #5f5d55;
+  }
+
+  .directory-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem 1rem;
+    margin-top: 1.5rem;
+    font-size: 0.82rem;
+    font-weight: 700;
+  }
+
+  .directory-links a {
+    min-height: 2.75rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    text-decoration: underline;
+    text-underline-offset: 0.25em;
+  }
+
+  .directory-links .directory-link--primary {
+    color: var(--workshop-cobalt);
+  }
+
+  .directory-links > span {
+    color: #747168;
+  }
+
+  .directory-anatomy,
+  .directory-history {
+    display: grid;
+    align-content: start;
+    gap: 1.25rem;
+  }
+
+  .directory-anatomy div,
+  .directory-history div {
+    display: grid;
+    gap: 0.3rem;
+  }
+
+  .directory-anatomy dt,
+  .directory-history dt,
+  .directory-stack > span {
+    color: var(--directory-quiet);
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .directory-anatomy dd,
+  .directory-history dd {
+    margin: 0;
+    font-size: 0.9rem;
+    font-weight: 600;
+  }
+
+  .directory-anatomy small {
+    display: block;
+    margin-top: 0.35rem;
+    color: var(--directory-quiet);
+    font-size: 0.76rem;
+    font-weight: 500;
+  }
+
+  .deployment-state {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+  }
+
+  .deployment-state::before {
+    width: 0.45rem;
+    height: 0.45rem;
+    border-radius: 50%;
+    background: #747168;
+    content: '';
+  }
+
+  .deployment-state--live::before {
+    background: #1746a2;
+  }
+
+  .directory-stack {
+    background: var(--workshop-seeded);
+  }
+
+  .directory-stack ul {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+    margin-top: 0.75rem;
+    list-style: none;
+  }
+
+  .directory-stack li {
+    border: 1px solid rgba(20, 21, 17, 0.28);
+    border-radius: 999px;
+    padding: 0.35rem 0.65rem;
+    font-size: 0.75rem;
+    font-weight: 650;
+  }
+
+  .directory-history {
+    background: #f5f0e6;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .directory-empty {
+    padding: clamp(4rem, 10vw, 8rem) 2rem;
+    background: var(--workshop-seeded);
+    text-align: center;
+  }
+
+  .directory-empty strong {
+    display: block;
+    font-size: clamp(2rem, 4vw, 4rem);
+    letter-spacing: -0.04em;
+  }
+
+  .directory-empty p {
+    margin-top: 0.75rem;
+    color: var(--workshop-muted);
+  }
+
+  .directory-empty button {
+    margin-top: 1.5rem;
+    border-color: #11120f;
+  }
+
+  .directory-provenance {
+    display: grid;
+    grid-template-columns: minmax(16rem, 0.7fr) minmax(18rem, 1fr);
+    gap: 6px;
+    margin-top: 6px;
+    background: var(--workshop-steel);
+  }
+
+  .directory-provenance > div {
+    padding: clamp(2rem, 5vw, 4.5rem);
+    background: var(--workshop-amber);
+  }
+
+  .directory-provenance > div:last-child {
+    display: grid;
+    align-content: center;
+    gap: 1rem;
+    background: var(--directory-pane);
+  }
+
+  .directory-provenance h2 {
+    max-width: 10ch;
+    margin-top: 1rem;
+    font-size: clamp(2rem, 4vw, 4rem);
+    font-weight: 600;
+    letter-spacing: -0.04em;
+    line-height: 0.98;
+  }
+
+  .directory-provenance p {
+    max-width: 68ch;
+    color: var(--workshop-muted);
+  }
+
+  .directory-provenance a {
+    min-height: 2.75rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    width: fit-content;
+    margin-top: 0.5rem;
+    font-weight: 700;
+  }
+
+  .directory-filter-return {
+    display: none;
+  }
+
+  [hidden] {
+    display: none !important;
+  }
+
+  @media (max-width: 72rem) {
+    .directory-row {
+      grid-template-columns: minmax(18rem, 1.2fr) minmax(13rem, 0.8fr) minmax(13rem, 0.7fr);
+    }
+
+    .directory-history {
+      grid-column: 1 / -1;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      border-top: 1px solid var(--directory-line);
+      border-left: 0 !important;
+    }
+  }
+
+  @media (max-width: 50rem) {
+    .directory-intro,
+    .directory-section-head,
+    .directory-provenance {
+      grid-template-columns: minmax(0, 1fr);
+    }
+
+    .directory-intro-copy,
+    .directory-count-pane {
+      min-height: 23rem;
+    }
+
+    .directory-controls {
+      position: static;
+      grid-template-columns: 1fr;
+    }
+
+    .directory-filter-return {
+      position: fixed;
+      right: 1rem;
+      bottom: 1rem;
+      z-index: 20;
+      display: inline-flex;
+      min-height: 2.75rem;
+      align-items: center;
+      border: 1px solid #fff;
+      border-radius: 999px;
+      padding: 0.65rem 1rem;
+      background: var(--workshop-steel);
+      color: #fff;
+      font: inherit;
+      font-size: 0.82rem;
+      font-weight: 700;
+      cursor: pointer;
+      transition: opacity 140ms ease, translate 140ms ease;
+    }
+
+    .directory-filter-return--hidden {
+      pointer-events: none;
+      opacity: 0;
+      translate: 0 0.5rem;
+    }
+
+    .directory-row {
+      grid-template-columns: minmax(0, 1fr) minmax(12rem, 0.55fr);
+    }
+
+    .directory-identity {
+      grid-column: 1 / -1;
+    }
+
+    .directory-anatomy {
+      border-top: 1px solid var(--directory-line);
+      border-left: 0 !important;
+    }
+
+    .directory-history {
+      grid-column: auto;
+      grid-template-columns: 1fr;
+      border-top: 0;
+      border-left: 1px solid var(--directory-line) !important;
+    }
+  }
+
+  @media (max-width: 34rem) {
+    .directory-shell {
+      width: min(100% - 1rem, 92rem);
+    }
+
+    .directory-intro-copy,
+    .directory-count-pane {
+      min-height: 21rem;
+      padding: 1.5rem;
+    }
+
+    .directory-intro h1 {
+      max-width: 12ch;
+      font-size: 2.65rem;
+      line-height: 0.98;
+    }
+
+    .directory-intro-copy > p:last-child {
+      overflow-wrap: anywhere;
+    }
+
+    :global(.directory-world .nav-links a:nth-child(2)) {
+      display: none;
+    }
+
+    .directory-count-pane strong {
+      font-size: 6rem;
+    }
+
+    .directory-selects,
+    .directory-row,
+    .directory-history {
+      grid-template-columns: 1fr;
+    }
+
+    .directory-row > * {
+      grid-column: auto;
+      border-top: 1px solid var(--directory-line);
+      border-left: 0 !important;
+    }
+
+    .directory-identity {
+      border-top: 0;
+    }
+
+    .directory-row-heading {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+
+    .directory-result-line {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .directory-filter-return {
+      transition: none;
+    }
+  }
+</style>

--- a/apps/showcase/src/pages/projects.json.ts
+++ b/apps/showcase/src/pages/projects.json.ts
@@ -1,7 +1,7 @@
-import { portfolioProjects } from '../lib/portfolio-projects';
+import { directoryProjects } from '../lib/portfolio-projects';
 
 export function GET() {
-  return new Response(JSON.stringify(portfolioProjects), {
+  return new Response(JSON.stringify(directoryProjects), {
     headers: {
       'Access-Control-Allow-Origin': '*',
       'Cache-Control': 'public, max-age=60, s-maxage=300, stale-while-revalidate=86400',

--- a/catalog/generated/public.json
+++ b/catalog/generated/public.json
@@ -1,7 +1,1742 @@
 {
-  "schemaVersion": 2,
+  "schemaVersion": 3,
   "generatedFrom": [
     "site-health/apps/backend/config/projects.json"
+  ],
+  "historySemantics": "firstCommitAt and latestCommitAt are dates from the currently retained Git history. They are not incorporation, launch, or retirement dates.",
+  "directory": [
+    {
+      "id": "codevetter",
+      "name": "CodeVetter",
+      "description": "AI code review platform — desktop-first, works offline.",
+      "kind": "product",
+      "form": "Desktop app",
+      "platforms": [
+        "macOS",
+        "Windows",
+        "Linux",
+        "Web"
+      ],
+      "technologies": [
+        "Tauri",
+        "React",
+        "Go",
+        "Rust"
+      ],
+      "group": "current",
+      "lifecycle": "maintained",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Pages",
+        "Cloudflare Workers"
+      ],
+      "domains": [
+        "codevetter.com"
+      ],
+      "url": "https://codevetter.com",
+      "repositoryUrl": "https://github.com/Codevetter/codevetter",
+      "changelogUrl": "https://codevetter.com/changelog",
+      "roadmapUrl": "https://github.com/Codevetter/codevetter/issues",
+      "firstCommitAt": "2025-11-30",
+      "latestCommitAt": "2026-08-22"
+    },
+    {
+      "id": "pace",
+      "name": "HeyPace",
+      "description": "Local-only macOS voice agent that can understand what is on your screen.",
+      "kind": "product",
+      "form": "macOS app",
+      "platforms": [
+        "macOS",
+        "Web"
+      ],
+      "technologies": [
+        "Swift",
+        "SwiftUI",
+        "Astro",
+        "Cloudflare Pages"
+      ],
+      "group": "current",
+      "lifecycle": "maintained",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Pages"
+      ],
+      "domains": [
+        "heypace.app"
+      ],
+      "url": "https://heypace.app",
+      "repositoryUrl": "https://github.com/HeyPace/pace",
+      "changelogUrl": "https://heypace.app/changelog",
+      "roadmapUrl": "https://github.com/HeyPace/pace/issues",
+      "firstCommitAt": "2026-07-13",
+      "latestCommitAt": "2026-08-22"
+    },
+    {
+      "id": "posttrainllm",
+      "name": "PostTrainLLM",
+      "description": "A local factory for training, evaluating, and running specialist language models.",
+      "kind": "product",
+      "form": "Research platform",
+      "platforms": [
+        "Web",
+        "Local"
+      ],
+      "technologies": [
+        "Astro",
+        "Python",
+        "Rust",
+        "Cloudflare Pages"
+      ],
+      "group": "current",
+      "lifecycle": "maintained",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Pages"
+      ],
+      "domains": [
+        "posttrainllm.com"
+      ],
+      "url": "https://posttrainllm.com",
+      "repositoryUrl": "https://github.com/PostTrainLLM/posttrainllm",
+      "changelogUrl": "https://posttrainllm.com/changelog",
+      "roadmapUrl": "https://github.com/PostTrainLLM/posttrainllm/issues",
+      "firstCommitAt": "2026-05-21",
+      "latestCommitAt": "2026-08-22"
+    },
+    {
+      "id": "site-health",
+      "name": "Site Health",
+      "description": "A local portfolio dashboard for domains, performance, search, and AI visibility evidence.",
+      "kind": "platform",
+      "form": "Local dashboard",
+      "platforms": [
+        "Web",
+        "Local"
+      ],
+      "technologies": [
+        "Astro",
+        "TypeScript",
+        "Node.js"
+      ],
+      "group": "current",
+      "lifecycle": "maintained",
+      "deployed": false,
+      "deploymentProviders": [],
+      "domains": [],
+      "firstCommitAt": "2026-05-02",
+      "latestCommitAt": "2026-08-22"
+    },
+    {
+      "id": "workflows-and-skills",
+      "name": "Workflows and Skills",
+      "description": "Reusable Fleet skills, workflows, and operator scripts without product runtime ownership.",
+      "kind": "platform",
+      "form": "Automation toolkit",
+      "platforms": [
+        "CLI",
+        "GitHub Actions"
+      ],
+      "technologies": [
+        "JavaScript",
+        "Shell",
+        "GitHub Actions"
+      ],
+      "group": "current",
+      "lifecycle": "maintained",
+      "deployed": true,
+      "deploymentProviders": [
+        "GitHub Actions"
+      ],
+      "domains": [],
+      "repositoryUrl": "https://github.com/sass-maker/workflows-and-skills",
+      "roadmapUrl": "https://github.com/sass-maker/workflows-and-skills/issues",
+      "firstCommitAt": "2026-07-30",
+      "latestCommitAt": "2026-08-22"
+    },
+    {
+      "id": "chatgpt-connections",
+      "name": "ChatGPT Connections",
+      "description": "A read-only MCP gateway that exposes selected public Fleet data to ChatGPT connections.",
+      "kind": "platform",
+      "form": "MCP service",
+      "platforms": [
+        "API",
+        "ChatGPT"
+      ],
+      "technologies": [
+        "TypeScript",
+        "Cloudflare Workers",
+        "MCP"
+      ],
+      "group": "current",
+      "lifecycle": "maintained",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Workers"
+      ],
+      "domains": [],
+      "repositoryUrl": "https://github.com/sass-maker/chatgpt-connections",
+      "roadmapUrl": "https://github.com/sass-maker/chatgpt-connections/issues",
+      "firstCommitAt": "2026-08-11",
+      "latestCommitAt": "2026-08-22"
+    },
+    {
+      "id": "saas-maker",
+      "name": "SaaS Maker",
+      "description": "Software as a specialized service: a living studio of focused products built for particular problems and maintained in public.",
+      "kind": "product",
+      "form": "Web directory and service",
+      "platforms": [
+        "Web",
+        "API"
+      ],
+      "technologies": [
+        "Astro",
+        "React",
+        "Cloudflare",
+        "D1"
+      ],
+      "group": "current",
+      "lifecycle": "maintained",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Pages",
+        "Cloudflare Workers"
+      ],
+      "domains": [
+        "sassmaker.com"
+      ],
+      "url": "https://sassmaker.com",
+      "repositoryUrl": "https://github.com/sass-maker/saas-maker",
+      "changelogUrl": "https://sassmaker.com/changelog",
+      "roadmapUrl": "https://github.com/sass-maker/saas-maker/issues",
+      "firstCommitAt": "2026-02-26",
+      "latestCommitAt": "2026-08-22"
+    },
+    {
+      "id": "gitstat",
+      "name": "GitStat",
+      "description": "A GitHub analytics dashboard for contribution history, code churn, collaboration, and AI-assisted work.",
+      "kind": "product",
+      "form": "Web app",
+      "platforms": [
+        "Web"
+      ],
+      "technologies": [
+        "React",
+        "Vite",
+        "TypeScript",
+        "Cloudflare Pages"
+      ],
+      "group": "current",
+      "lifecycle": "maintained",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Pages"
+      ],
+      "domains": [
+        "git.significanthobbies.com"
+      ],
+      "url": "https://git.significanthobbies.com",
+      "repositoryUrl": "https://github.com/sass-maker/gitstat",
+      "roadmapUrl": "https://github.com/sass-maker/gitstat/issues",
+      "firstCommitAt": "2026-08-21",
+      "latestCommitAt": "2026-08-22"
+    },
+    {
+      "id": "reel-pipeline",
+      "name": "Reel Pipeline",
+      "description": "A cost-bounded pipeline for planning, producing, and retaining short-form video artifacts.",
+      "kind": "product",
+      "form": "Video pipeline",
+      "platforms": [
+        "CLI",
+        "API",
+        "Local"
+      ],
+      "technologies": [
+        "Python",
+        "Rust",
+        "Cloudflare Workers",
+        "R2"
+      ],
+      "group": "current",
+      "lifecycle": "maintained",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Workers"
+      ],
+      "domains": [],
+      "repositoryUrl": "https://github.com/sass-maker/reel-pipeline",
+      "roadmapUrl": "https://github.com/sass-maker/reel-pipeline/issues",
+      "firstCommitAt": "2026-05-28",
+      "latestCommitAt": "2026-08-22"
+    },
+    {
+      "id": "mobile-dev-cockpit",
+      "name": "Mobile Dev Cockpit",
+      "description": "A parked mobile supervision client retained for possible future reactivation.",
+      "kind": "product",
+      "form": "Mobile app",
+      "platforms": [
+        "iOS",
+        "Android"
+      ],
+      "technologies": [
+        "React Native",
+        "TypeScript"
+      ],
+      "group": "past",
+      "lifecycle": "past",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Workers"
+      ],
+      "domains": [],
+      "repositoryUrl": "https://github.com/sarthakagrawal927/mobile-dev-cockpit",
+      "roadmapUrl": "https://github.com/sarthakagrawal927/mobile-dev-cockpit/issues",
+      "firstCommitAt": "2026-07-13",
+      "latestCommitAt": "2026-08-22"
+    },
+    {
+      "id": "drank",
+      "name": "Drank",
+      "description": "Domain Rating intelligence for product, SEO, and market research.",
+      "kind": "product",
+      "form": "Web tool",
+      "platforms": [
+        "Web"
+      ],
+      "technologies": [
+        "Next.js",
+        "React",
+        "TypeScript",
+        "Cloudflare Pages"
+      ],
+      "group": "supporting",
+      "lifecycle": "maintained",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Pages"
+      ],
+      "domains": [
+        "domains.sassmaker.com"
+      ],
+      "url": "https://domains.sassmaker.com",
+      "repositoryUrl": "https://github.com/sass-maker/drank",
+      "changelogUrl": "https://domains.sassmaker.com/changelog",
+      "roadmapUrl": "https://github.com/sass-maker/drank/issues",
+      "firstCommitAt": "2026-06-10",
+      "latestCommitAt": "2026-08-22"
+    },
+    {
+      "id": "email-manager",
+      "name": "Email Manager",
+      "description": "A private Gmail workspace for local semantic search, sender insights, and explicit unsubscribe workflows.",
+      "kind": "product",
+      "form": "Web app",
+      "platforms": [
+        "Web",
+        "API"
+      ],
+      "technologies": [
+        "React",
+        "Hono",
+        "Cloudflare Workers",
+        "D1"
+      ],
+      "group": "supporting",
+      "lifecycle": "maintained",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Workers"
+      ],
+      "domains": [
+        "mail.significanthobbies.com"
+      ],
+      "url": "https://mail.significanthobbies.com",
+      "repositoryUrl": "https://github.com/Significant-Hobbies/email-manager",
+      "changelogUrl": "https://mail.significanthobbies.com/changelog",
+      "roadmapUrl": "https://github.com/Significant-Hobbies/email-manager/issues",
+      "firstCommitAt": "2026-02-24",
+      "latestCommitAt": "2026-08-22"
+    },
+    {
+      "id": "chatgpt-memory-insights",
+      "name": "Memory Map",
+      "description": "Turn a ChatGPT export into a private, browser-computed map of recurring themes, facts, and conversations.",
+      "kind": "product",
+      "form": "Web app",
+      "platforms": [
+        "Web"
+      ],
+      "technologies": [
+        "Astro",
+        "TypeScript",
+        "Cloudflare Pages"
+      ],
+      "group": "current",
+      "lifecycle": "maintained",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Pages"
+      ],
+      "domains": [
+        "chatgpt.significanthobbies.com"
+      ],
+      "url": "https://chatgpt.significanthobbies.com",
+      "repositoryUrl": "https://github.com/Significant-Hobbies/chatgpt-memory-insights",
+      "changelogUrl": "https://chatgpt.significanthobbies.com/changelog",
+      "roadmapUrl": "https://github.com/Significant-Hobbies/chatgpt-memory-insights/issues",
+      "firstCommitAt": "2026-07-28",
+      "latestCommitAt": "2026-08-20"
+    },
+    {
+      "id": "free-ai",
+      "name": "Free AI",
+      "description": "OpenAI-compatible gateway across free-tier model providers.",
+      "kind": "platform",
+      "form": "API gateway",
+      "platforms": [
+        "API",
+        "Web"
+      ],
+      "technologies": [
+        "Hono",
+        "TypeScript",
+        "Cloudflare Workers",
+        "D1"
+      ],
+      "group": "supporting",
+      "lifecycle": "maintained",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Workers"
+      ],
+      "domains": [
+        "ai-gateway.sassmaker.com"
+      ],
+      "url": "https://ai-gateway.sassmaker.com",
+      "repositoryUrl": "https://github.com/sass-maker/free-ai",
+      "changelogUrl": "https://ai-gateway.sassmaker.com/changelog",
+      "roadmapUrl": "https://github.com/sass-maker/free-ai/issues",
+      "firstCommitAt": "2026-02-15",
+      "latestCommitAt": "2026-08-22"
+    },
+    {
+      "id": "psi-swarm",
+      "name": "PSI Swarm",
+      "description": "Repeated Lighthouse distributions for honest website performance tracking.",
+      "kind": "platform",
+      "form": "Performance platform",
+      "platforms": [
+        "Web",
+        "CLI"
+      ],
+      "technologies": [
+        "Astro",
+        "React",
+        "TypeScript",
+        "Cloudflare Pages"
+      ],
+      "group": "supporting",
+      "lifecycle": "maintained",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Pages"
+      ],
+      "domains": [
+        "performance.sassmaker.com"
+      ],
+      "url": "https://performance.sassmaker.com",
+      "repositoryUrl": "https://github.com/sass-maker/psi-swarm",
+      "changelogUrl": "https://performance.sassmaker.com/changelog",
+      "roadmapUrl": "https://github.com/sass-maker/psi-swarm/issues",
+      "firstCommitAt": "2026-06-03",
+      "latestCommitAt": "2026-08-22"
+    },
+    {
+      "id": "high-signal",
+      "name": "High Signal",
+      "description": "Evidence-backed daily intelligence across technology, startups, finance, and public markets.",
+      "kind": "product",
+      "form": "Intelligence web app",
+      "platforms": [
+        "Web",
+        "API"
+      ],
+      "technologies": [
+        "Next.js",
+        "React",
+        "Hono",
+        "Cloudflare"
+      ],
+      "group": "current",
+      "lifecycle": "maintained",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Workers"
+      ],
+      "domains": [
+        "highsignal.app"
+      ],
+      "url": "https://highsignal.app",
+      "repositoryUrl": "https://github.com/High-Signal-App/high-signal",
+      "changelogUrl": "https://highsignal.app/changelog",
+      "roadmapUrl": "https://github.com/High-Signal-App/high-signal/issues",
+      "firstCommitAt": "2026-04-25",
+      "latestCommitAt": "2026-08-22"
+    },
+    {
+      "id": "everythingrated",
+      "name": "EverythingRated",
+      "description": "A general-purpose rating and comparison experiment.",
+      "kind": "experiment",
+      "form": "Ratings experiment",
+      "platforms": [
+        "Web"
+      ],
+      "technologies": [
+        "Astro",
+        "Next.js",
+        "Cloudflare Workers",
+        "D1"
+      ],
+      "group": "past",
+      "lifecycle": "past",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Workers"
+      ],
+      "domains": [
+        "ratings.highsignal.app"
+      ],
+      "url": "https://ratings.highsignal.app",
+      "repositoryUrl": "https://github.com/High-Signal-App/everythingrated",
+      "roadmapUrl": "https://github.com/High-Signal-App/everythingrated/issues",
+      "firstCommitAt": "2026-04-26",
+      "latestCommitAt": "2026-08-22"
+    },
+    {
+      "id": "research-papers",
+      "name": "Research Papers",
+      "description": "Academic paper discovery and a structured research data asset.",
+      "kind": "product",
+      "form": "Research library",
+      "platforms": [
+        "Web"
+      ],
+      "technologies": [
+        "Astro",
+        "Python",
+        "React",
+        "TypeScript"
+      ],
+      "group": "current",
+      "lifecycle": "maintained",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Pages"
+      ],
+      "domains": [
+        "papers.highsignal.app"
+      ],
+      "url": "https://papers.highsignal.app",
+      "repositoryUrl": "https://github.com/High-Signal-App/research-papers",
+      "changelogUrl": "https://papers.highsignal.app/changelog",
+      "roadmapUrl": "https://github.com/High-Signal-App/research-papers/issues",
+      "firstCommitAt": "2026-05-30",
+      "latestCommitAt": "2026-08-20"
+    },
+    {
+      "id": "materia",
+      "name": "Materia",
+      "description": "Evidence-graded remedy reference organized by body system.",
+      "kind": "experiment",
+      "form": "Interactive experiment",
+      "platforms": [
+        "Web"
+      ],
+      "technologies": [
+        "Astro",
+        "React",
+        "Three.js",
+        "Cloudflare Pages"
+      ],
+      "group": "past",
+      "lifecycle": "past",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Pages"
+      ],
+      "domains": [
+        "materia.significanthobbies.com"
+      ],
+      "url": "https://materia.significanthobbies.com",
+      "repositoryUrl": "https://github.com/Significant-Hobbies/materia",
+      "roadmapUrl": "https://github.com/Significant-Hobbies/materia/issues",
+      "firstCommitAt": "2026-06-21",
+      "latestCommitAt": "2026-08-22"
+    },
+    {
+      "id": "knowledge-base",
+      "name": "Knowledge Base",
+      "description": "Private agent search over specialized corpora with ranked citations, provenance, and schema-aware retrieval.",
+      "kind": "platform",
+      "form": "Knowledge platform",
+      "platforms": [
+        "Web",
+        "API"
+      ],
+      "technologies": [
+        "Astro",
+        "Hono",
+        "Cloudflare Workers",
+        "D1"
+      ],
+      "group": "current",
+      "lifecycle": "maintained",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Pages",
+        "Cloudflare Workers"
+      ],
+      "domains": [
+        "knowledgebase.sassmaker.com",
+        "search.sassmaker.com"
+      ],
+      "url": "https://knowledgebase.sassmaker.com",
+      "repositoryUrl": "https://github.com/sass-maker/knowledge-base",
+      "changelogUrl": "https://knowledgebase.sassmaker.com/changelog",
+      "roadmapUrl": "https://github.com/sass-maker/knowledge-base/issues",
+      "firstCommitAt": "2026-05-27",
+      "latestCommitAt": "2026-08-20"
+    },
+    {
+      "id": "significanthobbies",
+      "name": "Significant Hobbies",
+      "description": "A simple directory for Live, Journal, Habits, Calorie, Setline, Kith, and Anchor.",
+      "kind": "product",
+      "form": "Publication",
+      "platforms": [
+        "Web"
+      ],
+      "technologies": [
+        "Astro",
+        "Next.js",
+        "Cloudflare Workers",
+        "D1"
+      ],
+      "group": "current",
+      "lifecycle": "maintained",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Workers",
+        "Apple App Store Connect"
+      ],
+      "domains": [
+        "significanthobbies.com",
+        "live.significanthobbies.com"
+      ],
+      "url": "https://significanthobbies.com",
+      "repositoryUrl": "https://github.com/Significant-Hobbies/significanthobbies",
+      "changelogUrl": "https://significanthobbies.com/changelog",
+      "roadmapUrl": "https://github.com/Significant-Hobbies/significanthobbies/issues",
+      "firstCommitAt": "2026-03-01",
+      "latestCommitAt": "2026-08-22"
+    },
+    {
+      "id": "india-standards",
+      "name": "India Standards",
+      "description": "A transparent India demographic standards calculator using aggregate PLFS data, explicit uncertainty ranges, and clear source limits.",
+      "kind": "product",
+      "form": "Reference web app",
+      "platforms": [
+        "Web",
+        "API"
+      ],
+      "technologies": [
+        "Next.js",
+        "React",
+        "TypeScript",
+        "Cloudflare Workers"
+      ],
+      "group": "supporting",
+      "lifecycle": "maintained",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Workers"
+      ],
+      "domains": [
+        "india-standards.significanthobbies.com",
+        "india-numbers.significanthobbies.com"
+      ],
+      "url": "https://india-standards.significanthobbies.com",
+      "repositoryUrl": "https://github.com/Significant-Hobbies/india-standards",
+      "changelogUrl": "https://india-standards.significanthobbies.com/changelog",
+      "roadmapUrl": "https://github.com/Significant-Hobbies/india-standards/issues",
+      "firstCommitAt": "2026-07-27",
+      "latestCommitAt": "2026-08-21"
+    },
+    {
+      "id": "anime-list",
+      "name": "Anime List",
+      "description": "Anime and manga discovery with multi-axis filtering and personal watchlists.",
+      "kind": "product",
+      "form": "Web app",
+      "platforms": [
+        "Web",
+        "API"
+      ],
+      "technologies": [
+        "React",
+        "Vite",
+        "Hono",
+        "Cloudflare"
+      ],
+      "group": "supporting",
+      "lifecycle": "maintained",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Pages",
+        "Cloudflare Workers"
+      ],
+      "domains": [
+        "anime.significanthobbies.com"
+      ],
+      "url": "https://anime.significanthobbies.com",
+      "repositoryUrl": "https://github.com/Significant-Hobbies/anime-list",
+      "changelogUrl": "https://anime.significanthobbies.com/changelog",
+      "roadmapUrl": "https://github.com/Significant-Hobbies/anime-list/issues",
+      "firstCommitAt": "2025-02-16",
+      "latestCommitAt": "2026-08-22"
+    },
+    {
+      "id": "chess",
+      "name": "Chess Coach",
+      "description": "Browser chess against Stockfish with optional AI move coaching.",
+      "kind": "experiment",
+      "form": "Web game",
+      "platforms": [
+        "Web"
+      ],
+      "technologies": [
+        "Astro",
+        "React",
+        "Vite",
+        "Cloudflare Pages"
+      ],
+      "group": "past",
+      "lifecycle": "past",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Pages"
+      ],
+      "domains": [
+        "chess.significanthobbies.com"
+      ],
+      "url": "https://chess.significanthobbies.com",
+      "repositoryUrl": "https://github.com/Significant-Hobbies/chess",
+      "roadmapUrl": "https://github.com/Significant-Hobbies/chess/issues",
+      "firstCommitAt": "2026-02-22",
+      "latestCommitAt": "2026-08-17"
+    },
+    {
+      "id": "looptv",
+      "name": "LoopTV",
+      "description": "A lean-back, TV-style random video player for curated channels.",
+      "kind": "product",
+      "form": "Web app",
+      "platforms": [
+        "Web",
+        "TV"
+      ],
+      "technologies": [
+        "Astro",
+        "React",
+        "Vite",
+        "Cloudflare Pages"
+      ],
+      "group": "supporting",
+      "lifecycle": "maintained",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Pages"
+      ],
+      "domains": [
+        "tv.significanthobbies.com"
+      ],
+      "url": "https://tv.significanthobbies.com",
+      "repositoryUrl": "https://github.com/Significant-Hobbies/looptv",
+      "changelogUrl": "https://tv.significanthobbies.com/changelog",
+      "roadmapUrl": "https://github.com/Significant-Hobbies/looptv/issues",
+      "firstCommitAt": "2026-04-04",
+      "latestCommitAt": "2026-08-22"
+    },
+    {
+      "id": "reader",
+      "name": "Reader",
+      "description": "Capture, annotate, revisit, and discuss saved reading.",
+      "kind": "product",
+      "form": "Reading web app",
+      "platforms": [
+        "Web",
+        "API"
+      ],
+      "technologies": [
+        "React",
+        "Hono",
+        "Cloudflare Workers",
+        "D1"
+      ],
+      "group": "current",
+      "lifecycle": "maintained",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Workers"
+      ],
+      "domains": [
+        "read.significanthobbies.com"
+      ],
+      "url": "https://read.significanthobbies.com",
+      "repositoryUrl": "https://github.com/Significant-Hobbies/reader",
+      "changelogUrl": "https://read.significanthobbies.com/changelog",
+      "roadmapUrl": "https://github.com/Significant-Hobbies/reader/issues",
+      "firstCommitAt": "2025-11-16",
+      "latestCommitAt": "2026-08-22"
+    },
+    {
+      "id": "swe-interview-prep",
+      "name": "SWE Interview Prep",
+      "description": "A learning OS for software-engineering interview practice.",
+      "kind": "product",
+      "form": "Learning web app",
+      "platforms": [
+        "Web"
+      ],
+      "technologies": [
+        "React",
+        "Vite",
+        "TypeScript",
+        "Cloudflare Pages"
+      ],
+      "group": "current",
+      "lifecycle": "maintained",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Pages"
+      ],
+      "domains": [
+        "learn.significanthobbies.com"
+      ],
+      "url": "https://learn.significanthobbies.com",
+      "repositoryUrl": "https://github.com/Significant-Hobbies/swe-interview-prep",
+      "changelogUrl": "https://learn.significanthobbies.com/changelog",
+      "roadmapUrl": "https://github.com/Significant-Hobbies/swe-interview-prep/issues",
+      "firstCommitAt": "2026-02-08",
+      "latestCommitAt": "2026-08-22"
+    },
+    {
+      "id": "calorie",
+      "name": "Calorie",
+      "description": "A private, local-first food, water, and weight journal with transparent timing guidance.",
+      "kind": "product",
+      "form": "iOS app",
+      "platforms": [
+        "iOS",
+        "API"
+      ],
+      "technologies": [
+        "SwiftUI",
+        "Hono",
+        "Cloudflare Workers",
+        "D1"
+      ],
+      "group": "current",
+      "lifecycle": "maintained",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Workers",
+        "Apple App Store Connect"
+      ],
+      "domains": [
+        "calorie.significanthobbies.com"
+      ],
+      "url": "https://calorie.significanthobbies.com",
+      "repositoryUrl": "https://github.com/Significant-Hobbies/calorie",
+      "changelogUrl": "https://calorie.significanthobbies.com/changelog",
+      "roadmapUrl": "https://github.com/Significant-Hobbies/calorie/issues",
+      "firstCommitAt": "2026-07-25",
+      "latestCommitAt": "2026-08-22"
+    },
+    {
+      "id": "setline",
+      "name": "Setline",
+      "description": "An iOS-native training tracker that runs a written strength, cardio and mobility programme one set at a time and measures each exercise against an authored target.",
+      "kind": "product",
+      "form": "Web app",
+      "platforms": [
+        "Web"
+      ],
+      "technologies": [
+        "Astro",
+        "TypeScript",
+        "Cloudflare Pages"
+      ],
+      "group": "current",
+      "lifecycle": "maintained",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Pages",
+        "Apple App Store Connect"
+      ],
+      "domains": [
+        "setline.significanthobbies.com"
+      ],
+      "url": "https://setline.significanthobbies.com",
+      "repositoryUrl": "https://github.com/Significant-Hobbies/setline",
+      "changelogUrl": "https://setline.significanthobbies.com/changelog",
+      "roadmapUrl": "https://github.com/Significant-Hobbies/setline/issues",
+      "firstCommitAt": "2026-07-27",
+      "latestCommitAt": "2026-08-22"
+    },
+    {
+      "id": "personal-platform",
+      "name": "Personal Platform",
+      "description": "A private shared identity and data plane for selected Significant Hobbies apps.",
+      "kind": "platform",
+      "form": "Shared API platform",
+      "platforms": [
+        "API"
+      ],
+      "technologies": [
+        "TypeScript",
+        "Cloudflare Workers",
+        "D1"
+      ],
+      "group": "current",
+      "lifecycle": "maintained",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Workers"
+      ],
+      "domains": [],
+      "repositoryUrl": "https://github.com/Significant-Hobbies/personal-platform",
+      "roadmapUrl": "https://github.com/Significant-Hobbies/personal-platform/issues",
+      "firstCommitAt": "2026-08-21",
+      "latestCommitAt": "2026-08-22"
+    },
+    {
+      "id": "kith",
+      "name": "Kith",
+      "description": "A private iPhone app for the people you actually want to stay close to — closeness-weighted constellation home, standing notes, and a chronological log per person.",
+      "kind": "product",
+      "form": "Web app",
+      "platforms": [
+        "Web"
+      ],
+      "technologies": [
+        "Astro",
+        "TypeScript",
+        "Cloudflare Pages"
+      ],
+      "group": "current",
+      "lifecycle": "maintained",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Pages",
+        "Apple App Store Connect"
+      ],
+      "domains": [
+        "kith.significanthobbies.com"
+      ],
+      "url": "https://kith.significanthobbies.com",
+      "repositoryUrl": "https://github.com/Significant-Hobbies/kith",
+      "changelogUrl": "https://kith.significanthobbies.com/changelog",
+      "roadmapUrl": "https://github.com/Significant-Hobbies/kith/issues",
+      "firstCommitAt": "2026-08-16",
+      "latestCommitAt": "2026-08-22"
+    },
+    {
+      "id": "ios-landings",
+      "name": "iOS landings",
+      "description": "Shared Astro factory that builds separate static sites for Significant Hobbies iOS apps.",
+      "kind": "platform",
+      "form": "Landing-site factory",
+      "platforms": [
+        "Web"
+      ],
+      "technologies": [
+        "Astro",
+        "TypeScript",
+        "Cloudflare Pages"
+      ],
+      "group": "current",
+      "lifecycle": "maintained",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Pages"
+      ],
+      "domains": [
+        "journal.significanthobbies.com"
+      ],
+      "url": "https://journal.significanthobbies.com",
+      "firstCommitAt": "2026-08-17",
+      "latestCommitAt": "2026-08-22"
+    },
+    {
+      "id": "rolepatch",
+      "name": "RolePatch",
+      "description": "AI-assisted resume tailoring, role research, and interview preparation.",
+      "kind": "product",
+      "form": "Web app",
+      "platforms": [
+        "Web",
+        "API"
+      ],
+      "technologies": [
+        "Next.js",
+        "React",
+        "Cloudflare Workers",
+        "D1"
+      ],
+      "group": "current",
+      "lifecycle": "maintained",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Workers"
+      ],
+      "domains": [
+        "rolepatch.com"
+      ],
+      "url": "https://rolepatch.com",
+      "repositoryUrl": "https://github.com/Significant-Hobbies/rolepatch",
+      "changelogUrl": "https://rolepatch.com/changelog",
+      "roadmapUrl": "https://github.com/Significant-Hobbies/rolepatch/issues",
+      "firstCommitAt": "2026-02-23",
+      "latestCommitAt": "2026-08-22"
+    },
+    {
+      "id": "karte",
+      "name": "Karte",
+      "description": "An AI link-in-bio that turns a profile into a conversation.",
+      "kind": "product",
+      "form": "Web app",
+      "platforms": [
+        "Web",
+        "API"
+      ],
+      "technologies": [
+        "Next.js",
+        "React",
+        "Cloudflare Workers",
+        "D1"
+      ],
+      "group": "current",
+      "lifecycle": "maintained",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Workers",
+        "Cloudflare Email Workers"
+      ],
+      "domains": [
+        "karte.cc"
+      ],
+      "url": "https://karte.cc",
+      "repositoryUrl": "https://github.com/Significant-Hobbies/karte",
+      "changelogUrl": "https://karte.cc/changelog",
+      "roadmapUrl": "https://github.com/Significant-Hobbies/karte/issues",
+      "firstCommitAt": "2026-03-05",
+      "latestCommitAt": "2026-08-22"
+    },
+    {
+      "id": "starboard",
+      "name": "Starboard",
+      "description": "Organize and semantically search your GitHub stars.",
+      "kind": "product",
+      "form": "Web app",
+      "platforms": [
+        "Web",
+        "API"
+      ],
+      "technologies": [
+        "Next.js",
+        "React",
+        "Cloudflare Workers",
+        "D1"
+      ],
+      "group": "current",
+      "lifecycle": "maintained",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Workers"
+      ],
+      "domains": [
+        "starboard.codevetter.com"
+      ],
+      "url": "https://starboard.codevetter.com",
+      "repositoryUrl": "https://github.com/Codevetter/starboard",
+      "changelogUrl": "https://starboard.codevetter.com/changelog",
+      "roadmapUrl": "https://github.com/Codevetter/starboard/issues",
+      "firstCommitAt": "2026-02-22",
+      "latestCommitAt": "2026-08-22"
+    },
+    {
+      "id": "ai-game",
+      "name": "AliveVille",
+      "description": "Persistent AI world and multi-agent simulation experiments.",
+      "kind": "experiment",
+      "form": "Web game",
+      "platforms": [
+        "Web"
+      ],
+      "technologies": [
+        "React",
+        "Vite",
+        "Three.js",
+        "Cloudflare"
+      ],
+      "group": "past",
+      "lifecycle": "past",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Pages",
+        "Cloudflare Workers"
+      ],
+      "domains": [
+        "aliveville.com"
+      ],
+      "url": "https://aliveville.com",
+      "repositoryUrl": "https://github.com/sarthakagrawal927/aliveville",
+      "roadmapUrl": "https://github.com/sarthakagrawal927/aliveville/issues",
+      "firstCommitAt": "2026-05-03",
+      "latestCommitAt": "2026-08-22"
+    },
+    {
+      "id": "protein-index",
+      "name": "Protein Index",
+      "description": "Searchable protein and nutrition reference.",
+      "kind": "experiment",
+      "form": "Data API and web app",
+      "platforms": [
+        "Web",
+        "API"
+      ],
+      "technologies": [
+        "React",
+        "Hono",
+        "Cloudflare Workers",
+        "D1"
+      ],
+      "group": "past",
+      "lifecycle": "past",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Workers"
+      ],
+      "domains": [
+        "protein.significanthobbies.com"
+      ],
+      "url": "https://protein.significanthobbies.com",
+      "repositoryUrl": "https://github.com/Significant-Hobbies/protein-index-resilience",
+      "roadmapUrl": "https://github.com/Significant-Hobbies/protein-index-resilience/issues",
+      "firstCommitAt": "2026-07-15",
+      "latestCommitAt": "2026-07-25"
+    },
+    {
+      "id": "veg-protein-food",
+      "name": "Recipe Index",
+      "description": "A searchable directory of vegetarian protein foods and practical nutrition comparisons.",
+      "kind": "experiment",
+      "form": "Food directory",
+      "platforms": [
+        "Web"
+      ],
+      "technologies": [
+        "Astro",
+        "Cloudflare Pages"
+      ],
+      "group": "supporting",
+      "lifecycle": "maintained",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Pages"
+      ],
+      "domains": [
+        "veg-protein-food.significanthobbies.com"
+      ],
+      "url": "https://veg-protein-food.significanthobbies.com",
+      "repositoryUrl": "https://github.com/Significant-Hobbies/veg-protein-food",
+      "roadmapUrl": "https://github.com/Significant-Hobbies/veg-protein-food/issues",
+      "firstCommitAt": "2026-08-15",
+      "latestCommitAt": "2026-08-20"
+    },
+    {
+      "id": "app-health",
+      "name": "App Health",
+      "description": "Privacy-first endpoint health for Node, Go, and OpenTelemetry services.",
+      "kind": "product",
+      "form": "Monitoring service",
+      "platforms": [
+        "Web",
+        "API"
+      ],
+      "technologies": [
+        "Hono",
+        "TypeScript",
+        "Cloudflare Workers",
+        "D1"
+      ],
+      "group": "current",
+      "lifecycle": "maintained",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Workers"
+      ],
+      "domains": [
+        "health.sassmaker.com",
+        "ingest.sassmaker.com"
+      ],
+      "url": "https://health.sassmaker.com",
+      "repositoryUrl": "https://github.com/sass-maker/app-health",
+      "changelogUrl": "https://health.sassmaker.com/changelog",
+      "roadmapUrl": "https://github.com/sass-maker/app-health/issues",
+      "firstCommitAt": "2026-07-20",
+      "latestCommitAt": "2026-08-21"
+    },
+    {
+      "id": "mashup",
+      "name": "Mashup",
+      "description": "A local-first tool that turns owned media archives into inspectable multi-clip edits.",
+      "kind": "experiment",
+      "form": "Local media tool",
+      "platforms": [
+        "CLI",
+        "Local"
+      ],
+      "technologies": [
+        "Python",
+        "FFmpeg",
+        "SQLite",
+        "MLX"
+      ],
+      "group": "current",
+      "lifecycle": "maintained",
+      "deployed": false,
+      "deploymentProviders": [],
+      "domains": [],
+      "repositoryUrl": "https://github.com/sass-maker/mashup",
+      "roadmapUrl": "https://github.com/sass-maker/mashup/issues",
+      "firstCommitAt": "2026-07-25",
+      "latestCommitAt": "2026-08-20"
+    },
+    {
+      "id": "saas-ideas",
+      "name": "SaaS Ideas",
+      "description": "A past public directory of software product ideas.",
+      "kind": "product",
+      "form": "Idea directory",
+      "platforms": [
+        "Web"
+      ],
+      "technologies": [
+        "JavaScript",
+        "Cloudflare Pages"
+      ],
+      "group": "past",
+      "lifecycle": "past",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Pages"
+      ],
+      "domains": [
+        "ideas.sassmaker.com"
+      ],
+      "url": "https://ideas.sassmaker.com",
+      "firstCommitAt": "2025-05-10",
+      "latestCommitAt": "2026-08-22"
+    },
+    {
+      "id": "motion",
+      "name": "Motion",
+      "description": "Use your body as the controller for an iPhone-hosted game that can mirror to a larger screen.",
+      "kind": "product",
+      "form": "iOS game",
+      "platforms": [
+        "iOS",
+        "iPadOS",
+        "Web"
+      ],
+      "technologies": [
+        "SwiftUI",
+        "Apple Vision",
+        "Vite",
+        "TypeScript"
+      ],
+      "group": "current",
+      "lifecycle": "maintained",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Pages"
+      ],
+      "domains": [
+        "motion.significanthobbies.com"
+      ],
+      "url": "https://motion.significanthobbies.com",
+      "repositoryUrl": "https://github.com/Significant-Hobbies/motion",
+      "changelogUrl": "https://motion.significanthobbies.com/changelog",
+      "roadmapUrl": "https://github.com/Significant-Hobbies/motion/issues",
+      "firstCommitAt": "2026-08-17",
+      "latestCommitAt": "2026-08-22"
+    },
+    {
+      "id": "truehire",
+      "name": "TrueHire",
+      "description": "Earlier resume and hiring workflow superseded by RolePatch.",
+      "kind": "experiment",
+      "form": "Hiring experiment",
+      "platforms": [
+        "Web"
+      ],
+      "technologies": [
+        "Next.js",
+        "React",
+        "TypeScript",
+        "Cloudflare"
+      ],
+      "group": "past",
+      "lifecycle": "past",
+      "deployed": false,
+      "deploymentProviders": [],
+      "domains": [],
+      "repositoryUrl": "https://github.com/sarthakagrawal927/truehire",
+      "roadmapUrl": "https://github.com/sarthakagrawal927/truehire/issues",
+      "firstCommitAt": "2026-04-24",
+      "latestCommitAt": "2026-07-20"
+    },
+    {
+      "id": "today-little-log",
+      "name": "Today Little Log",
+      "description": "A small daily logging experiment later folded into other work.",
+      "kind": "experiment",
+      "form": "Personal PWA",
+      "platforms": [
+        "Web",
+        "Mobile"
+      ],
+      "technologies": [
+        "React",
+        "Vite",
+        "TypeScript",
+        "Cloudflare"
+      ],
+      "group": "past",
+      "lifecycle": "past",
+      "deployed": false,
+      "deploymentProviders": [
+        "Cloudflare Pages"
+      ],
+      "domains": [],
+      "repositoryUrl": "https://github.com/sarthakagrawal927/today-little-log",
+      "roadmapUrl": "https://github.com/sarthakagrawal927/today-little-log/issues",
+      "firstCommitAt": "2025-12-03",
+      "latestCommitAt": "2026-07-03"
+    },
+    {
+      "id": "open-historia",
+      "name": "Open Historia",
+      "description": "Interactive historical storytelling and world simulation.",
+      "kind": "experiment",
+      "form": "Strategy web game",
+      "platforms": [
+        "Web"
+      ],
+      "technologies": [
+        "React",
+        "Vite",
+        "Hono",
+        "Cloudflare Workers"
+      ],
+      "group": "past",
+      "lifecycle": "past",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Workers"
+      ],
+      "domains": [
+        "historia.aliveville.com"
+      ],
+      "url": "https://historia.aliveville.com",
+      "repositoryUrl": "https://github.com/sarthakagrawal927/open-historia",
+      "roadmapUrl": "https://github.com/sarthakagrawal927/open-historia/issues",
+      "firstCommitAt": "2026-02-08",
+      "latestCommitAt": "2026-08-22"
+    },
+    {
+      "id": "companion-robot",
+      "name": "Companion Robot",
+      "description": "Earlier companion robotics and embodied-agent exploration.",
+      "kind": "experiment",
+      "form": "Hardware experiment",
+      "platforms": [
+        "iOS",
+        "macOS",
+        "ESP32"
+      ],
+      "technologies": [
+        "Swift",
+        "Apple Vision",
+        "ESP32",
+        "Local AI"
+      ],
+      "group": "past",
+      "lifecycle": "past",
+      "deployed": false,
+      "deploymentProviders": [],
+      "domains": [],
+      "repositoryUrl": "https://github.com/HeyPace/companion-robot",
+      "roadmapUrl": "https://github.com/HeyPace/companion-robot/issues",
+      "firstCommitAt": "2026-06-25",
+      "latestCommitAt": "2026-07-17"
+    },
+    {
+      "id": "elves-hq",
+      "name": "Elves HQ",
+      "description": "A past collaborative-agent interface experiment retained for reference.",
+      "kind": "experiment",
+      "form": "Web experiment",
+      "platforms": [
+        "Web"
+      ],
+      "technologies": [
+        "React",
+        "Vite",
+        "TypeScript"
+      ],
+      "group": "past",
+      "lifecycle": "past",
+      "deployed": false,
+      "deploymentProviders": [],
+      "domains": [],
+      "firstCommitAt": "2026-07-06",
+      "latestCommitAt": "2026-07-25"
+    },
+    {
+      "id": "forecast-lab",
+      "name": "Forecast Lab",
+      "description": "Forecasting experiments and evaluation tooling.",
+      "kind": "experiment",
+      "form": "Research toolkit",
+      "platforms": [
+        "CLI",
+        "Web"
+      ],
+      "technologies": [
+        "Rust",
+        "Python",
+        "React",
+        "Vite"
+      ],
+      "group": "past",
+      "lifecycle": "past",
+      "deployed": false,
+      "deploymentProviders": [],
+      "domains": [],
+      "repositoryUrl": "https://github.com/sarthakagrawal927/forecast-lab",
+      "roadmapUrl": "https://github.com/sarthakagrawal927/forecast-lab/issues",
+      "firstCommitAt": "2026-06-21",
+      "latestCommitAt": "2026-07-04"
+    },
+    {
+      "id": "web-playables",
+      "name": "Web Playables",
+      "description": "Small browser-playable game experiments.",
+      "kind": "experiment",
+      "form": "Game collection",
+      "platforms": [
+        "Web",
+        "YouTube Playables"
+      ],
+      "technologies": [
+        "TypeScript",
+        "Vite",
+        "Cloudflare Pages"
+      ],
+      "group": "past",
+      "lifecycle": "past",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Pages"
+      ],
+      "domains": [
+        "idle.aliveville.com"
+      ],
+      "url": "https://idle.aliveville.com",
+      "repositoryUrl": "https://github.com/sarthakagrawal927/web-playables",
+      "roadmapUrl": "https://github.com/sarthakagrawal927/web-playables/issues",
+      "firstCommitAt": "2026-07-10",
+      "latestCommitAt": "2026-08-22"
+    },
+    {
+      "id": "what-it-takes-to-win",
+      "name": "What It Takes to Win",
+      "description": "Explore 2,585 documented early-breakthrough paths without pretending success follows a formula.",
+      "kind": "product",
+      "form": "Research publication",
+      "platforms": [
+        "Web"
+      ],
+      "technologies": [
+        "Astro",
+        "TypeScript",
+        "Cloudflare Pages"
+      ],
+      "group": "supporting",
+      "lifecycle": "maintained",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Pages"
+      ],
+      "domains": [
+        "paths.significanthobbies.com"
+      ],
+      "url": "https://paths.significanthobbies.com",
+      "repositoryUrl": "https://github.com/Significant-Hobbies/what-it-takes-to-win",
+      "changelogUrl": "https://paths.significanthobbies.com/changelog",
+      "roadmapUrl": "https://github.com/Significant-Hobbies/what-it-takes-to-win/issues",
+      "firstCommitAt": "2026-07-21",
+      "latestCommitAt": "2026-08-21"
+    },
+    {
+      "id": "sarthakagrawal-personal",
+      "name": "Sarthak Agrawal",
+      "description": "Personal portfolio of Sarthak Agrawal — AI infrastructure and product engineer.",
+      "kind": "product",
+      "form": "Portfolio website",
+      "platforms": [
+        "Web"
+      ],
+      "technologies": [
+        "Astro",
+        "React",
+        "TypeScript",
+        "Cloudflare Pages"
+      ],
+      "group": "supporting",
+      "lifecycle": "maintained",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Pages"
+      ],
+      "domains": [
+        "sarthakagrawal.dev"
+      ],
+      "url": "https://sarthakagrawal.dev",
+      "repositoryUrl": "https://github.com/sarthakagrawal927/portfolio",
+      "changelogUrl": "https://sarthakagrawal.dev/changelog",
+      "roadmapUrl": "https://github.com/sarthakagrawal927/portfolio/issues",
+      "firstCommitAt": "2026-05-22",
+      "latestCommitAt": "2026-08-17"
+    },
+    {
+      "id": "agent-office",
+      "name": "Office OS",
+      "description": "A local-first Mac workplace where named AI employees have bounded responsibilities and their work stays inspectable.",
+      "kind": "product",
+      "form": "macOS app",
+      "platforms": [
+        "macOS",
+        "Local"
+      ],
+      "technologies": [
+        "SwiftUI",
+        "SpriteKit",
+        "Codex CLI"
+      ],
+      "group": "current",
+      "lifecycle": "maintained",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Pages",
+        "Local macOS"
+      ],
+      "domains": [
+        "office-os.sassmaker.com"
+      ],
+      "url": "https://office-os.sassmaker.com",
+      "firstCommitAt": "2026-08-09",
+      "latestCommitAt": "2026-08-20"
+    },
+    {
+      "id": "indulge",
+      "name": "Habits",
+      "description": "A private habit practice for noticing patterns, making intentional trades, and building better defaults.",
+      "kind": "product",
+      "form": "iOS app",
+      "platforms": [
+        "iOS",
+        "Web"
+      ],
+      "technologies": [
+        "SwiftUI",
+        "Astro",
+        "Cloudflare Pages"
+      ],
+      "group": "current",
+      "lifecycle": "maintained",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Pages",
+        "Apple App Store Connect"
+      ],
+      "domains": [
+        "habits.significanthobbies.com",
+        "indulge.significanthobbies.com"
+      ],
+      "url": "https://habits.significanthobbies.com",
+      "firstCommitAt": "2026-08-17",
+      "latestCommitAt": "2026-08-22"
+    },
+    {
+      "id": "local-ai-video-studio",
+      "name": "Local AI Video Studio",
+      "description": "A local-first Mac studio for comparing reproducible video-effect variants before export.",
+      "kind": "experiment",
+      "form": "macOS app",
+      "platforms": [
+        "macOS",
+        "Local"
+      ],
+      "technologies": [
+        "SwiftUI",
+        "AVFoundation",
+        "Core Image",
+        "VideoToolbox"
+      ],
+      "group": "current",
+      "lifecycle": "maintained",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Pages",
+        "Local macOS"
+      ],
+      "domains": [
+        "local-ai-video-studio.sassmaker.com"
+      ],
+      "url": "https://local-ai-video-studio.sassmaker.com",
+      "firstCommitAt": "2026-08-09",
+      "latestCommitAt": "2026-08-21"
+    },
+    {
+      "id": "field-track",
+      "name": "Field Track",
+      "description": "A private field-location system for managed Android devices and team-scoped route review.",
+      "kind": "product",
+      "form": "Android app and dashboard",
+      "platforms": [
+        "Android",
+        "Web",
+        "API"
+      ],
+      "technologies": [
+        "React Native",
+        "MapLibre",
+        "Cloudflare Workers",
+        "D1"
+      ],
+      "group": "current",
+      "lifecycle": "maintained",
+      "deployed": false,
+      "deploymentProviders": [],
+      "domains": [],
+      "firstCommitAt": "2026-08-12",
+      "latestCommitAt": "2026-08-20"
+    },
+    {
+      "id": "reddit-insights",
+      "name": "Reddit Insights",
+      "description": "A bounded research collector for subreddit evidence and recurring insight snapshots.",
+      "kind": "experiment",
+      "form": "Research collector",
+      "platforms": [
+        "Web",
+        "API"
+      ],
+      "technologies": [
+        "TypeScript",
+        "Cloudflare Workers",
+        "R2"
+      ],
+      "group": "supporting",
+      "lifecycle": "maintained",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Pages",
+        "Cloudflare Workers"
+      ],
+      "domains": [
+        "reddit-insights.highsignal.app"
+      ],
+      "url": "https://reddit-insights.highsignal.app",
+      "firstCommitAt": "2026-08-07",
+      "latestCommitAt": "2026-08-20"
+    },
+    {
+      "id": "verified-bases",
+      "name": "Verified Bases",
+      "description": "A retained research-data identity with no retained local Git history or standalone public destination.",
+      "kind": "experiment",
+      "form": "Research dataset",
+      "platforms": [
+        "GitHub"
+      ],
+      "technologies": [
+        "Markdown",
+        "Git"
+      ],
+      "group": "past",
+      "lifecycle": "past",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Workers"
+      ],
+      "domains": [],
+      "firstCommitAt": null,
+      "latestCommitAt": null
+    },
+    {
+      "id": "anchor",
+      "name": "Anchor",
+      "description": "A local-first focus timer for Mac, iPhone and Apple Watch that parks distractions instead of losing the session, and shows what actually costs you your focus.",
+      "kind": "product",
+      "form": "Apple app",
+      "platforms": [
+        "macOS",
+        "iOS",
+        "watchOS",
+        "Web"
+      ],
+      "technologies": [
+        "SwiftUI",
+        "SwiftData",
+        "CloudKit",
+        "Foundation Models"
+      ],
+      "group": "current",
+      "lifecycle": "local-only",
+      "deployed": true,
+      "deploymentProviders": [
+        "Cloudflare Pages",
+        "Apple App Store Connect"
+      ],
+      "domains": [
+        "anchor.significanthobbies.com"
+      ],
+      "url": "https://anchor.significanthobbies.com",
+      "firstCommitAt": "2026-08-16",
+      "latestCommitAt": "2026-08-22"
+    }
   ],
   "products": [
     {

--- a/scripts/public-products.mjs
+++ b/scripts/public-products.mjs
@@ -15,6 +15,26 @@ const PRODUCT_FIELDS = new Set([
 ]);
 
 const PAST_PROJECT_FIELDS = new Set(['id', 'name', 'description', 'lifecycle', 'repositoryUrl']);
+const DIRECTORY_FIELDS = new Set([
+  'id',
+  'name',
+  'description',
+  'kind',
+  'form',
+  'platforms',
+  'technologies',
+  'group',
+  'lifecycle',
+  'deployed',
+  'deploymentProviders',
+  'domains',
+  'url',
+  'repositoryUrl',
+  'changelogUrl',
+  'roadmapUrl',
+  'firstCommitAt',
+  'latestCommitAt',
+]);
 
 const FORBIDDEN_KEYS =
   /(?:secret|token|password|credential|private|owner|cfProject|notes|dependencies|evidenceSources|contracts|sourcePath|attention)/i;
@@ -24,6 +44,12 @@ const CREDENTIAL_VALUE =
 export function buildPublicProducts(catalog) {
   const products = [];
   const pastProjects = [];
+  const directory = [];
+  const directoryMetadata = catalog.publicDirectory?.projects;
+
+  if (!directoryMetadata || typeof directoryMetadata !== 'object') {
+    throw new Error('catalog.publicDirectory.projects is required');
+  }
 
   for (const project of catalog.projects) {
     const metadata = project.public ?? { listing: 'hidden' };
@@ -83,6 +109,62 @@ export function buildPublicProducts(catalog) {
     throw new Error(`${project.id}: unsupported public listing ${metadata.listing}`);
   }
 
+  const catalogIds = catalog.projects.map((project) => project.id).sort();
+  const directoryIds = Object.keys(directoryMetadata).sort();
+  if (JSON.stringify(catalogIds) !== JSON.stringify(directoryIds)) {
+    throw new Error('public directory metadata must cover every canonical project exactly once');
+  }
+
+  for (const project of catalog.projects) {
+    const metadata = directoryMetadata[project.id];
+    const repositoryUrl = publicRepositoryUrl(project);
+    const domains = project.domains ?? [];
+    const output = {
+      id: project.id,
+      name: project.public?.name ?? project.name,
+      description: metadata.description ?? project.public?.description,
+      kind: project.portfolio.kind,
+      form: metadata.form,
+      platforms: metadata.platforms,
+      technologies: metadata.technologies,
+      group: directoryGroup(project),
+      lifecycle: project.lifecycle,
+      deployed: project.portfolio.deployed,
+      deploymentProviders: publicDeploymentProviders(
+        catalog.infrastructure.projects[project.id]?.deployments ?? []
+      ),
+      domains,
+      ...(domains[0] ? { url: `https://${domains[0]}` } : {}),
+      ...(repositoryUrl ? { repositoryUrl } : {}),
+      ...(project.public?.listing === 'maintained' &&
+      project.public?.hasChangelog !== false &&
+      domains[0]
+        ? { changelogUrl: `https://${domains[0]}/changelog` }
+        : {}),
+      ...(repositoryUrl ? { roadmapUrl: `${repositoryUrl}/issues` } : {}),
+      firstCommitAt: metadata.firstCommitAt,
+      latestCommitAt: metadata.latestCommitAt,
+    };
+    assertShape(output, DIRECTORY_FIELDS, [
+      'id',
+      'name',
+      'description',
+      'kind',
+      'form',
+      'platforms',
+      'technologies',
+      'group',
+      'lifecycle',
+    ]);
+    if (!Array.isArray(output.platforms) || output.platforms.length === 0) {
+      throw new Error(`${project.id}: directory platforms are required`);
+    }
+    if (!Array.isArray(output.technologies) || output.technologies.length === 0) {
+      throw new Error(`${project.id}: directory technologies are required`);
+    }
+    directory.push(output);
+  }
+
   assertUnique(products, 'maintained product');
   assertUnique(pastProjects, 'past project');
   const allIds = [...products, ...pastProjects].map((project) => project.id);
@@ -97,13 +179,56 @@ export function buildPublicProducts(catalog) {
   pastProjects.sort((left, right) => left.name.localeCompare(right.name));
 
   const projection = {
-    schemaVersion: 2,
+    schemaVersion: 3,
     generatedFrom: ['site-health/apps/backend/config/projects.json'],
+    historySemantics: catalog.publicDirectory.historySemantics,
+    directory,
     products,
     pastProjects,
   };
   assertNoPrivateData(projection);
   return projection;
+}
+
+function directoryGroup(project) {
+  if (project.portfolio.status === 'archived' || project.lifecycle === 'past') return 'past';
+  if (
+    project.status === 'orphan' ||
+    project.lifecycle === 'non-product' ||
+    project.attention === 'ignored' ||
+    project.tier === 'out-of-fleet' ||
+    project.portfolio.priority === 'P4'
+  ) {
+    return 'supporting';
+  }
+  return 'current';
+}
+
+function publicRepositoryUrl(project) {
+  if (project.repositoryVisibility !== 'public') return undefined;
+  const repositoryUrl = project.public?.repositoryUrl ?? project.repositoryUrl;
+  if (!repositoryUrl) return undefined;
+  if (!/^https:\/\/github\.com\/[^/]+\/[^/]+$/.test(repositoryUrl)) {
+    throw new Error(`${project.id}: public directory repository must be a GitHub root URL`);
+  }
+  return repositoryUrl;
+}
+
+function publicDeploymentProviders(deployments) {
+  const labels = new Set();
+  for (const deployment of deployments) {
+    const key = `${deployment.provider}:${deployment.kind}`;
+    const label = {
+      'apple:app-store-connect': 'Apple App Store Connect',
+      'cloudflare:email-worker': 'Cloudflare Email Workers',
+      'cloudflare:pages': 'Cloudflare Pages',
+      'cloudflare:worker': 'Cloudflare Workers',
+      'github:actions': 'GitHub Actions',
+      'local:macos-app': 'Local macOS',
+    }[key];
+    if (label) labels.add(label);
+  }
+  return [...labels];
 }
 
 export function assertEvidenceLinks(product) {

--- a/scripts/smoke-prod.mjs
+++ b/scripts/smoke-prod.mjs
@@ -12,6 +12,7 @@
  *
  * Run:
  *   node scripts/smoke-prod.mjs
+ *   node scripts/smoke-prod.mjs --directory-only
  *   SAAS_MAKER_API=https://api.sassmaker.com SAAS_MAKER_APP=https://app.sassmaker.com node scripts/smoke-prod.mjs
  */
 
@@ -19,10 +20,11 @@ const API = process.env.SAAS_MAKER_API ?? 'https://api.sassmaker.com';
 const APP = process.env.SAAS_MAKER_APP ?? 'https://app.sassmaker.com';
 const DIRECTORY = process.env.SAAS_MAKER_DIRECTORY ?? 'https://sassmaker.com';
 const DOCS = process.env.SAAS_MAKER_DOCS ?? 'https://saas-maker-packages.pages.dev';
+const DIRECTORY_ONLY = process.argv.includes('--directory-only');
 
-const checks = [
+const directoryChecks = [
   {
-    name: 'Public directory renders',
+    name: 'Public directory index renders',
     fn: async () => {
       const res = await fetch(DIRECTORY);
       if (res.status !== 200) throw new Error(`status ${res.status}`);
@@ -30,6 +32,35 @@ const checks = [
       if (!body.includes('SaaS Maker')) throw new Error('missing SaaS Maker identity');
     },
   },
+  {
+    name: 'Complete project directory renders 58 identities',
+    fn: async () => {
+      const res = await fetch(`${DIRECTORY}/projects`);
+      if (res.status !== 200) throw new Error(`status ${res.status}`);
+      const body = await res.text();
+      const rows = body.match(/<article class="directory-row" data-directory-row/g)?.length ?? 0;
+      if (rows !== 58) throw new Error(`expected 58 directory rows, got ${rows}`);
+      if (!body.includes('First retained commit') || !body.includes('Latest retained commit')) {
+        throw new Error('missing Git-history bounds');
+      }
+    },
+  },
+  {
+    name: 'Machine-readable directory exposes 58 identities',
+    fn: async () => {
+      const res = await fetch(`${DIRECTORY}/projects.json`);
+      if (res.status !== 200) throw new Error(`status ${res.status}`);
+      const body = await res.json();
+      if (!Array.isArray(body) || body.length !== 58) {
+        throw new Error(
+          `expected 58 JSON entries, got ${Array.isArray(body) ? body.length : 'non-array'}`
+        );
+      }
+    },
+  },
+];
+
+const productChecks = [
   {
     name: 'Package docs render',
     fn: async () => {
@@ -113,6 +144,8 @@ const checks = [
     },
   },
 ];
+
+const checks = DIRECTORY_ONLY ? directoryChecks : [...directoryChecks, ...productChecks];
 
 const start = Date.now();
 let failures = 0;

--- a/scripts/sync-fleet-public-products.mjs
+++ b/scripts/sync-fleet-public-products.mjs
@@ -28,6 +28,26 @@ const PUBLIC_FIELDS = new Set([
   'pillarId',
 ]);
 const REQUIRED_FIELDS = ['id', 'name', 'description', 'url'];
+const DIRECTORY_FIELDS = new Set([
+  'id',
+  'name',
+  'description',
+  'kind',
+  'form',
+  'platforms',
+  'technologies',
+  'group',
+  'lifecycle',
+  'deployed',
+  'deploymentProviders',
+  'domains',
+  'url',
+  'repositoryUrl',
+  'changelogUrl',
+  'roadmapUrl',
+  'firstCommitAt',
+  'latestCommitAt',
+]);
 const FORBIDDEN_KEYS =
   /(?:secret|token|password|credential|private|owner|cfProject|notes|dependencies|evidenceSources|contracts)/i;
 const CREDENTIAL_VALUE =
@@ -51,7 +71,7 @@ function assertNoPrivateData(value, trail = 'projection') {
 }
 
 function validateProjection(parsed, sourcePath) {
-  if (![1, 2].includes(parsed.schemaVersion) || !Array.isArray(parsed.products)) {
+  if (![1, 2, 3].includes(parsed.schemaVersion) || !Array.isArray(parsed.products)) {
     throw new Error(`Unsupported Fleet public projection: ${sourcePath}`);
   }
 
@@ -70,6 +90,26 @@ function validateProjection(parsed, sourcePath) {
     if (ids.has(product.id)) throw new Error(`public product ids must be unique: ${product.id}`);
     ids.add(product.id);
   }
+  if (parsed.schemaVersion >= 3) {
+    if (!Array.isArray(parsed.directory) || parsed.directory.length === 0) {
+      throw new Error(`${sourcePath}: complete public directory is required`);
+    }
+    const directoryIds = new Set();
+    for (const project of parsed.directory) {
+      for (const key of Object.keys(project)) {
+        if (!DIRECTORY_FIELDS.has(key)) {
+          throw new Error(`${project.id ?? 'unknown'}: unsupported directory field ${key}`);
+        }
+      }
+      for (const key of ['id', 'name', 'description', 'form', 'group', 'lifecycle']) {
+        if (!project[key]) throw new Error(`${project.id ?? 'unknown'}: missing directory ${key}`);
+      }
+      if (directoryIds.has(project.id)) {
+        throw new Error(`public directory ids must be unique: ${project.id}`);
+      }
+      directoryIds.add(project.id);
+    }
+  }
   assertNoPrivateData(parsed);
 }
 
@@ -77,7 +117,9 @@ if (process.argv.includes('--validate')) {
   const checkedIn = await readFile(destination, 'utf8');
   const parsed = JSON.parse(checkedIn);
   validateProjection(parsed, destination);
-  console.log(`SaaS Maker checked-in public catalog is valid (${parsed.products.length} products)`);
+  console.log(
+    `SaaS Maker checked-in public catalog is valid (${parsed.directory?.length ?? parsed.products.length} identities)`
+  );
   process.exit(0);
 }
 
@@ -93,10 +135,12 @@ if (process.argv.includes('--check')) {
     process.exitCode = 1;
   } else {
     console.log(
-      `SaaS Maker public catalog matches Site Health (${projection.products.length} products)`
+      `SaaS Maker public catalog matches Site Health (${projection.directory?.length ?? projection.products.length} identities)`
     );
   }
 } else {
   await writeFile(destination, rendered);
-  console.log(`Synced ${projection.products.length} public products from Site Health`);
+  console.log(
+    `Synced ${projection.directory?.length ?? projection.products.length} public identities from Site Health`
+  );
 }

--- a/tests/showcase/directory.test.ts
+++ b/tests/showcase/directory.test.ts
@@ -50,6 +50,7 @@ describe('complete public Fleet directory', () => {
     expect(page).toMatch(/Search name, purpose, stack, or domain/);
     expect(page).toMatch(/First retained commit/);
     expect(page).toMatch(/Latest retained commit/);
+    expect(page).toMatch(/Prominent tools/);
     expect(page).toMatch(/data-directory-filter-return/);
     expect(page).toMatch(/Inventory is not promotion/);
     expect(data).toMatch(/publicCatalog\.directory/);

--- a/tests/showcase/directory.test.ts
+++ b/tests/showcase/directory.test.ts
@@ -1,0 +1,73 @@
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it } from 'vitest';
+import { DIRECTORY_PROJECTS, directoryFormFamilies } from '../../apps/showcase/src/data/directory';
+
+async function readRepository(relativePath: string) {
+  return readFile(new URL(`../../${relativePath}`, import.meta.url), 'utf8');
+}
+
+describe('complete public Fleet directory', () => {
+  it('projects all 58 identities exactly once with privacy-safe anatomy', async () => {
+    const catalog = JSON.parse(await readRepository('catalog/generated/public.json'));
+    const ids = catalog.directory.map((project: { id: string }) => project.id);
+    const counts = (catalog.directory as Array<{ group: string }>).reduce<Record<string, number>>(
+      (result, project) => {
+        result[project.group] = (result[project.group] ?? 0) + 1;
+        return result;
+      },
+      {}
+    );
+
+    expect(catalog.schemaVersion).toBe(3);
+    expect(catalog.directory).toHaveLength(58);
+    expect(new Set(ids).size).toBe(58);
+    expect(counts.current).toBe(32);
+    expect(counts.supporting).toBe(11);
+    expect(counts.past).toBe(15);
+
+    for (const project of catalog.directory) {
+      expect(project.name).toBeTruthy();
+      expect(project.description).toBeTruthy();
+      expect(project.form).toBeTruthy();
+      expect(project.platforms.length).toBeGreaterThan(0);
+      expect(project.technologies.length).toBeGreaterThan(0);
+      expect(JSON.stringify(project)).not.toMatch(
+        /(?:sourcePath|cfProject|credential|password|private repository|\/Users\/)/i
+      );
+    }
+  });
+
+  it('renders a server-first directory with accessible filters and evidence links', async () => {
+    const [page, data, nav, routes, jsonRoute] = await Promise.all([
+      readRepository('apps/showcase/src/pages/projects.astro'),
+      readRepository('apps/showcase/src/data/directory.ts'),
+      readRepository('apps/showcase/src/components/Nav.astro'),
+      readRepository('apps/showcase/src/data/publicRoutes.ts'),
+      readRepository('apps/showcase/src/pages/projects.json.ts'),
+    ]);
+
+    expect(page).toMatch(/data-directory-row/);
+    expect(page).toMatch(/Search name, purpose, stack, or domain/);
+    expect(page).toMatch(/First retained commit/);
+    expect(page).toMatch(/Latest retained commit/);
+    expect(page).toMatch(/data-directory-filter-return/);
+    expect(page).toMatch(/Inventory is not promotion/);
+    expect(data).toMatch(/publicCatalog\.directory/);
+    expect(nav).toMatch(/href="\/projects"/);
+    expect(routes).toMatch(/path: '\/projects'/);
+    expect(jsonRoute).toMatch(/JSON\.stringify\(directoryProjects\)/);
+  });
+
+  it('keeps established web identities discoverable through the public form families', () => {
+    for (const projectId of [
+      'significanthobbies',
+      'veg-protein-food',
+      'truehire',
+      'today-little-log',
+    ]) {
+      const project = DIRECTORY_PROJECTS.find((candidate) => candidate.id === projectId);
+      expect(project).toBeDefined();
+      expect(directoryFormFamilies(project!)).toContain('Web');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- publish all 58 retained Fleet identities at `/projects`
- show product form, platforms, deployment context, public links, prominent tools, and retained Git-history bounds
- keep HTML, JSON, Markdown, sitemap, and agent surfaces on one privacy-safe Site Health projection
- add accessible search/filtering, mobile filter return, and a directory-only production smoke gate

## Verification
- `pnpm lint` (passes; four pre-existing informational notices)
- `pnpm typecheck`
- `pnpm test` (31 tests)
- `pnpm build:showcase`
- `pnpm catalog:validate-public`
- `pnpm catalog:check-public`
- local directory smoke 3/3
- design workflow: preserve lane, critique 34/40, audit 19/20, zero unresolved P0/P1

Closes #49