### PR TITLE
Keep the homepage curated and /projects complete

### DIFF
--- a/.fleet/design-review.json
+++ b/.fleet/design-review.json
@@ -2,7 +2,7 @@
   "$schema": "fleet.design-review.v1",
   "version": 1,
   "project": "saas-maker",
-  "target": "shared workshop frame and /projects alignment",
+  "target": "homepage and complete-directory content boundary",
   "mode": "preserve",
   "register": "product",
   "context": {
@@ -14,33 +14,33 @@
     "probes": [],
     "selected": "existing-design",
     "approval": "not-required",
-    "before": "artifacts/design/live-projects-1440.png"
+    "before": "artifacts/design/home-boundary-before-1440.png"
   },
   "evidence": {
     "screenshots": [
       {
         "width": 390,
-        "path": "artifacts/design/after-projects-390.png"
+        "path": "artifacts/design/home-boundary-after-390.png"
       },
       {
         "width": 768,
-        "path": "artifacts/design/after-projects-768.png"
+        "path": "artifacts/design/home-boundary-after-768.png"
       },
       {
         "width": 1440,
-        "path": "artifacts/design/after-projects-1440.png"
+        "path": "artifacts/design/home-boundary-after-1440.png"
       }
     ],
     "projectCheck": {
-      "command": "pnpm catalog:validate-public && pnpm check:docs && pnpm test && pnpm typecheck && pnpm build:widget && pnpm check:shared-packages && pnpm build:showcase && pnpm build:docs && pnpm build:cockpit && git diff --check",
+      "command": "pnpm catalog:validate-public && FLEET_PUBLIC_PRODUCTS_PATH=/Users/sarthak/Desktop/fleet/site-health/apps/backend/config/projects.json pnpm catalog:check-public && pnpm check:docs && pnpm lint && pnpm test && pnpm typecheck && pnpm build:widget && pnpm check:shared-packages && pnpm build:showcase && pnpm build:docs && pnpm build:cockpit && git diff --check",
       "status": "pass"
     },
     "critique": {
-      "score": 36,
+      "score": 38,
       "maximum": 40
     },
     "audit": {
-      "score": 18,
+      "score": 19,
       "maximum": 20
     },
     "unresolved": {
@@ -49,11 +49,13 @@
     },
     "detector": {
       "posture": "advisory",
-      "findings": []
+      "findings": [
+        "single-font warning in Layout.astro is an intentional Schibsted Grotesk system documented in DESIGN.md"
+      ]
     }
   },
   "ownerFeedback": {
     "decision": "delegated",
-    "note": "Owner explicitly delegated correcting the public frame mismatch and unnecessary gutter while preserving the established landing-page direction."
+    "note": "Owner explicitly directed separating the curated homepage from the complete /projects register while preserving the established landing-page direction."
   }
 }

--- a/.impeccable/critique/2026-08-22T13-35-27Z__apps-showcase-src-pages-index-astro.md
+++ b/.impeccable/critique/2026-08-22T13-35-27Z__apps-showcase-src-pages-index-astro.md
@@ -1,0 +1,63 @@
+---
+target: homepage and /projects content boundary
+total_score: 27
+max_score: 28
+na_heuristics: 7,9,10
+p0_count: 0
+p1_count: 0
+timestamp: 2026-08-22T13-35-27Z
+slug: apps-showcase-src-pages-index-astro
+---
+Method: dual-agent (A: directory_design_review · B: directory_detector_review)
+
+## Design Health Score
+
+| # | Heuristic | Score | Key issue |
+|---|---|---:|---|
+| 1 | Visibility of system status | 4 | Current-state and verification language is visible. |
+| 2 | Match system / real world | 4 | Final directory copy is direct and visitor-facing. |
+| 3 | User control and freedom | 4 | Standard links and navigation provide direct exits. |
+| 4 | Consistency and standards | 4 | The workshop system remains coherent. |
+| 5 | Error prevention | 4 | No risky interactions; external destinations are marked. |
+| 6 | Recognition rather than recall | 4 | Four focused products and one complete-directory gateway are explicit. |
+| 7 | Flexibility and efficiency | n/a | No repeated workflow requires accelerators. |
+| 8 | Aesthetic and minimalist design | 3 | Token World remains intentionally expansive on mobile. |
+| 9 | Error recovery | n/a | No user-input or error workflow exists on this surface. |
+| 10 | Help and documentation | n/a | The landing experience needs no instructional layer. |
+| **Total** | | **27/28** | **Excellent** |
+
+## Design Specificity Verdict
+
+The glazier workshop, steel mullions, saturated product panes, and Token World make the homepage recognizably SaaS Maker. The final information architecture is now authored around two distinct jobs: the homepage curates four products and studio evidence; `/projects` owns complete enumeration.
+
+The deterministic scan returned one `single-font` warning in `Layout.astro`. This is a false positive because `DESIGN.md` explicitly defines Schibsted Grotesk as the single-family system and the page establishes hierarchy through scale, weight, proportion, and color.
+
+## Overall Impression
+
+The page is materially clearer and shorter. It presents a studio, not a second directory, and leaves one unambiguous route to all 58 projects.
+
+## What's Working
+
+- Exactly four focused product links appear on the homepage at all reviewed widths.
+- One directory gateway replaces the repeated maintained and past catalogs and the self-embedded project strip.
+- Latest learning is now a sibling section with its own heading, not semantically part of the directory invitation.
+
+## Priority Issues
+
+- **P3 — Token World remains long on narrow screens.** It is the page's intentional spectacle, but it delays later sections. If the mobile homepage needs further shortening, compact its stage and metrics without removing the proof surface.
+- **P3 — Overflow clipping can conceal future regressions.** Current browser measurements show no overflow at 390, 768, or 1440, but keep the viewport assertion in future visual checks.
+
+## Persona Red Flags
+
+- **Jordan:** No current red flag; the four products and one directory gateway now describe distinct choices.
+- **Riley:** No duplicate directory promise remains; the 58-row destination matches the gateway claim.
+- **Casey:** Token World is still a long mobile interlude before learning and package content.
+
+## Minor Observations
+
+- The homepage title now foregrounds the product studio rather than the directory.
+- The agent-readable homepage uses one H1, H2 section headings, and H3 entry headings.
+
+## Questions to Consider
+
+- Should Token World remain the homepage's deliberate spectacle, or become a shorter mobile proof panel in a later pass?

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -25,6 +25,12 @@ Cockpit, CodeVetter, and App Health remain independent repositories.
 
 ## Timeline
 
+- **2026-08-22 — Homepage and directory roles separated:** Reduced the public
+  homepage to four products in focus, one complete-directory gateway, the
+  current learning entry, and SaaS Maker's package surfaces. Removed the
+  repeated maintained/past catalogs and SaaS Maker's self-embedded portfolio
+  strip; `/projects` remains the sole complete 58-identity register, with the
+  same boundary reflected in the agent-readable homepage.
 - **2026-08-22 — Complete directory distilled:** Replaced 58 repeated,
   full-height anatomy panels with compact specimen rows. Purpose, form,
   platforms, prominent tools, and destination remain visible; public links,
@@ -103,6 +109,8 @@ Cockpit, CodeVetter, and App Health remain independent repositories.
 
 ## Features (shipped)
 
+- Curated public homepage with four products in focus and a single gateway to
+  the complete register, without duplicating the 58-project directory.
 - Deterministic 58-identity public projection consumed without private Fleet
   runtime access, with deny-by-default field validation.
 - Searchable `/projects` register grouped by current, supporting/parked, and

--- a/apps/showcase/DESIGN.md
+++ b/apps/showcase/DESIGN.md
@@ -37,8 +37,9 @@ long prose near 70 characters.
 Compose public product discovery as a wall elevation. Matte-black mullions
 separate unevenly proportioned panes; each pane carries one statement or
 destination. The homepage first viewport pairs one large studio pane with four
-featured product panes. Supporting products become disciplined specimen rows
-rather than cards.
+featured product panes. It does not repeat the catalog: one directory gateway
+points to `/projects`, where supporting and past work become disciplined
+specimen rows rather than cards.
 
 Product detail pages inherit the same workshop world: one clear identity pane
 shares a steel frame with a saturated canonical-product action, while public

--- a/apps/showcase/PRODUCT.md
+++ b/apps/showcase/PRODUCT.md
@@ -55,6 +55,7 @@ local machine state, schedules, private repositories, or operational telemetry.
 - Lead with products, not infrastructure.
 - Show evidence through canonical links rather than invented metrics.
 - Keep the spotlight concise while preserving the complete public catalog.
+- Curate on the homepage; enumerate only in the complete `/projects` register.
 - Let one visual identity carry the directory without merging product brands.
 - Make the same public facts legible to people, search engines, and AI agents.
 

--- a/apps/showcase/src/components/Fleet.astro
+++ b/apps/showcase/src/components/Fleet.astro
@@ -1,43 +1,23 @@
 ---
-import { ACTIVE_GROUPS, PAST_PROJECTS, PROJECT_COUNT } from '../data/projects';
-import { LEARNINGS } from '../data/learnings';
 import { DIRECTORY_COUNT } from '../data/directory';
+import { LEARNINGS } from '../data/learnings';
 
 const latestLearning = LEARNINGS[0];
 ---
-<section class="studio-index" id="products" aria-labelledby="catalog-title">
-  <header class="studio-index-head">
-    <p class="studio-kicker">The maintained catalog</p>
-    <h2 id="catalog-title">{PROJECT_COUNT} products.<br />One accountable maker.</h2>
-    <div class="studio-index-context">
-      <p>
-        Each product keeps its own domain, roadmap, changelog, and release
-        boundary. Nothing here is a concept render.
-      </p>
-      <a href="/projects">Browse the complete {DIRECTORY_COUNT}-project directory <span aria-hidden="true">→</span></a>
-    </div>
-  </header>
-
-  <div class="catalog-wall">
-    <div class="catalog-groups">
-      {ACTIVE_GROUPS.map((group) => (
-        <section class="catalog-group" aria-labelledby={`group-${group.id}`}>
-          <h3 id={`group-${group.id}`}>{group.label}</h3>
-          <ul>
-            {group.products.map((project) => (
-              <li>
-                <a href={project.href} class="catalog-row">
-                  <strong>{project.name}</strong>
-                  <span>{project.desc}</span>
-                  <span aria-hidden="true">→</span>
-                </a>
-              </li>
-            ))}
-          </ul>
-        </section>
-      ))}
-    </div>
-  </div>
+<div class="studio-index">
+  <section id="directory" aria-labelledby="directory-title">
+    <header class="studio-index-head">
+      <p class="studio-kicker">The complete directory</p>
+      <h2 id="directory-title">{DIRECTORY_COUNT} projects.<br />{' '}One directory.</h2>
+      <div class="studio-index-context">
+        <p>
+          Browse current, supporting, parked, and past work in one place, with
+          public links, deployment details, prominent tools, and retained Git dates.
+        </p>
+        <a href="/projects">Open the complete directory <span aria-hidden="true">→</span></a>
+      </div>
+    </header>
+  </section>
 
   <article class="learning-ledger" id="latest-learning" aria-labelledby="learning-title">
     <header class="learning-ledger-meta">
@@ -48,7 +28,7 @@ const latestLearning = LEARNINGS[0];
       </div>
     </header>
     <div class="learning-ledger-story">
-      <h3 id="learning-title">{latestLearning.title}</h3>
+      <h2 id="learning-title">{latestLearning.title}</h2>
       <p>{latestLearning.description}</p>
       <a href={latestLearning.href}>
         Read the learning
@@ -56,26 +36,4 @@ const latestLearning = LEARNINGS[0];
       </a>
     </div>
   </article>
-
-  <section class="archive-wall" id="past-projects" aria-labelledby="archive-title">
-    <header>
-      <p class="studio-kicker">Public repository history</p>
-      <h2 id="archive-title">Past work, kept legible.</h2>
-      <p>
-        {PAST_PROJECTS.length} public repositories preserved for source and
-        attribution, without pretending they are still maintained.
-      </p>
-    </header>
-    <ul>
-      {PAST_PROJECTS.map((project) => (
-        <li>
-          <a href={project.repositoryUrl} target="_blank" rel="noopener noreferrer">
-            <strong>{project.name}</strong>
-            <span>{project.desc}</span>
-            <span aria-hidden="true">↗</span>
-          </a>
-        </li>
-      ))}
-    </ul>
-  </section>
-</section>
+</div>

--- a/apps/showcase/src/components/Hero.astro
+++ b/apps/showcase/src/components/Hero.astro
@@ -1,5 +1,5 @@
 ---
-import { CORE, PROJECT_COUNT } from '../data/projects';
+import { CORE } from '../data/projects';
 
 const PANE_TONES = ['cobalt', 'seeded', 'amber', 'oxblood'];
 ---
@@ -11,13 +11,9 @@ const PANE_TONES = ['cobalt', 'seeded', 'amber', 'oxblood'];
     <p class="studio-kicker">Software as a specialized service</p>
     <h1 id="studio-title">A living index of things I build.</h1>
     <p class="studio-intro">
-      {PROJECT_COUNT} maintained products, with their real domains, roadmaps,
-      release history, and someone accountable for every one.
+      Four products in focus, with the complete portfolio accounted for in one
+      separate register.
     </p>
-    <a href="#products" class="studio-action">
-      Explore the work
-      <span aria-hidden="true">↓</span>
-    </a>
     <p class="studio-status">
       <span aria-hidden="true"></span>
       Built in public. Kept current.

--- a/apps/showcase/src/data/projects.ts
+++ b/apps/showcase/src/data/projects.ts
@@ -7,24 +7,6 @@ export interface CoreProject {
   href: string;
 }
 
-export interface ActiveProject {
-  name: string;
-  desc: string;
-  href: string;
-}
-
-export interface ActiveProjectGroup {
-  id: string;
-  label: string;
-  products: ActiveProject[];
-}
-
-export interface PastProject {
-  name: string;
-  desc: string;
-  repositoryUrl: string;
-}
-
 interface PublicProduct {
   id: string;
   name: string;
@@ -52,35 +34,14 @@ function toCore(product: PublicProduct): CoreProject {
   };
 }
 
-const spotlight = spotlightOrder
-  .map((id) => products.find((product) => product.id === id))
-  .filter((product): product is PublicProduct => Boolean(product?.spotlight));
+const spotlight = spotlightOrder.map((id) => {
+  const product = products.find((candidate) => candidate.id === id);
+
+  if (!product?.spotlight) {
+    throw new Error(`Homepage spotlight is missing the public catalog entry for ${id}`);
+  }
+
+  return product;
+});
 
 export const CORE = spotlight.map(toCore);
-
-const GROUP_LABELS: Record<string, string> = {
-  product: 'Products & research',
-  helper: 'Maker tools',
-  personal: 'Personal utilities',
-};
-
-export const ACTIVE_GROUPS: ActiveProjectGroup[] = ['product', 'helper', 'personal']
-  .map((category) => ({
-    id: category,
-    label: GROUP_LABELS[category],
-    products: products
-      .filter((product) => !product.spotlight && product.category === category)
-      .sort((left, right) => left.name.localeCompare(right.name))
-      .map((product) => ({
-        name: product.name,
-        desc: product.description,
-        href: `/p/${product.id}`,
-      })),
-  }))
-  .filter((group) => group.products.length > 0);
-export const PROJECT_COUNT = products.length;
-export const PAST_PROJECTS: PastProject[] = publicCatalog.pastProjects.map((project) => ({
-  name: project.name,
-  desc: project.description,
-  repositoryUrl: project.repositoryUrl,
-}));

--- a/apps/showcase/src/data/publicRoutes.ts
+++ b/apps/showcase/src/data/publicRoutes.ts
@@ -2,6 +2,7 @@ import publicCatalog from '../../../../catalog/generated/public.json';
 import tokenWorld from './tokenWorld.json';
 import { CHANGELOG } from './changelog';
 import { LEARNINGS } from './learnings';
+import { CORE } from './projects';
 import { PAGED_PRODUCTS, type RegistryProduct } from './registry';
 
 export type PublicRoute = {
@@ -49,34 +50,13 @@ function productMarkdown(product: RegistryProduct): string {
 }
 
 function homeMarkdown(): string {
-  const products = publicCatalog.products
-    .filter((product) => product.id !== 'saas-maker')
-    .flatMap((product) => {
-      const links = product as typeof product & {
-        changelogUrl?: string;
-        roadmapUrl?: string;
-        repositoryUrl?: string;
-      };
-      const lines = [
-        `## ${product.name}`,
-        '',
-        product.description,
-        '',
-        `- Product: ${product.url}`,
-      ];
-      if (links.changelogUrl) lines.push(`- Changelog: ${links.changelogUrl}`);
-      if (links.roadmapUrl) lines.push(`- Roadmap: ${links.roadmapUrl}`);
-      if (links.repositoryUrl) lines.push(`- Source: ${links.repositoryUrl}`);
-      lines.push('');
-      return lines;
-    });
-  const pastProjects = publicCatalog.pastProjects.flatMap((project) => [
-    `## ${project.name}`,
+  const latestLearning = LEARNINGS[0];
+  const featuredProducts = CORE.flatMap((project) => [
+    `### ${project.name}`,
     '',
-    project.description,
+    project.desc,
     '',
-    `- Source: ${project.repositoryUrl}`,
-    '- Lifecycle: past project',
+    `- SaaS Maker profile: ${SITE_URL}${project.href}`,
     '',
   ]);
 
@@ -85,7 +65,7 @@ function homeMarkdown(): string {
     '',
     'Software as a specialized service: a living studio of focused products, generated from Fleet’s privacy-checked public projection.',
     '',
-    '# Tokens Spent for the World',
+    '## Tokens Spent for the World',
     '',
     `${tokenWorld.lifetimeTokens.toLocaleString('en-US')} verified model tokens across ${tokenWorld.projectsContributing} contributing project as of ${tokenWorld.snapshotDate}.`,
     '',
@@ -95,22 +75,32 @@ function homeMarkdown(): string {
     `- Projects contributing: ${tokenWorld.projectsContributing}`,
     `- Coverage: ${tokenWorld.coverage}`,
     '',
-    '# Learnings',
+    '## Products in focus',
     '',
-    ...LEARNINGS.flatMap((learning) => [
-      `## ${learning.title}`,
-      '',
-      learning.description,
-      '',
-      `- Article: ${SITE_URL}${learning.href}`,
-      `- Published: ${learning.publishedAt}`,
-      `- Author: ${learning.author}`,
-      '',
-    ]),
-    ...products,
-    '# Past projects',
+    ...featuredProducts,
+    '## Complete directory',
     '',
-    ...pastProjects,
+    `Current, supporting, parked, and past work is enumerated once at ${SITE_URL}/projects.`,
+    '',
+    `- Human directory: ${SITE_URL}/projects`,
+    `- Agent-readable directory: ${SITE_URL}/projects.md`,
+    `- JSON directory: ${SITE_URL}/projects.json`,
+    '',
+    '## Latest learning',
+    '',
+    `### ${latestLearning.title}`,
+    '',
+    latestLearning.description,
+    '',
+    `- Article: ${SITE_URL}${latestLearning.href}`,
+    `- Published: ${latestLearning.publishedAt}`,
+    `- Author: ${latestLearning.author}`,
+    '',
+    '## Public package',
+    '',
+    '@saas-maker/feedback is a React widget for bugs, feature requests, screenshots, and page-specific feedback.',
+    '',
+    `- Package overview: ${SITE_URL}/#package`,
   ].join('\n');
 }
 

--- a/apps/showcase/src/layouts/Layout.astro
+++ b/apps/showcase/src/layouts/Layout.astro
@@ -90,11 +90,5 @@ const OG_IMAGE = `${SITE_URL}/og-image.svg`;
   <body>
     <a class="skip-link" href="#main-content">Skip to content</a>
     <slot />
-    <script
-      is:inline
-      src="https://sassmaker.com/project-strip.js"
-      data-project="saas-maker"
-      defer
-    ></script>
   </body>
 </html>

--- a/apps/showcase/src/pages/index.astro
+++ b/apps/showcase/src/pages/index.astro
@@ -11,12 +11,15 @@ import Footer from '../components/Footer.astro';
 // Public product directory plus the one published SaaS Maker package.
 ---
 
-<Layout>
+<Layout
+  title="SaaS Maker — a public product studio"
+  description="A public studio for focused software, current learning, and reusable product packages by Sarthak Agrawal."
+>
   <!--
   THESIS: A maintained portfolio should feel like a workshop wall, not a startup card grid.
   OWN-WORLD: Limestone daylight, matte-black steel mullions, clear and seeded glass, with cobalt, amber, and oxblood panes.
-  STORY: Meet the maker, see four serious products immediately, inspect the full maintained catalog, then read or propose a build.
-  FIRST VIEWPORT: One large clear hero bay shares a full-height wall with four saturated product panes and a visible explore action.
+  STORY: Meet the maker, see four serious products immediately, inspect one studio measure, then choose the complete directory, latest learning, package, or a serious build.
+  FIRST VIEWPORT: One large clear hero bay shares a full-height wall with four saturated product panes.
   FORM: Monumental glass-wall elevation; selected probe A, delegated by the owner; direction seed 38815b6a.
   -->
   <div class="workshop-world">

--- a/apps/showcase/src/styles/globals.css
+++ b/apps/showcase/src/styles/globals.css
@@ -1261,30 +1261,6 @@ a {
   font-size: clamp(1.05rem, 1.5vw, 1.3rem);
 }
 
-.studio-action {
-  width: fit-content;
-  min-height: 3.25rem;
-  display: inline-flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 2.5rem;
-  margin-top: 2rem;
-  padding: 0 1rem 0 1.25rem;
-  border: 1px solid var(--workshop-steel);
-  background: var(--workshop-steel);
-  color: #fff;
-  font-weight: 700;
-  transition:
-    background 180ms ease,
-    color 180ms ease;
-}
-
-.studio-action:hover,
-.studio-action:focus-visible {
-  background: var(--workshop-cobalt);
-  color: #fff;
-}
-
 .studio-status {
   display: flex;
   align-items: center;
@@ -1446,80 +1422,11 @@ a {
   font-weight: 700;
 }
 
-.catalog-wall {
-  padding: 0.375rem;
-  background: var(--workshop-steel);
-}
-
-.catalog-groups {
-  min-width: 0;
-  background: #f8f4ea;
-}
-
-.catalog-group + .catalog-group {
-  border-top: 0.375rem solid var(--workshop-steel);
-}
-
-.catalog-group h3 {
-  padding: 1rem 1.25rem;
-  border-bottom: 1px solid rgba(20, 21, 17, 0.22);
-  color: var(--workshop-muted);
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-}
-
-.catalog-group ul,
-.archive-wall ul {
-  list-style: none;
-}
-
-.catalog-group li + li {
-  border-top: 1px solid rgba(20, 21, 17, 0.18);
-}
-
-.catalog-row {
-  min-height: 6.4rem;
-  display: grid;
-  grid-template-columns: minmax(9rem, 0.38fr) minmax(0, 1fr) auto;
-  gap: 1.5rem;
-  align-items: center;
-  padding: 1.15rem 1.25rem;
-  transition:
-    background 180ms ease,
-    color 180ms ease;
-}
-
-.catalog-row strong {
-  font-size: 1.05rem;
-  font-weight: 700;
-}
-
-.catalog-row > span:nth-child(2) {
-  color: var(--workshop-muted);
-}
-
-.catalog-row > span:last-child {
-  font-size: 1.15rem;
-}
-
-.catalog-row:hover,
-.catalog-row:focus-visible {
-  background: var(--workshop-amber);
-  color: var(--workshop-ink);
-}
-
-.catalog-row:hover > span:nth-child(2),
-.catalog-row:focus-visible > span:nth-child(2) {
-  color: var(--workshop-ink);
-}
-
 .learning-ledger {
   display: grid;
   grid-template-columns: minmax(18rem, 0.58fr) minmax(0, 1.42fr);
   gap: 0.375rem;
-  margin-top: clamp(5rem, 9vw, 8rem);
+  margin-top: 0;
   padding: 0.375rem;
   background: var(--workshop-steel);
 }
@@ -1556,7 +1463,7 @@ a {
   color: #fff;
 }
 
-.learning-ledger-story h3 {
+.learning-ledger-story h2 {
   max-width: 16ch;
   font-size: clamp(2.8rem, 5.8vw, 6rem);
   font-weight: 600;
@@ -1582,84 +1489,6 @@ a {
   padding-top: 1rem;
   border-top: 1px solid rgba(255, 255, 255, 0.46);
   font-weight: 700;
-}
-
-.archive-wall {
-  display: grid;
-  grid-template-columns: minmax(20rem, 0.7fr) minmax(0, 1.3fr);
-  margin-top: clamp(6rem, 10vw, 9rem);
-  border: 0.375rem solid var(--workshop-steel);
-  background: var(--workshop-steel);
-}
-
-.archive-wall > header {
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-  padding: clamp(2rem, 5vw, 4.5rem);
-  background:
-    rgba(239, 233, 221, 0.82)
-    url('/images/glazier-atelier-hero.webp') left center / cover no-repeat;
-  background-blend-mode: screen;
-  color: var(--workshop-ink);
-}
-
-.archive-wall h2 {
-  max-width: 10ch;
-  margin-top: 1.25rem;
-  font-size: clamp(2.5rem, 4.5vw, 4.4rem);
-  font-weight: 600;
-  letter-spacing: -0.035em;
-  line-height: 0.98;
-}
-
-.archive-wall header > p:last-child {
-  max-width: 40ch;
-  margin-top: 1.5rem;
-  color: var(--workshop-muted);
-}
-
-.archive-wall ul {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.375rem;
-  background: var(--workshop-steel);
-}
-
-.archive-wall li {
-  min-width: 0;
-  background: var(--workshop-seeded);
-}
-
-.archive-wall a {
-  min-height: 7.5rem;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 0.75rem 1rem;
-  align-content: center;
-  padding: 1.5rem;
-  transition: background 180ms ease;
-}
-
-.archive-wall a strong {
-  font-size: 1.2rem;
-}
-
-.archive-wall a > span:nth-child(2) {
-  grid-column: 1;
-  color: var(--workshop-muted);
-  font-size: 0.92rem;
-}
-
-.archive-wall a > span:last-child {
-  grid-column: 2;
-  grid-row: 1 / 3;
-  align-self: center;
-}
-
-.archive-wall a:hover,
-.archive-wall a:focus-visible {
-  background: #f8f4ea;
 }
 
 .studio-package {
@@ -2083,8 +1912,6 @@ a {
     min-height: 17rem;
   }
 
-  .catalog-wall,
-  .archive-wall,
   .studio-package,
   .studio-commission {
     grid-template-columns: 1fr;
@@ -2092,10 +1919,6 @@ a {
 
   .learning-ledger {
     grid-template-columns: minmax(15rem, 0.55fr) minmax(0, 1.45fr);
-  }
-
-  .archive-wall > header {
-    min-height: 30rem;
   }
 
   .workshop-world .package-action {
@@ -2190,23 +2013,8 @@ a {
     font-size: clamp(3rem, 15vw, 4.8rem);
   }
 
-  .catalog-row {
-    grid-template-columns: minmax(0, 1fr) auto;
-    gap: 0.5rem 1rem;
-  }
-
-  .catalog-row > span:nth-child(2) {
-    grid-column: 1;
-  }
-
-  .catalog-row > span:last-child {
-    grid-column: 2;
-    grid-row: 1 / 3;
-  }
-
   .learning-ledger {
     grid-template-columns: 1fr;
-    margin-top: 5rem;
   }
 
   .learning-ledger-meta {
@@ -2217,19 +2025,6 @@ a {
   .learning-ledger-story {
     min-height: 26rem;
     padding: 2.5rem 1.5rem;
-  }
-
-  .archive-wall ul {
-    grid-template-columns: 1fr;
-  }
-
-  .archive-wall > header {
-    min-height: 27rem;
-    padding: 2.5rem 1.5rem;
-  }
-
-  .archive-wall a {
-    min-height: 6.75rem;
   }
 
   .package-copy,

--- a/tests/showcase/public-surface.test.ts
+++ b/tests/showcase/public-surface.test.ts
@@ -32,7 +32,8 @@ describe('SaaS Maker public source boundary', () => {
       /PAGED_PRODUCTS = REGISTRY_PRODUCTS\.filter\(\(product\) => product\.id !== 'saas-maker'\)/
     );
     expect(projectsSource).toMatch(/\['personal-website', 'saas-maker'\]\.includes\(product\.id\)/);
-    expect(routesSource).toMatch(/filter\(\(product\) => product\.id !== 'saas-maker'\)/);
+    expect(routesSource).toMatch(/CORE\.flatMap/);
+    expect(routesSource).toMatch(/PAGED_PRODUCTS\.map/);
     expect(navSource).toMatch(/GITHUB_ORG_URL/);
     expect(navSource).toMatch(/Public source index/);
     expect(redirects).toMatch(/^\/p\/saas-maker \/ 301$/m);
@@ -51,5 +52,30 @@ describe('SaaS Maker public source boundary', () => {
     expect(articleMarkdown).toMatch(/## Sources and implementation/);
     expect(articleMarkdown.split(/\s+/u).length).toBeGreaterThan(700);
     expect(articleMarkdown).not.toMatch(/full article is available at/i);
+  });
+
+  it('keeps the homepage curated and reserves full enumeration for /projects', async () => {
+    const [home, fleet, layout, routes, projects] = await Promise.all([
+      readShowcase('src/pages/index.astro'),
+      readShowcase('src/components/Fleet.astro'),
+      readShowcase('src/layouts/Layout.astro'),
+      readShowcase('src/data/publicRoutes.ts'),
+      readShowcase('src/data/projects.ts'),
+    ]);
+
+    expect(home).toMatch(/<Hero \/>/);
+    expect(home).toMatch(/SaaS Maker — a public product studio/);
+    expect(fleet).toMatch(/DIRECTORY_COUNT/);
+    expect(fleet).toMatch(/Open the complete directory/);
+    expect(fleet).toMatch(/<h2 id="learning-title"/);
+    expect(fleet).not.toMatch(/ACTIVE_GROUPS|PAST_PROJECTS|catalog-row|archive-wall/);
+    expect(fleet).not.toMatch(/project identities|accounted for once/);
+    expect(layout).not.toMatch(/src="https:\/\/sassmaker\.com\/project-strip\.js"/);
+    expect(routes).toMatch(/# Products in focus/);
+    expect(routes).toMatch(/# Complete directory/);
+    expect(routes).toMatch(/CORE\.flatMap/);
+    expect(routes).not.toMatch(/publicCatalog\.pastProjects\.flatMap/);
+    expect(projects).toMatch(/throw new Error\(`Homepage spotlight is missing/);
+    expect(projects).not.toMatch(/ACTIVE_GROUPS|PAST_PROJECTS/);
   });
 });


### PR DESCRIPTION
## Outcome

- keeps four products in focus on the homepage
- moves complete 58-project enumeration exclusively to `/projects`
- removes the repeated maintained/past catalogs and SaaS Maker self-strip
- applies the same curated boundary to `/index.md`
- adds a four-spotlight build invariant and regression coverage

## Verification

- public catalog validation and Site Health parity: 58 identities
- lint, 32 tests, typecheck, shared packages, and all builds passed
- browser evidence at 390, 768, and 1440: no overflow, 4 focused product links, 1 directory gateway
- `/projects`: 58 directory rows
- design review: 0 P0 / 0 P1

Closes #49