### PR TITLE
Bump @saas-maker/feedback to 0.4.1 and keep CLIENT_VERSION with it

### DIFF
--- a/packages/widgets/feedback-widget/package.json
+++ b/packages/widgets/feedback-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saas-maker/feedback",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "React feedback widget with hosted or product-owned submission, screenshots, and page-element context.",
   "license": "MIT",
   "homepage": "https://www.npmjs.com/package/@saas-maker/feedback",

--- a/packages/widgets/feedback-widget/src/ingestion.ts
+++ b/packages/widgets/feedback-widget/src/ingestion.ts
@@ -49,7 +49,7 @@ export async function submitFeedbackToUrl(
 }
 
 const DEFAULT_API_BASE = 'https://api.sassmaker.com';
-const CLIENT_VERSION = '0.4.0';
+const CLIENT_VERSION = '0.4.1';
 
 export async function submitFeedbackToProject(
   projectKey: string,

--- a/packages/widgets/feedback-widget/test/ingestion.test.mjs
+++ b/packages/widgets/feedback-widget/test/ingestion.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 import { submitFeedbackToProject, submitFeedbackToUrl } from '../dist/index.mjs';
@@ -142,4 +143,27 @@ test('hosted mode sends one multipart request with the project key', async (t) =
   assert.equal(payload.source, 'widget');
   assert.deepEqual(payload.page, submission().page);
   assert.equal(requests[0].init.body.get('screenshot').name, 'screen.png');
+});
+
+test('reports the published package version to the server', async (t) => {
+  // CLIENT_VERSION is hand-maintained next to the package version, so a
+  // release that bumps one and forgets the other silently mislabels every
+  // submission's origin. Pin them together.
+  const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
+  const originalFetch = globalThis.fetch;
+  let sent;
+  globalThis.fetch = async (_url, init) => {
+    sent = init.body;
+    return new Response(JSON.stringify({ id: 'fb_1' }), {
+      status: 201,
+      headers: { 'content-type': 'application/json' },
+    });
+  };
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  await submitFeedbackToProject('proj_test', submission());
+
+  assert.equal(JSON.parse(sent.get('feedback')).client_version, pkg.version);
 });


### PR DESCRIPTION
The version bump was sitting uncommitted in the working tree. Committing it as the release prerequisite for #52.

`CLIENT_VERSION` in `src/ingestion.ts` is hand-maintained beside the package version and still read `0.4.0`, so **every submission would have reported a stale client origin** after the release. Bumped in lockstep and pinned with a test comparing it to `package.json` — and I verified the test actually fails when only one side moves (reverted `CLIENT_VERSION` alone: 6 pass / 1 fail; restored: 7 pass / 0 fail).

The test also caught its own first draft: `client_version` is nested inside the `feedback` JSON field, not a top-level multipart field.

## Verification
- `tsc --noEmit` clean
- `tsup` build clean
- `node --test` **7 passed, 0 failed**
- `biome check` clean, 16 files
- Rebuilt tracked `dist/` now carries `0.4.1`

## Does not close #52
Publishing still needs npm credentials — `npm whoami` returns 401. Once you run `npm login`, publish plus the Anime List `projectKey` switch is ~30 minutes.

Refs #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)