### PR TITLE
Fix the shared workshop frame and directory gutter

### DIFF
--- a/.fleet/design-review.json
+++ b/.fleet/design-review.json
@@ -2,7 +2,7 @@
   "$schema": "fleet.design-review.v1",
   "version": 1,
   "project": "saas-maker",
-  "target": "/projects directory distillation",
+  "target": "shared workshop frame and /projects alignment",
   "mode": "preserve",
   "register": "product",
   "context": {
@@ -14,33 +14,33 @@
     "probes": [],
     "selected": "existing-design",
     "approval": "not-required",
-    "before": "artifacts/design/directory-distill-before-1440.png"
+    "before": "artifacts/design/live-projects-1440.png"
   },
   "evidence": {
     "screenshots": [
       {
         "width": 390,
-        "path": "artifacts/design/after-390.png"
+        "path": "artifacts/design/after-projects-390.png"
       },
       {
         "width": 768,
-        "path": "artifacts/design/after-768.png"
+        "path": "artifacts/design/after-projects-768.png"
       },
       {
         "width": 1440,
-        "path": "artifacts/design/after-1440.png"
+        "path": "artifacts/design/after-projects-1440.png"
       }
     ],
     "projectCheck": {
-      "command": "pnpm test -- tests/showcase/directory.test.ts && pnpm -F @saas-maker/landing-page typecheck && pnpm build:showcase && git diff --check",
+      "command": "pnpm catalog:validate-public && pnpm check:docs && pnpm test && pnpm typecheck && pnpm build:widget && pnpm check:shared-packages && pnpm build:showcase && pnpm build:docs && pnpm build:cockpit && git diff --check",
       "status": "pass"
     },
     "critique": {
-      "score": 34,
+      "score": 36,
       "maximum": 40
     },
     "audit": {
-      "score": 16,
+      "score": 18,
       "maximum": 20
     },
     "unresolved": {
@@ -54,6 +54,6 @@
   },
   "ownerFeedback": {
     "decision": "delegated",
-    "note": "Owner requested an agent-led cleanup of the repeated directory anatomy while preserving all project facts."
+    "note": "Owner explicitly delegated correcting the public frame mismatch and unnecessary gutter while preserving the established landing-page direction."
   }
 }

--- a/apps/showcase/functions/_middleware.ts
+++ b/apps/showcase/functions/_middleware.ts
@@ -7,113 +7,126 @@
 // - Adds rate-limit headers to API responses.
 // - Serves /api/ai with rate-limit headers (static asset passthrough with headers).
 
-const SITE_URL = "https://sassmaker.com";
+const SITE_URL = 'https://sassmaker.com';
 const RATE_LIMIT = 120;
 const RATE_LIMIT_WINDOW = 60;
 
 const errorSchema = {
-  type: "object",
+  type: 'object',
   properties: {
     error: {
-      type: "object",
+      type: 'object',
       properties: {
-        code: { type: "string", description: "Machine-readable error code" },
-        message: { type: "string", description: "Human-readable error message" },
-        path: { type: "string", description: "Request path that caused the error" },
+        code: { type: 'string', description: 'Machine-readable error code' },
+        message: { type: 'string', description: 'Human-readable error message' },
+        path: { type: 'string', description: 'Request path that caused the error' },
       },
-      required: ["code", "message"],
+      required: ['code', 'message'],
     },
   },
-  required: ["error"],
+  required: ['error'],
 };
 
 const errorResponse = (description: string) => ({
   description,
-  content: { "application/json": { schema: errorSchema } },
+  content: { 'application/json': { schema: errorSchema } },
 });
 
 const OPENAPI_SPEC = {
-  openapi: "3.1.0",
+  openapi: '3.1.0',
   info: {
-    title: "SaaS Maker public agent surfaces",
-    version: "1.0.0",
+    title: 'SaaS Maker public agent surfaces',
+    version: '1.0.0',
     description:
-      "Read-only, unauthenticated endpoints that let AI agents discover and consume the SaaS Maker product directory, its markdown alternates, and machine-readable indexes.",
-    contact: { name: "SaaS Maker", url: SITE_URL },
+      'Read-only, unauthenticated endpoints that let AI agents discover and consume the SaaS Maker product directory, its markdown alternates, and machine-readable indexes.',
+    contact: { name: 'SaaS Maker', url: SITE_URL },
   },
   servers: [{ url: SITE_URL }],
-  tags: [{ name: "agent-surfaces", description: "Machine-readable public surfaces" }],
+  tags: [{ name: 'agent-surfaces', description: 'Machine-readable public surfaces' }],
   paths: {
-    "/": {
+    '/': {
       get: {
-        operationId: "getHome",
-        tags: ["agent-surfaces"],
-        summary: "Product directory",
-        description: "HTML page with a Markdown alternate (Accept: text/markdown).",
+        operationId: 'getHome',
+        tags: ['agent-surfaces'],
+        summary: 'Product directory',
+        description: 'HTML page with a Markdown alternate (Accept: text/markdown).',
         responses: {
-          "200": {
-            description: "Product directory HTML or markdown",
+          '200': {
+            description: 'Product directory HTML or markdown',
             content: {
-              "text/html": { schema: { type: "string" } },
-              "text/markdown": { schema: { type: "string" } },
+              'text/html': { schema: { type: 'string' } },
+              'text/markdown': { schema: { type: 'string' } },
             },
           },
         },
       },
     },
-    "/llms.txt": {
+    '/llms.txt': {
       get: {
-        operationId: "getLlmsTxt",
-        tags: ["agent-surfaces"],
-        summary: "llms.txt index",
-        description: "Markdown index of agent surfaces and product context for LLM consumption.",
+        operationId: 'getLlmsTxt',
+        tags: ['agent-surfaces'],
+        summary: 'llms.txt index',
+        description: 'Markdown index of agent surfaces and product context for LLM consumption.',
         responses: {
-          "200": {
-            description: "Markdown index",
-            content: { "text/plain": { schema: { type: "string", description: "Markdown-formatted agent index" } } },
+          '200': {
+            description: 'Markdown index',
+            content: {
+              'text/plain': {
+                schema: { type: 'string', description: 'Markdown-formatted agent index' },
+              },
+            },
           },
         },
       },
     },
-    "/sitemap.xml": {
+    '/sitemap.xml': {
       get: {
-        operationId: "getSitemap",
-        tags: ["agent-surfaces"],
-        summary: "Sitemap",
-        description: "XML sitemap listing all public pages.",
+        operationId: 'getSitemap',
+        tags: ['agent-surfaces'],
+        summary: 'Sitemap',
+        description: 'XML sitemap listing all public pages.',
         responses: {
-          "200": {
-            description: "XML sitemap",
-            content: { "application/xml": { schema: { type: "string", description: "XML sitemap document" } } },
+          '200': {
+            description: 'XML sitemap',
+            content: {
+              'application/xml': {
+                schema: { type: 'string', description: 'XML sitemap document' },
+              },
+            },
           },
         },
       },
     },
-    "/api/ai": {
+    '/api/ai': {
       get: {
-        operationId: "getAgentCatalog",
-        tags: ["agent-surfaces"],
-        summary: "Agent catalog",
-        description: "JSON inventory of public agent surfaces, the product catalog, and markdown alternates.",
+        operationId: 'getAgentCatalog',
+        tags: ['agent-surfaces'],
+        summary: 'Agent catalog',
+        description:
+          'JSON inventory of public agent surfaces, the product catalog, and markdown alternates.',
         responses: {
-          "200": {
-            description: "Agent catalog",
-            content: { "application/json": { schema: { type: "object" } } },
+          '200': {
+            description: 'Agent catalog',
+            content: { 'application/json': { schema: { type: 'object' } } },
           },
-          "429": errorResponse("Rate limit exceeded"),
+          '429': errorResponse('Rate limit exceeded'),
         },
       },
     },
-    "/openapi.json": {
+    '/openapi.json': {
       get: {
-        operationId: "getOpenApiSpec",
-        tags: ["agent-surfaces"],
-        summary: "OpenAPI specification",
-        description: "This document — the OpenAPI 3.1 specification for the public API.",
+        operationId: 'getOpenApiSpec',
+        tags: ['agent-surfaces'],
+        summary: 'OpenAPI specification',
+        description: 'This document — the OpenAPI 3.1 specification for the public API.',
         responses: {
-          "200": {
-            description: "OpenAPI 3.1 spec",
-            content: { "application/json": { schema: { type: "object", description: "OpenAPI 3.1 specification document" } } },
+          '200': {
+            description: 'OpenAPI 3.1 spec',
+            content: {
+              'application/json': {
+                schema: { type: 'object', description: 'OpenAPI 3.1 specification document' },
+              },
+            },
           },
         },
       },
@@ -122,22 +135,22 @@ const OPENAPI_SPEC = {
 };
 
 function wantsMarkdown(request: Request): boolean {
-  const accept = (request.headers.get("accept") || "").toLowerCase();
-  if (!accept.includes("text/markdown")) return false;
-  if (!accept.includes("text/html")) return true;
-  return accept.indexOf("text/markdown") < accept.indexOf("text/html");
+  const accept = (request.headers.get('accept') || '').toLowerCase();
+  if (!accept.includes('text/markdown')) return false;
+  if (!accept.includes('text/html')) return true;
+  return accept.indexOf('text/markdown') < accept.indexOf('text/html');
 }
 
 function normalizePath(pathname: string): string {
-  if (!pathname || pathname === "/") return "/";
-  const withSlash = pathname.startsWith("/") ? pathname : `/${pathname}`;
-  return withSlash.replace(/\/{2,}/g, "/").replace(/\/+$/, "") || "/";
+  if (!pathname || pathname === '/') return '/';
+  const withSlash = pathname.startsWith('/') ? pathname : `/${pathname}`;
+  return withSlash.replace(/\/{2,}/g, '/').replace(/\/+$/, '') || '/';
 }
 
 function addRateLimitHeaders(headers: Headers): void {
-  headers.set("RateLimit-Limit", String(RATE_LIMIT));
-  headers.set("RateLimit-Remaining", String(RATE_LIMIT - 1));
-  headers.set("RateLimit-Reset", String(RATE_LIMIT_WINDOW));
+  headers.set('RateLimit-Limit', String(RATE_LIMIT));
+  headers.set('RateLimit-Remaining', String(RATE_LIMIT - 1));
+  headers.set('RateLimit-Reset', String(RATE_LIMIT_WINDOW));
 }
 
 function markdown404(pathname: string, method: string): Response {
@@ -154,49 +167,46 @@ function markdown404(pathname: string, method: string): Response {
 - [Agent catalog (JSON)](${SITE_URL}/api/ai)
 - [OpenAPI spec](${SITE_URL}/openapi.json)
 `;
-  return new Response(method === "HEAD" ? null : body, {
+  return new Response(method === 'HEAD' ? null : body, {
     status: 404,
     headers: {
-      "content-type": "text/markdown; charset=utf-8",
-      "cache-control": "no-store",
-      "x-content-type-options": "nosniff",
+      'content-type': 'text/markdown; charset=utf-8',
+      'cache-control': 'no-store',
+      'x-content-type-options': 'nosniff',
     },
   });
 }
 
-function html404(request: Request): Response {
+function html404(_request: Request): Response {
   const body = `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>404 — Not Found</title></head><body><h1>404 — Not Found</h1><p>The page you requested does not exist.</p></body></html>`;
   return new Response(body, {
     status: 404,
     headers: {
-      "content-type": "text/html; charset=utf-8",
-      "cache-control": "no-store",
-      "vary": "Accept, Accept-Encoding",
+      'content-type': 'text/html; charset=utf-8',
+      'cache-control': 'no-store',
+      vary: 'Accept, Accept-Encoding',
     },
   });
 }
 
 function jsonError(status: number, code: string, message: string, path: string): Response {
-  return new Response(
-    JSON.stringify({ error: { code, message, path } }),
-    {
-      status,
-      headers: {
-        "content-type": "application/json; charset=utf-8",
-        "cache-control": "no-store",
-        "access-control-allow-origin": "*",
-        "RateLimit-Limit": String(RATE_LIMIT),
-        "RateLimit-Remaining": String(RATE_LIMIT - 1),
-        "RateLimit-Reset": String(RATE_LIMIT_WINDOW),
-      },
+  return new Response(JSON.stringify({ error: { code, message, path } }), {
+    status,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      'cache-control': 'no-store',
+      'access-control-allow-origin': '*',
+      'RateLimit-Limit': String(RATE_LIMIT),
+      'RateLimit-Remaining': String(RATE_LIMIT - 1),
+      'RateLimit-Reset': String(RATE_LIMIT_WINDOW),
     },
-  );
+  });
 }
 
 export const onRequest: PagesFunction = async (context) => {
   const { request } = context;
 
-  if (request.method !== "GET" && request.method !== "HEAD") {
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
     return context.next();
   }
 
@@ -204,24 +214,24 @@ export const onRequest: PagesFunction = async (context) => {
   const pathname = url.pathname;
 
   // /openapi.json — serve the spec directly.
-  if (pathname === "/openapi.json" || pathname === "/openapi.yaml") {
+  if (pathname === '/openapi.json' || pathname === '/openapi.yaml') {
     const headers = new Headers({
-      "content-type": "application/json; charset=utf-8",
-      "access-control-allow-origin": "*",
-      "cache-control": "public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800",
+      'content-type': 'application/json; charset=utf-8',
+      'access-control-allow-origin': '*',
+      'cache-control': 'public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800',
     });
     addRateLimitHeaders(headers);
     return new Response(JSON.stringify(OPENAPI_SPEC, null, 2), { headers });
   }
 
   // /api/ai — serve from static asset with rate-limit headers.
-  if (pathname === "/api/ai") {
+  if (pathname === '/api/ai') {
     const response = await context.next();
     if (response.status === 200) {
       const headers = new Headers(response.headers);
       addRateLimitHeaders(headers);
-      headers.set("access-control-allow-origin", "*");
-      return new Response(request.method === "HEAD" ? null : response.body, {
+      headers.set('access-control-allow-origin', '*');
+      return new Response(request.method === 'HEAD' ? null : response.body, {
         status: response.status,
         statusText: response.statusText,
         headers,
@@ -231,22 +241,22 @@ export const onRequest: PagesFunction = async (context) => {
   }
 
   // JSON errors for unknown /api/* paths.
-  if (pathname.startsWith("/api/")) {
-    return jsonError(404, "not_found", `Unknown API path: ${pathname}`, pathname);
+  if (pathname.startsWith('/api/')) {
+    return jsonError(404, 'not_found', `Unknown API path: ${pathname}`, pathname);
   }
 
   // Skip asset paths — let Pages handle directly.
   if (
-    pathname.startsWith("/_astro/") ||
-    pathname.startsWith("/_next/") ||
-    (pathname.includes(".") && !pathname.endsWith(".md"))
+    pathname.startsWith('/_astro/') ||
+    pathname.startsWith('/_next/') ||
+    (pathname.includes('.') && !pathname.endsWith('.md'))
   ) {
     return context.next();
   }
 
   // Accept: text/markdown negotiation for HTML pages that have a .md alternate.
-  if (wantsMarkdown(request) && !pathname.endsWith(".md")) {
-    const mdPath = pathname === "/" ? "/index.md" : `${pathname.replace(/\/$/, "")}.md`;
+  if (wantsMarkdown(request) && !pathname.endsWith('.md')) {
+    const mdPath = pathname === '/' ? '/index.md' : `${pathname.replace(/\/$/, '')}.md`;
     if (context.env.ASSETS) {
       const mdUrl = new URL(url);
       mdUrl.pathname = mdPath;
@@ -254,13 +264,13 @@ export const onRequest: PagesFunction = async (context) => {
       // Only serve as markdown if the asset actually exists (not a soft-404 HTML page).
       // Cloudflare Pages may serve index.html with 200 for unknown .md paths.
       if (mdResponse.status === 200) {
-        const mdContentType = mdResponse.headers.get("content-type") ?? "";
-        if (mdContentType.includes("text/markdown") && !mdContentType.includes("text/html")) {
+        const mdContentType = mdResponse.headers.get('content-type') ?? '';
+        if (mdContentType.includes('text/markdown') && !mdContentType.includes('text/html')) {
           const headers = new Headers(mdResponse.headers);
-          headers.set("content-type", "text/markdown; charset=utf-8");
-          headers.set("vary", "Accept, Accept-Encoding");
-          headers.set("x-content-type-options", "nosniff");
-          return new Response(request.method === "HEAD" ? null : mdResponse.body, {
+          headers.set('content-type', 'text/markdown; charset=utf-8');
+          headers.set('vary', 'Accept, Accept-Encoding');
+          headers.set('x-content-type-options', 'nosniff');
+          return new Response(request.method === 'HEAD' ? null : mdResponse.body, {
             status: 200,
             headers,
           });
@@ -270,10 +280,10 @@ export const onRequest: PagesFunction = async (context) => {
   }
 
   const response = await context.next();
-  const contentType = response.headers.get("content-type") ?? "";
+  const contentType = response.headers.get('content-type') ?? '';
 
   // Agent-friendly 404 with markdown recovery body.
-  if (response.status === 404 && !pathname.startsWith("/api/")) {
+  if (response.status === 404 && !pathname.startsWith('/api/')) {
     if (wantsMarkdown(request)) {
       return markdown404(pathname, request.method);
     }
@@ -286,9 +296,9 @@ export const onRequest: PagesFunction = async (context) => {
   // a different path, it's a soft-404.
   if (
     response.status === 200 &&
-    contentType.includes("text/html") &&
-    !pathname.startsWith("/api/") &&
-    pathname !== "/"
+    contentType.includes('text/html') &&
+    !pathname.startsWith('/api/') &&
+    pathname !== '/'
   ) {
     const body = await response.text();
     const pathCanonical = `href="https://sassmaker.com${pathname}"`;
@@ -301,8 +311,8 @@ export const onRequest: PagesFunction = async (context) => {
     }
     // Valid page — reconstruct with Vary header
     const headers = new Headers(response.headers);
-    const existingVary = headers.get("vary");
-    headers.set("vary", existingVary ? `${existingVary}, Accept` : "Accept, Accept-Encoding");
+    const existingVary = headers.get('vary');
+    headers.set('vary', existingVary ? `${existingVary}, Accept` : 'Accept, Accept-Encoding');
     return new Response(body, {
       status: response.status,
       statusText: response.statusText,
@@ -310,14 +320,14 @@ export const onRequest: PagesFunction = async (context) => {
     });
   }
 
-  if (response.status !== 200 || !contentType.includes("text/html")) {
+  if (response.status !== 200 || !contentType.includes('text/html')) {
     return response;
   }
 
   // Add Vary: Accept to HTML pages that might have markdown alternates.
   const headers = new Headers(response.headers);
-  const existingVary = headers.get("vary");
-  headers.set("vary", existingVary ? `${existingVary}, Accept` : "Accept, Accept-Encoding");
+  const existingVary = headers.get('vary');
+  headers.set('vary', existingVary ? `${existingVary}, Accept` : 'Accept, Accept-Encoding');
   return new Response(response.body, {
     status: response.status,
     statusText: response.statusText,

--- a/apps/showcase/package.json
+++ b/apps/showcase/package.json
@@ -21,6 +21,7 @@
     "typescript": "5.8.3"
   },
   "devDependencies": {
+    "@cloudflare/workers-types": "4.20260424.1",
     "wrangler": "4.85.0"
   }
 }

--- a/apps/showcase/src/pages/changelog.astro
+++ b/apps/showcase/src/pages/changelog.astro
@@ -60,7 +60,7 @@ import Layout from '../layouts/Layout.astro';
 
 <style>
   .changelog {
-    width: min(92rem, calc(100% - 2rem));
+    width: var(--workshop-frame-width);
     margin-inline: auto;
     border: 0.375rem solid var(--workshop-steel);
     border-top: 0;

--- a/apps/showcase/src/pages/p/[id].astro
+++ b/apps/showcase/src/pages/p/[id].astro
@@ -106,7 +106,7 @@ const productJsonLd = {
 
 <style>
   .project {
-    width: min(92rem, calc(100% - 2rem));
+    width: var(--workshop-frame-width);
     margin: 0 auto;
     padding-bottom: 2rem;
   }
@@ -349,10 +349,6 @@ const productJsonLd = {
   }
 
   @media (max-width: 760px) {
-    .project {
-      width: min(100% - 1rem, 92rem);
-    }
-
     .project-back {
       align-items: flex-start;
       flex-direction: column;

--- a/apps/showcase/src/pages/projects.astro
+++ b/apps/showcase/src/pages/projects.astro
@@ -398,9 +398,17 @@ const pastCount = DIRECTORY_GROUPS.find((group) => group.id === 'past')?.project
   }
 
   .directory-shell {
-    width: min(92rem, calc(100% - 2rem));
+    width: var(--workshop-frame-width);
     margin-inline: auto;
     padding-bottom: 1rem;
+  }
+
+  .directory-intro,
+  .directory-controls,
+  .directory-sections,
+  .directory-empty,
+  .directory-provenance {
+    border-inline: 0.375rem solid var(--workshop-steel);
   }
 
   .directory-intro {
@@ -1015,10 +1023,6 @@ const pastCount = DIRECTORY_GROUPS.find((group) => group.id === 'past')?.project
   }
 
   @media (max-width: 34rem) {
-    .directory-shell {
-      width: min(100% - 1rem, 92rem);
-    }
-
     .directory-intro-copy {
       min-height: 21rem;
       padding: 1.5rem;

--- a/apps/showcase/src/styles/globals.css
+++ b/apps/showcase/src/styles/globals.css
@@ -1142,6 +1142,7 @@ a {
 /* Homepage: the glazier's workshop */
 
 .workshop-world {
+  --workshop-frame-width: min(92rem, 100%);
   --workshop-ground: #eee8dc;
   --workshop-pane: rgba(250, 247, 239, 0.9);
   --workshop-seeded: #d9d2c4;
@@ -1152,7 +1153,7 @@ a {
   --workshop-amber: #c9820d;
   --workshop-oxblood: #7b211c;
   min-height: 100svh;
-  overflow: hidden;
+  overflow-x: clip;
   background: var(--workshop-ground);
   color: var(--workshop-ink);
 }
@@ -1164,7 +1165,7 @@ a {
 .studio-package,
 .studio-commission,
 .workshop-world .footer {
-  width: min(92rem, calc(100% - 2rem));
+  width: var(--workshop-frame-width);
   margin-inline: auto;
 }
 
@@ -1781,6 +1782,7 @@ a {
 
 .workshop-world .footer {
   margin-top: clamp(2rem, 5vw, 4rem);
+  padding-inline: 1rem;
   border-color: rgba(20, 21, 17, 0.35);
   color: var(--workshop-muted);
 }
@@ -2103,16 +2105,6 @@ a {
 }
 
 @media (max-width: 760px) {
-  .workshop-world .nav,
-  .studio-hero,
-  .token-world,
-  .studio-index,
-  .studio-package,
-  .studio-commission,
-  .workshop-world .footer {
-    width: min(100% - 1rem, 92rem);
-  }
-
   .workshop-world .nav {
     min-height: 4.25rem;
     padding-inline: 0.9rem;

--- a/apps/showcase/tsconfig.json
+++ b/apps/showcase/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "astro/tsconfigs/strict",
+  "compilerOptions": {
+    "types": ["@cloudflare/workers-types"]
+  },
   "include": [".astro/types.d.ts", "**/*"],
   "exclude": ["dist"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,6 +154,9 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
     devDependencies:
+      '@cloudflare/workers-types':
+        specifier: 4.20260424.1
+        version: 4.20260424.1
       wrangler:
         specifier: 4.85.0
         version: 4.85.0(@cloudflare/workers-types@4.20260424.1)


### PR DESCRIPTION
## Outcome
- replaces duplicated route gutters with one shared workshop frame
- restores the directory steel side rails so `/projects` matches the landing-page architecture
- preserves the 92rem ultra-wide cap and removes sub-cap outer gutters across home, directory, changelog, and product detail routes
- replaces vertical overflow containment so the directory filter rail can remain sticky
- repairs the pre-existing `PagesFunction` CI failure with the already-used Cloudflare types package as a dev-only dependency
- formats the same newly added middleware so the repository push guard passes again

## Verification
- 31 tests pass
- catalog validation and docs checks pass
- lint and full workspace typecheck pass
- showcase, feedback widget, shared packages, docs, and cockpit builds pass
- layout detector: 0 findings
- 390/768/1440 browser captures reviewed; no horizontal overflow
- design review: 36/40 critique, 18/20 audit, 0 unresolved P0/P1

Closes #49