### PR TITLE
Distill the complete project directory

### DIFF
--- a/.fleet/design-review.json
+++ b/.fleet/design-review.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "fleet.design-review.v1",
+  "version": 1,
+  "project": "saas-maker",
+  "target": "/projects directory distillation",
+  "mode": "preserve",
+  "register": "product",
+  "context": {
+    "product": "apps/showcase/PRODUCT.md",
+    "design": "apps/showcase/DESIGN.md"
+  },
+  "direction": {
+    "references": [],
+    "probes": [],
+    "selected": "existing-design",
+    "approval": "not-required",
+    "before": "artifacts/design/directory-distill-before-1440.png"
+  },
+  "evidence": {
+    "screenshots": [
+      {
+        "width": 390,
+        "path": "artifacts/design/after-390.png"
+      },
+      {
+        "width": 768,
+        "path": "artifacts/design/after-768.png"
+      },
+      {
+        "width": 1440,
+        "path": "artifacts/design/after-1440.png"
+      }
+    ],
+    "projectCheck": {
+      "command": "pnpm test -- tests/showcase/directory.test.ts && pnpm -F @saas-maker/landing-page typecheck && pnpm build:showcase && git diff --check",
+      "status": "pass"
+    },
+    "critique": {
+      "score": 34,
+      "maximum": 40
+    },
+    "audit": {
+      "score": 16,
+      "maximum": 20
+    },
+    "unresolved": {
+      "p0": 0,
+      "p1": 0
+    },
+    "detector": {
+      "posture": "advisory",
+      "findings": []
+    }
+  },
+  "ownerFeedback": {
+    "decision": "delegated",
+    "note": "Owner requested an agent-led cleanup of the repeated directory anatomy while preserving all project facts."
+  }
+}

--- a/.impeccable/critique/2026-08-22T11-06-06Z__apps-showcase-src-pages-projects-astro.md
+++ b/.impeccable/critique/2026-08-22T11-06-06Z__apps-showcase-src-pages-projects-astro.md
@@ -1,0 +1,92 @@
+---
+target: 58-project directory distillation
+total_score: 34
+max_score: 40
+na_heuristics: ""
+p0_count: 0
+p1_count: 0
+timestamp: 2026-08-22T11-06-06Z
+slug: apps-showcase-src-pages-projects-astro
+---
+Method: dual-agent (A: directory_design_review · B: directory_detector_review)
+
+## Design Health Score
+
+| # | Heuristic | Score | Key issue |
+|---|---|---:|---|
+| 1 | Visibility of system status | 4 | Live counts, pressed filter states, disclosures, and empty recovery are clear. |
+| 2 | Match system / real world | 3 | Fleet and identity still assume some portfolio context. |
+| 3 | User control and freedom | 3 | Reset and filter return work; state does not persist across refresh. |
+| 4 | Consistency and standards | 4 | Rows, rails, terminology, and responsive restacking are predictable. |
+| 5 | Error prevention | 4 | No-JS visitors keep all content without inert filter controls. |
+| 6 | Recognition rather than recall | 3 | Essential facts remain visible; evidence is intentionally disclosed. |
+| 7 | Flexibility and efficiency | 3 | Search and three filter dimensions provide useful accelerators. |
+| 8 | Aesthetic and minimalist design | 3 | The anatomy is compact, though 58 mobile rows remain physically long. |
+| 9 | Error recovery | 4 | No-results state names the problem and gives an immediate reset. |
+| 10 | Help and documentation | 3 | Retained-history and inventory boundaries are explained inline. |
+| **Total** | | **34/40** | **Good, close to excellent.** |
+
+## Design Specificity Verdict
+
+The result is strongly authored for SaaS Maker. Lifecycle bays, black mullions,
+the seeded tools rail, and the cobalt count pane preserve the workshop identity
+while compact specimen rows avoid generic cards or admin-table styling. The
+deterministic detector returned zero findings. The browser overlay was
+unavailable because the installed browser client version did not match the
+requested runtime; local Chrome DevTools evidence was used separately for
+viewport and interaction verification.
+
+## Overall Impression
+
+The distillation succeeds. Name, purpose, shape, prominent tools, and location
+stay glanceable; links, deployment evidence, and retained history move behind a
+native disclosure. The page is still intrinsically long because the inventory
+contains 58 identities, but it no longer repeats four full-height panes per
+project.
+
+## What's Working
+
+- Progressive disclosure removes most visual repetition without hiding any
+  identity from HTML, search engines, or no-JS visitors.
+- Column labels appear once per lifecycle group on wide screens and return only
+  when responsive stacking needs local context.
+- Native details and summary controls retain keyboard behavior and avoid custom
+  state machinery.
+
+## Priority Issues
+
+1. **[P1, resolved] Invisible mobile filter return:** the visually hidden
+   fixed button remained focusable. Visibility now uses the `hidden` attribute,
+   removing it from the tab order until it is shown.
+2. **[P2, resolved] Hidden-field search matches:** deployment providers could
+   match a row without appearing in its collapsed anatomy. Search now uses only
+   the advertised visible fields.
+3. **[P2, resolved] Verbose disclosure names:** summaries exposed roughly 200
+   characters to assistive technology. Each now has a concise project-specific
+   evidence label.
+4. **[P2] Deferred canonical action:** the visible domain is evidence rather
+   than a link; visitors open the evidence disclosure before following it.
+5. **[P2] Mobile length:** even compact rows remain long across 58 identities,
+   and the first row follows the full introduction and filter set.
+
+## Persona Red Flags
+
+- Jordan may still need a moment to interpret Fleet and project identities.
+- Sam now receives concise native disclosure names and cannot tab to an
+  invisible filter-return control.
+- Casey benefits from the fixed return-to-filters action, but the 58-item mobile
+  inventory remains a long browse.
+
+## Minor Observations
+
+- Reset remains available at the default state.
+- Catalog kind is internal language inside the evidence panel.
+- The machine-readable directory is intentionally separated into the closing
+  provenance pane.
+
+## Questions to Consider
+
+- Should the canonical domain eventually become a direct action in the compact
+  row?
+- Should filter state persist in the URL for repeat visits?
+- Could the mobile count pane keep the 58 moment in less vertical space?

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -25,6 +25,12 @@ Cockpit, CodeVetter, and App Health remain independent repositories.
 
 ## Timeline
 
+- **2026-08-22 — Complete directory distilled:** Replaced 58 repeated,
+  full-height anatomy panels with compact specimen rows. Purpose, form,
+  platforms, prominent tools, and destination remain visible; public links,
+  deployment evidence, and retained Git bounds use accessible native
+  disclosures. Wide layouts label columns once per lifecycle group, while
+  stacked layouts restore local labels for context.
 - **2026-08-22 — Complete Fleet directory published:** Expanded the public,
   privacy-filtered projection from the maintained subset to all 58 retained
   Fleet identities. The new `/projects` register separates current,
@@ -101,8 +107,8 @@ Cockpit, CodeVetter, and App Health remain independent repositories.
   runtime access, with deny-by-default field validation.
 - Searchable `/projects` register grouped by current, supporting/parked, and
   past work, with form-family and platform filters, mobile filter return,
-  deployment context, public links, technology labels, and retained Git-history
-  bounds.
+  compact project anatomy, prominent tools, and native disclosures for public
+  links, deployment context, and retained Git-history bounds.
 - Matching human, JSON, Markdown, sitemap, and agent-readable directory
   surfaces.
 - Feedback submission for bug, feature, and general feedback.

--- a/apps/showcase/.impeccable/surfaces/apps-showcase-src-pages-projects-astro.md
+++ b/apps/showcase/.impeccable/surfaces/apps-showcase-src-pages-projects-astro.md
@@ -14,5 +14,5 @@ related_targets: ["apps/showcase/src/pages/projects.json.ts"]
 - Content boundary: all 58 canonical identities from the privacy-safe Site Health projection; no private repositories, local paths, priorities, controls, health metrics, or operational notes.
 - Direction: extend the established workshop wall as lifecycle bays crossed by platform, technology, deployment, and history rails.
 - Memorable moment: the cobalt 58-identity pane gives way immediately to a filterable, server-rendered register.
-- Interaction: search plus group, form, and platform filters; all content remains present without JavaScript.
+- Interaction: search plus group, form, and platform filters; compact specimen rows keep the essential facts visible and use native disclosures for deployment evidence, links, and history. All content remains present without JavaScript.
 - Provenance: Git dates are explicitly first/latest retained commits, not launch or retirement claims.

--- a/apps/showcase/src/pages/projects.astro
+++ b/apps/showcase/src/pages/projects.astro
@@ -34,10 +34,8 @@ const searchableText = (project: DirectoryProject) =>
     project.name,
     project.description,
     project.form,
-    project.kind,
     ...project.platforms,
     ...project.technologies,
-    ...project.deploymentProviders,
     ...project.domains,
   ]
     .join(' ')
@@ -140,9 +138,17 @@ const pastCount = DIRECTORY_GROUPS.find((group) => group.id === 'past')?.project
               <p>{group.description}</p>
             </header>
 
+            <div class="directory-column-guide" aria-hidden="true">
+              <span>Project</span>
+              <span>Shape</span>
+              <span>Prominent tools</span>
+              <span>Where</span>
+              <span>Evidence</span>
+            </div>
+
             <div class="directory-rows">
               {group.projects.map((project) => (
-                <article
+                <details
                   class="directory-row"
                   data-directory-row
                   data-group={project.group}
@@ -150,84 +156,103 @@ const pastCount = DIRECTORY_GROUPS.find((group) => group.id === 'past')?.project
                   data-platforms={project.platforms.join('|')}
                   data-search={searchableText(project)}
                 >
-                  <div class="directory-identity">
-                    <div class="directory-row-heading">
-                      <h3>{project.name}</h3>
-                      <span>{project.kind}</span>
-                    </div>
-                    <p>{project.description}</p>
-                    <div class="directory-links" aria-label={`${project.name} public links`}>
-                      {project.domains.map((domain, index) => (
-                        <a
-                          class:list={{ 'directory-link--primary': index === 0 }}
-                          href={`https://${domain}`}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                        >
-                          {domain} <span aria-hidden="true">↗</span>
-                        </a>
-                      ))}
-                      {project.repositoryUrl && (
-                        <a href={project.repositoryUrl} target="_blank" rel="noopener noreferrer">
-                          Source <span aria-hidden="true">↗</span>
-                        </a>
-                      )}
-                      {project.changelogUrl && (
-                        <a href={project.changelogUrl} target="_blank" rel="noopener noreferrer">
-                          Changelog <span aria-hidden="true">↗</span>
-                        </a>
-                      )}
-                      {project.roadmapUrl && (
-                        <a href={project.roadmapUrl} target="_blank" rel="noopener noreferrer">
-                          Issues <span aria-hidden="true">↗</span>
-                        </a>
-                      )}
-                      {project.domains.length === 0 && !project.repositoryUrl && (
-                        <span>No public destination</span>
-                      )}
-                    </div>
-                  </div>
+                  <summary class="directory-summary" aria-label={`Open evidence for ${project.name}`}>
+                    <h3 class="directory-identity">
+                      <span class="directory-row-heading">
+                        <span class="directory-project-name">{project.name}</span>
+                      </span>
+                      <span class="directory-identity-description">{project.description}</span>
+                    </h3>
 
-                  <dl class="directory-anatomy">
-                    <div>
-                      <dt>Form</dt>
-                      <dd>{project.form}</dd>
-                    </div>
-                    <div>
-                      <dt>Platforms</dt>
-                      <dd>{project.platforms.join(' · ')}</dd>
-                    </div>
-                    <div>
-                      <dt>Deployment</dt>
-                      <dd>
-                        <span class:list={['deployment-state', { 'deployment-state--live': project.deployed }]}>
-                          {deploymentLabel(project)}
-                        </span>
-                        {project.deploymentProviders.length > 0 && (
-                          <small>{project.deploymentProviders.join(' · ')}</small>
+                    <span class="directory-glance">
+                      <span>Shape</span>
+                      <strong>{project.form}</strong>
+                      <small>{project.platforms.join(' · ')}</small>
+                    </span>
+
+                    <span class="directory-glance directory-glance--tools">
+                      <span>Prominent tools</span>
+                      <strong>{project.technologies.join(' · ')}</strong>
+                    </span>
+
+                    <span class="directory-glance directory-glance--where">
+                      <span>Where</span>
+                      <strong>{project.domains[0] ?? deploymentLabel(project)}</strong>
+                      {project.domains[0] && <small>{deploymentLabel(project)}</small>}
+                    </span>
+
+                    <span class="directory-disclosure" aria-hidden="true">
+                      <span>Evidence</span>
+                      <svg viewBox="0 0 16 16" focusable="false">
+                        <path d="M3.5 6 8 10.5 12.5 6" />
+                      </svg>
+                    </span>
+                  </summary>
+
+                  <div class="directory-detail">
+                    <div class="directory-links-panel">
+                      <span>Public destinations</span>
+                      <div class="directory-links" aria-label={`${project.name} public links`}>
+                        {project.domains.map((domain, index) => (
+                          <a
+                            class:list={{ 'directory-link--primary': index === 0 }}
+                            href={`https://${domain}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            {domain} <span aria-hidden="true">↗</span>
+                          </a>
+                        ))}
+                        {project.repositoryUrl && (
+                          <a href={project.repositoryUrl} target="_blank" rel="noopener noreferrer">
+                            Source <span aria-hidden="true">↗</span>
+                          </a>
                         )}
-                      </dd>
+                        {project.changelogUrl && (
+                          <a href={project.changelogUrl} target="_blank" rel="noopener noreferrer">
+                            Changelog <span aria-hidden="true">↗</span>
+                          </a>
+                        )}
+                        {project.roadmapUrl && (
+                          <a href={project.roadmapUrl} target="_blank" rel="noopener noreferrer">
+                            Issues <span aria-hidden="true">↗</span>
+                          </a>
+                        )}
+                        {project.domains.length === 0 && !project.repositoryUrl && (
+                          <span>No public destination</span>
+                        )}
+                      </div>
                     </div>
-                  </dl>
 
-                  <div class="directory-stack">
-                    <span>Prominent tools</span>
-                    <ul>
-                      {project.technologies.map((technology) => <li>{technology}</li>)}
-                    </ul>
+                    <dl class="directory-evidence">
+                      <div>
+                        <dt>Catalog kind</dt>
+                        <dd>{project.kind}</dd>
+                      </div>
+                      <div>
+                        <dt>Deployment</dt>
+                        <dd>
+                          <span
+                            class:list={['deployment-state', { 'deployment-state--live': project.deployed }]}
+                          >
+                            {deploymentLabel(project)}
+                          </span>
+                          {project.deploymentProviders.length > 0 && (
+                            <small>{project.deploymentProviders.join(' · ')}</small>
+                          )}
+                        </dd>
+                      </div>
+                      <div>
+                        <dt>First retained commit</dt>
+                        <dd>{formatDate(project.firstCommitAt)}</dd>
+                      </div>
+                      <div>
+                        <dt>Latest retained commit</dt>
+                        <dd>{formatDate(project.latestCommitAt)}</dd>
+                      </div>
+                    </dl>
                   </div>
-
-                  <dl class="directory-history">
-                    <div>
-                      <dt>First retained commit</dt>
-                      <dd>{formatDate(project.firstCommitAt)}</dd>
-                    </div>
-                    <div>
-                      <dt>Latest retained commit</dt>
-                      <dd>{formatDate(project.latestCommitAt)}</dd>
-                    </div>
-                  </dl>
-                </article>
+                </details>
               ))}
             </div>
           </section>
@@ -285,10 +310,7 @@ const pastCount = DIRECTORY_GROUPS.find((group) => group.id === 'past')?.project
 
   if (controls && filterReturn) {
     const updateFilterReturnVisibility = () => {
-      filterReturn.classList.toggle(
-        'directory-filter-return--hidden',
-        controls.getBoundingClientRect().bottom > 0
-      );
+      filterReturn.hidden = controls.getBoundingClientRect().bottom > 0;
     };
     updateFilterReturnVisibility();
     window.addEventListener('scroll', updateFilterReturnVisibility, { passive: true });
@@ -391,7 +413,7 @@ const pastCount = DIRECTORY_GROUPS.find((group) => group.id === 'past')?.project
 
   .directory-intro > *,
   .directory-controls > *,
-  .directory-row > * {
+  .directory-summary > * {
     min-width: 0;
   }
 
@@ -563,10 +585,10 @@ const pastCount = DIRECTORY_GROUPS.find((group) => group.id === 'past')?.project
 
   .directory-section-head {
     display: grid;
-    grid-template-columns: minmax(15rem, 0.65fr) minmax(18rem, 1fr);
+    grid-template-columns: minmax(15rem, 0.55fr) minmax(18rem, 1fr);
     gap: 2rem;
-    align-items: end;
-    padding: clamp(2.25rem, 4vw, 3.5rem) clamp(1.25rem, 4vw, 3.5rem);
+    align-items: center;
+    padding: clamp(1.4rem, 2.5vw, 2rem) clamp(1.25rem, 3vw, 2.5rem);
     background: var(--workshop-seeded);
   }
 
@@ -578,7 +600,7 @@ const pastCount = DIRECTORY_GROUPS.find((group) => group.id === 'past')?.project
   }
 
   .directory-section-head h2 {
-    font-size: clamp(2.5rem, 5vw, 5rem);
+    font-size: clamp(2rem, 3.5vw, 3.5rem);
     font-weight: 600;
     letter-spacing: -0.04em;
     line-height: 0.95;
@@ -596,19 +618,64 @@ const pastCount = DIRECTORY_GROUPS.find((group) => group.id === 'past')?.project
     background: rgba(20, 21, 17, 0.32);
   }
 
-  .directory-row {
+  .directory-column-guide {
     display: grid;
-    grid-template-columns: minmax(19rem, 1.25fr) minmax(14rem, 0.72fr) minmax(12rem, 0.58fr) minmax(10rem, 0.46fr);
-    min-height: 15rem;
+    grid-template-columns: minmax(22rem, 1.35fr) minmax(9rem, 0.45fr) minmax(15rem, 0.72fr) minmax(12rem, 0.6fr) 5.5rem;
+    background: var(--workshop-steel);
+    color: #c9c4b8;
+    font-size: 0.66rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .directory-column-guide span {
+    padding: 0.65rem clamp(1rem, 1.6vw, 1.5rem);
+  }
+
+  .directory-column-guide span + span {
+    border-left: 1px solid #3b3c38;
+  }
+
+  .directory-row {
     background: var(--directory-pane);
   }
 
-  .directory-row > * {
-    padding: clamp(1.25rem, 2.5vw, 2rem);
+  .directory-summary {
+    display: grid;
+    grid-template-columns: minmax(22rem, 1.35fr) minmax(9rem, 0.45fr) minmax(15rem, 0.72fr) minmax(12rem, 0.6fr) 5.5rem;
+    align-items: stretch;
+    min-height: 8.25rem;
+    cursor: pointer;
+    list-style: none;
+    transition: background-color 140ms ease;
   }
 
-  .directory-row > * + * {
+  .directory-summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .directory-summary:hover {
+    background: #fffdf7;
+  }
+
+  .directory-row[open] .directory-summary {
+    background: #fffdf7;
+  }
+
+  .directory-summary > * {
+    padding: clamp(1rem, 1.6vw, 1.5rem);
+  }
+
+  .directory-summary > * + * {
     border-left: 1px solid var(--directory-line);
+  }
+
+  .directory-identity {
+    display: grid;
+    align-content: center;
+    font: inherit;
+    font-weight: 400;
   }
 
   .directory-row-heading {
@@ -618,31 +685,103 @@ const pastCount = DIRECTORY_GROUPS.find((group) => group.id === 'past')?.project
     gap: 1rem;
   }
 
-  .directory-row-heading h3 {
-    font-size: clamp(1.55rem, 2.4vw, 2.25rem);
+  .directory-project-name {
+    font-size: clamp(1.35rem, 1.8vw, 1.85rem);
     font-weight: 600;
     letter-spacing: -0.035em;
     line-height: 1;
   }
 
-  .directory-row-heading span {
-    color: var(--workshop-muted);
-    font-size: 0.7rem;
+  .directory-identity-description {
+    display: block;
+    max-width: 58ch;
+    margin-top: 0.65rem;
+    color: #5f5d55;
+    font-size: 0.92rem;
+  }
+
+  .directory-glance {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 0.3rem;
+  }
+
+  .directory-glance--tools {
+    background: var(--workshop-seeded);
+  }
+
+  .directory-glance > span,
+  .directory-links-panel > span,
+  .directory-evidence dt {
+    color: var(--directory-quiet);
+    font-size: 0.68rem;
     font-weight: 700;
+    letter-spacing: 0.08em;
     text-transform: uppercase;
   }
 
-  .directory-identity > p {
-    max-width: 58ch;
-    margin-top: 1rem;
-    color: #5f5d55;
+  .directory-glance strong {
+    overflow-wrap: anywhere;
+    font-size: 0.86rem;
+    font-weight: 650;
+    line-height: 1.35;
+  }
+
+  .directory-glance small {
+    color: var(--directory-quiet);
+    font-size: 0.74rem;
+    line-height: 1.35;
+  }
+
+  .directory-disclosure {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35rem;
+    color: var(--directory-quiet);
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .directory-disclosure svg {
+    width: 1.1rem;
+    height: 1.1rem;
+    fill: none;
+    stroke: currentColor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-width: 1.5;
+    transition: rotate 140ms ease;
+  }
+
+  .directory-row[open] .directory-disclosure svg {
+    rotate: 180deg;
+  }
+
+  .directory-detail {
+    display: grid;
+    grid-template-columns: minmax(18rem, 0.85fr) minmax(28rem, 1.15fr);
+    border-top: 1px solid var(--directory-line);
+    background: #f5f0e6;
+  }
+
+  .directory-detail > * {
+    padding: clamp(1rem, 1.8vw, 1.5rem);
+  }
+
+  .directory-detail > * + * {
+    border-left: 1px solid var(--directory-line);
   }
 
   .directory-links {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.35rem 1rem;
-    margin-top: 1.5rem;
+    gap: 0.25rem 1rem;
+    margin-top: 0.65rem;
     font-size: 0.82rem;
     font-weight: 700;
   }
@@ -664,41 +803,30 @@ const pastCount = DIRECTORY_GROUPS.find((group) => group.id === 'past')?.project
     color: #747168;
   }
 
-  .directory-anatomy,
-  .directory-history {
+  .directory-evidence {
     display: grid;
-    align-content: start;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
     gap: 1.25rem;
+    font-variant-numeric: tabular-nums;
   }
 
-  .directory-anatomy div,
-  .directory-history div {
+  .directory-evidence div {
     display: grid;
+    align-content: start;
     gap: 0.3rem;
   }
 
-  .directory-anatomy dt,
-  .directory-history dt,
-  .directory-stack > span {
-    color: var(--directory-quiet);
-    font-size: 0.68rem;
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-  }
-
-  .directory-anatomy dd,
-  .directory-history dd {
+  .directory-evidence dd {
     margin: 0;
-    font-size: 0.9rem;
+    font-size: 0.86rem;
     font-weight: 600;
   }
 
-  .directory-anatomy small {
+  .directory-evidence small {
     display: block;
     margin-top: 0.35rem;
     color: var(--directory-quiet);
-    font-size: 0.76rem;
+    font-size: 0.74rem;
     font-weight: 500;
   }
 
@@ -718,31 +846,6 @@ const pastCount = DIRECTORY_GROUPS.find((group) => group.id === 'past')?.project
 
   .deployment-state--live::before {
     background: #1746a2;
-  }
-
-  .directory-stack {
-    background: var(--workshop-seeded);
-  }
-
-  .directory-stack ul {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.45rem;
-    margin-top: 0.75rem;
-    list-style: none;
-  }
-
-  .directory-stack li {
-    border: 1px solid rgba(20, 21, 17, 0.28);
-    border-radius: 999px;
-    padding: 0.35rem 0.65rem;
-    font-size: 0.75rem;
-    font-weight: 650;
-  }
-
-  .directory-history {
-    background: #f5f0e6;
-    font-variant-numeric: tabular-nums;
   }
 
   .directory-empty {
@@ -820,15 +923,22 @@ const pastCount = DIRECTORY_GROUPS.find((group) => group.id === 'past')?.project
   }
 
   @media (max-width: 72rem) {
-    .directory-row {
-      grid-template-columns: minmax(18rem, 1.2fr) minmax(13rem, 0.8fr) minmax(13rem, 0.7fr);
+    .directory-column-guide {
+      display: none;
     }
 
-    .directory-history {
-      grid-column: 1 / -1;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
+    .directory-summary {
+      grid-template-columns: minmax(18rem, 1.2fr) minmax(9rem, 0.55fr) minmax(13rem, 0.75fr) 4rem;
+    }
+
+    .directory-glance--where {
+      grid-column: 2 / 4;
       border-top: 1px solid var(--directory-line);
-      border-left: 0 !important;
+    }
+
+    .directory-disclosure {
+      grid-column: 4;
+      grid-row: 1 / 3;
     }
   }
 
@@ -839,9 +949,12 @@ const pastCount = DIRECTORY_GROUPS.find((group) => group.id === 'past')?.project
       grid-template-columns: minmax(0, 1fr);
     }
 
-    .directory-intro-copy,
-    .directory-count-pane {
+    .directory-intro-copy {
       min-height: 23rem;
+    }
+
+    .directory-count-pane {
+      min-height: 18rem;
     }
 
     .directory-controls {
@@ -869,30 +982,35 @@ const pastCount = DIRECTORY_GROUPS.find((group) => group.id === 'past')?.project
       transition: opacity 140ms ease, translate 140ms ease;
     }
 
-    .directory-filter-return--hidden {
-      pointer-events: none;
-      opacity: 0;
-      translate: 0 0.5rem;
-    }
-
-    .directory-row {
-      grid-template-columns: minmax(0, 1fr) minmax(12rem, 0.55fr);
+    .directory-summary {
+      grid-template-columns: minmax(0, 0.85fr) minmax(0, 1.25fr) minmax(0, 0.85fr) 3.75rem;
     }
 
     .directory-identity {
       grid-column: 1 / -1;
     }
 
-    .directory-anatomy {
+    .directory-glance {
       border-top: 1px solid var(--directory-line);
-      border-left: 0 !important;
     }
 
-    .directory-history {
+    .directory-glance--where {
       grid-column: auto;
+    }
+
+    .directory-disclosure {
+      grid-column: 4;
+      grid-row: 2;
+      border-top: 1px solid var(--directory-line);
+    }
+
+    .directory-detail {
       grid-template-columns: 1fr;
-      border-top: 0;
-      border-left: 1px solid var(--directory-line) !important;
+    }
+
+    .directory-detail > * + * {
+      border-top: 1px solid var(--directory-line);
+      border-left: 0;
     }
   }
 
@@ -901,9 +1019,13 @@ const pastCount = DIRECTORY_GROUPS.find((group) => group.id === 'past')?.project
       width: min(100% - 1rem, 92rem);
     }
 
-    .directory-intro-copy,
-    .directory-count-pane {
+    .directory-intro-copy {
       min-height: 21rem;
+      padding: 1.5rem;
+    }
+
+    .directory-count-pane {
+      min-height: 14rem;
       padding: 1.5rem;
     }
 
@@ -926,12 +1048,12 @@ const pastCount = DIRECTORY_GROUPS.find((group) => group.id === 'past')?.project
     }
 
     .directory-selects,
-    .directory-row,
-    .directory-history {
+    .directory-summary,
+    .directory-evidence {
       grid-template-columns: 1fr;
     }
 
-    .directory-row > * {
+    .directory-summary > * {
       grid-column: auto;
       border-top: 1px solid var(--directory-line);
       border-left: 0 !important;
@@ -939,6 +1061,24 @@ const pastCount = DIRECTORY_GROUPS.find((group) => group.id === 'past')?.project
 
     .directory-identity {
       border-top: 0;
+    }
+
+    .directory-glance {
+      display: grid;
+      grid-template-columns: minmax(7rem, 0.42fr) 1fr;
+      align-items: baseline;
+      gap: 0.25rem 1rem;
+    }
+
+    .directory-glance small {
+      grid-column: 2;
+    }
+
+    .directory-disclosure {
+      grid-row: auto;
+      flex-direction: row;
+      justify-content: space-between;
+      min-height: 3.25rem;
     }
 
     .directory-row-heading {
@@ -953,8 +1093,23 @@ const pastCount = DIRECTORY_GROUPS.find((group) => group.id === 'past')?.project
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .directory-filter-return {
+    .directory-filter-return,
+    .directory-summary,
+    .directory-disclosure svg {
       transition: none;
+    }
+  }
+
+  @media (min-width: 72.001rem) {
+    .directory-glance > span,
+    .directory-disclosure > span {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+      clip: rect(0 0 0 0);
+      clip-path: inset(50%);
+      white-space: nowrap;
     }
   }
 </style>

--- a/scripts/smoke-prod.mjs
+++ b/scripts/smoke-prod.mjs
@@ -38,7 +38,7 @@ const directoryChecks = [
       const res = await fetch(`${DIRECTORY}/projects`);
       if (res.status !== 200) throw new Error(`status ${res.status}`);
       const body = await res.text();
-      const rows = body.match(/<article class="directory-row" data-directory-row/g)?.length ?? 0;
+      const rows = body.match(/<details class="directory-row" data-directory-row/g)?.length ?? 0;
       if (rows !== 58) throw new Error(`expected 58 directory rows, got ${rows}`);
       if (!body.includes('First retained commit') || !body.includes('Latest retained commit')) {
         throw new Error('missing Git-history bounds');

--- a/tests/showcase/directory.test.ts
+++ b/tests/showcase/directory.test.ts
@@ -47,6 +47,8 @@ describe('complete public Fleet directory', () => {
     ]);
 
     expect(page).toMatch(/data-directory-row/);
+    expect(page).toMatch(/<details/);
+    expect(page).toMatch(/<summary class="directory-summary" aria-label=/);
     expect(page).toMatch(/Search name, purpose, stack, or domain/);
     expect(page).toMatch(/First retained commit/);
     expect(page).toMatch(/Latest retained commit/);


### PR DESCRIPTION
## What
- replace 58 repeated full-height anatomy panels with compact specimen rows
- keep purpose, shape, prominent tools, and location visible while moving links, deployment, and Git bounds into native evidence disclosures
- label columns once on wide layouts and restore local labels when rows stack
- remove hidden-field search matches and invisible mobile filter focus

## Verification
- `pnpm test -- tests/showcase/directory.test.ts` (31 passed)
- `FLEET_PUBLIC_PRODUCTS_PATH=/Users/sarthak/Desktop/fleet/site-health/apps/backend/config/projects.json pnpm catalog:check-public`
- `pnpm -F @saas-maker/landing-page typecheck`
- `pnpm build:showcase`
- design review: 34/40 critique, 16/20 audit, zero unresolved P0/P1
- browser: 58 rows and no horizontal overflow at 390, 768, or 1440 px

Closes #49