### PR TITLE
Block cockpit deploys that would ship without auth secrets

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -47,8 +47,17 @@ Cockpit, CodeVetter, and App Health remain independent repositories.
 - **2026-08-22 — Feedback agent contract deployed:** Applied D1 migration
   `0025` (both preserved feedback rows kept), deployed `saasmaker-api` and
   `saasmaker-dashboard` at `c5d3e845`, and attached `app.sassmaker.com` as a
-  Worker custom domain. npm publication of `@saas-maker/feedback` and the
-  Anime List consumer merge are still blocked.
+  Worker custom domain. The Anime List consumer merge is still blocked.
+  `@saas-maker/feedback` is published on npm at `0.4.0` (4 versions).
+- **2026-08-22 — Inbox sign-in is down; package docs host is missing:**
+  `saasmaker-dashboard` carries no Worker secrets, so every `/api/auth/*` route
+  returns 500 — better-auth 1.6.30 (bumped in `b9b5858a`) refuses to run on its
+  default secret instead of warning. `BETTER_AUTH_SECRET`, `AUTH_GOOGLE_ID` and
+  `AUTH_GOOGLE_SECRET` all need attaching; `pnpm deploy:cockpit` now blocks
+  while any is absent. Separately, Pages project `saas-maker-packages` does not
+  exist, so `saas-maker-packages.pages.dev` has no DNS and the feedback package
+  documentation this file and README both advertise is unreachable. The public
+  submit path, `api.sassmaker.com`, and the npm package are unaffected.
 - **2026-08-22 — Standalone catalog boundary repaired:** Repointed public
   catalog synchronization to Site Health's canonical `projects.json`, retained
   the checked-in privacy-filtered projection for runtime use, and repointed the

--- a/apps/cockpit/.dev.vars.example
+++ b/apps/cockpit/.dev.vars.example
@@ -1,0 +1,27 @@
+# Cockpit (saasmaker-dashboard) — required environment
+#
+# Copy to `.dev.vars` for local development. In production these are Worker
+# SECRETS, not [vars] — set them with:
+#
+#   openssl rand -base64 32 | wrangler secret put BETTER_AUTH_SECRET --name saasmaker-dashboard
+#   wrangler secret put AUTH_GOOGLE_ID --name saasmaker-dashboard
+#   wrangler secret put AUTH_GOOGLE_SECRET --name saasmaker-dashboard
+#
+# `pnpm deploy:cockpit` refuses to deploy while any of the three is missing.
+# See scripts/check-worker-secrets.mjs.
+
+# Signs and verifies better-auth sessions. Read at apps/cockpit/src/lib/auth.ts.
+# better-auth >= 1.6.30 REFUSES TO START on its built-in default rather than
+# warning, so an unset value returns 500 from every /api/auth/* route.
+# At least 32 characters, randomly generated.
+BETTER_AUTH_SECRET=
+
+# Google OAuth client for the inbox sign-in. Both default to '' in auth.ts, so
+# an unset pair fails the social sign-in exchange even once the secret is set.
+AUTH_GOOGLE_ID=
+AUTH_GOOGLE_SECRET=
+
+# Already set as plain [vars] in wrangler.toml — listed here for local runs.
+AUTH_URL=http://localhost:3000
+NEXT_PUBLIC_API_URL=http://localhost:8787
+NEXT_PUBLIC_SITE_URL=http://localhost:3000

--- a/apps/cockpit/package.json
+++ b/apps/cockpit/package.json
@@ -7,7 +7,7 @@
     "build": "next build --webpack",
     "build:next": "next build",
     "cf:build": "opennextjs-cloudflare build && opennextjs-cloudflare populateCache local && pnpm --filter cockpit-landing-astro build && node scripts/run-overlay-astro-landing.mjs --strict",
-    "deploy": "pnpm --filter @saas-maker/ui build && pnpm cf:build && wrangler deploy && node ../../scripts/smoke-prod.mjs",
+    "deploy": "node ../../scripts/check-worker-secrets.mjs saasmaker-dashboard BETTER_AUTH_SECRET AUTH_GOOGLE_ID AUTH_GOOGLE_SECRET && pnpm --filter @saas-maker/ui build && pnpm cf:build && wrangler deploy && node ../../scripts/smoke-prod.mjs",
     "preview": "wrangler pages dev",
     "start": "next start",
     "typecheck": "tsc --noEmit"

--- a/scripts/check-worker-secrets.mjs
+++ b/scripts/check-worker-secrets.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * Pre-deploy secret preflight.
+ *
+ * `smoke-prod.mjs` already catches a broken auth surface, but it runs *after*
+ * `wrangler deploy` — so a Worker missing its secrets goes live and stays live
+ * until someone reads the smoke output. This runs first and refuses to deploy.
+ *
+ * Why it exists: on 2026-08-22 `saasmaker-dashboard` shipped with zero secrets.
+ * better-auth 1.6.30 (bumped in b9b5858a to clear an OAuth advisory) refuses to
+ * run on its default secret instead of warning, so every `/api/auth/*` request
+ * returned 500 and nobody could sign in to the feedback inbox.
+ *
+ * Usage:
+ *   node ../../scripts/check-worker-secrets.mjs <worker-name> SECRET_A SECRET_B
+ *
+ * Exit code:
+ *   0  — every required secret is present
+ *   1  — at least one is missing, or the secret list could not be read
+ *
+ * Set SKIP_SECRET_PREFLIGHT=1 to bypass (for a first deploy that creates the
+ * Worker before any secret can be attached to it).
+ */
+
+import { spawnSync } from 'node:child_process';
+
+const [worker, ...required] = process.argv.slice(2);
+
+if (!worker || required.length === 0) {
+  console.error('usage: check-worker-secrets.mjs <worker-name> <SECRET_NAME...>');
+  process.exit(1);
+}
+
+if (process.env.SKIP_SECRET_PREFLIGHT === '1') {
+  console.log(`⚠ secret preflight skipped for ${worker} (SKIP_SECRET_PREFLIGHT=1)`);
+  process.exit(0);
+}
+
+const res = spawnSync('wrangler', ['secret', 'list', '--name', worker, '--format', 'json'], {
+  encoding: 'utf8',
+  shell: false,
+});
+
+if (res.status !== 0) {
+  console.error(`✗ could not read secrets for ${worker}`);
+  console.error((res.stderr || res.stdout || '').trim().slice(0, 600));
+  console.error('\nIf the Worker does not exist yet, run the first deploy with');
+  console.error('SKIP_SECRET_PREFLIGHT=1 and attach its secrets immediately after.');
+  process.exit(1);
+}
+
+// wrangler prints a banner before the JSON payload; take the last array.
+const out = res.stdout ?? '';
+const start = out.indexOf('[');
+const end = out.lastIndexOf(']');
+
+let present = [];
+if (start !== -1 && end > start) {
+  try {
+    present = JSON.parse(out.slice(start, end + 1)).map((entry) => entry?.name ?? entry);
+  } catch {
+    console.error(`✗ could not parse the secret list for ${worker}`);
+    process.exit(1);
+  }
+} else {
+  console.error(`✗ no secret list in wrangler output for ${worker}`);
+  process.exit(1);
+}
+
+const missing = required.filter((name) => !present.includes(name));
+
+for (const name of required) {
+  console.log(`${missing.includes(name) ? '✗' : '✓'} ${name}`);
+}
+
+if (missing.length > 0) {
+  console.error(`\n✗ ${worker} is missing ${missing.length} required secret(s). Not deploying.`);
+  console.error('\nSet each one without writing it to disk or your shell history:');
+  for (const name of missing) {
+    const hint =
+      name === 'BETTER_AUTH_SECRET'
+        ? 'openssl rand -base64 32 | '
+        : `# paste the value from your provider, then:\n  `;
+    console.error(`  ${hint}wrangler secret put ${name} --name ${worker}`);
+  }
+  process.exit(1);
+}
+
+console.log(`\n✓ ${worker} has every required secret.`);

--- a/turbo.json
+++ b/turbo.json
@@ -11,7 +11,8 @@
     "SAAS_MAKER_API",
     "SAAS_MAKER_APP",
     "SAAS_MAKER_DIRECTORY",
-    "SAAS_MAKER_DOCS"
+    "SAAS_MAKER_DOCS",
+    "SKIP_SECRET_PREFLIGHT"
   ],
   "tasks": {
     "build": {


### PR DESCRIPTION
## Why

`app.sassmaker.com` returns 500 from every `/api/auth/*` route right now, so nobody can sign in to the feedback inbox. Captured from the live worker:

```
GET https://app.sassmaker.com/api/auth/get-session → 500
BetterAuthError: You are using the default secret. Please set `BETTER_AUTH_SECRET`
in your environment variables or pass `secret` in your auth config.
```

`wrangler secret list --name saasmaker-dashboard` returns `[]`. `apps/cockpit/src/lib/auth.ts` resolves `BETTER_AUTH_SECRET`/`AUTH_SECRET` to `undefined`, better-auth falls back to its built-in default, and 1.6.30 — bumped in b9b5858a to clear an OAuth advisory — refuses to run on that default instead of warning as 1.6.9 did. The bump was correct; it surfaced a secret that had been missing and silent.

`scripts/smoke-prod.mjs` already detects this — *"Cockpit /api/auth/sign-in/social returns Google OAuth URL"* fails with status 500 — but it runs **after** `wrangler deploy`, so a Worker missing its secrets goes live and stays live until someone reads the output.

## What changes

- **`scripts/check-worker-secrets.mjs`** — pre-deploy preflight. Reads `wrangler secret list` and refuses to deploy while any required secret is absent, naming each one with the exact command to set it. `SKIP_SECRET_PREFLIGHT=1` bypasses it for a first deploy that has to create the Worker before secrets can attach.
- **`apps/cockpit/package.json`** — `deploy` runs the preflight first, before the build, so it fails fast.
- **`apps/cockpit/.dev.vars.example`** — documents all three required secrets and why each matters. Nothing in the repo documented these names; a grep for `BETTER_AUTH_SECRET` across all markdown and scripts returned nothing.
- **`turbo.json`** — declares `SKIP_SECRET_PREFLIGHT` in `globalEnv` so Biome's Turborepo rule stays clean.
- **`PROJECT_STATUS.md`** — records the two live breakages, and corrects a stale line: `@saas-maker/feedback` is published on npm at `0.4.0`, not blocked.

## Verified

- Preflight run against current production state fails as designed, listing all three missing secrets.
- `biome check` clean on all changed files; `turbo.json` and `package.json` parse.
- Cherry-picked onto `origin/main` so it carries none of the unrelated TokenWorld commits sitting on the local branch.

## Still needs the owner

This PR sets no secret and deploys nothing.

```bash
cd apps/cockpit
openssl rand -base64 32 | wrangler secret put BETTER_AUTH_SECRET --name saasmaker-dashboard
wrangler secret put AUTH_GOOGLE_ID     --name saasmaker-dashboard
wrangler secret put AUTH_GOOGLE_SECRET --name saasmaker-dashboard
```

`AUTH_GOOGLE_ID`/`AUTH_GOOGLE_SECRET` default to `''` in `auth.ts`, so Google sign-in fails even once the secret lands — all three are required.

**Separate breakage, not fixed here:** Pages project `saas-maker-packages` does not exist, so `saas-maker-packages.pages.dev` has no DNS and the feedback package documentation advertised in `README.md:22` and `PROJECT_STATUS.md` is unreachable. `apps/docs-blume`'s deploy script creates the project on first run, so `pnpm deploy:docs` resolves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)