### PR TITLE
Add the cockpit's own Microsoft Clarity project

### DIFF
--- a/apps/cockpit/src/app/layout.tsx
+++ b/apps/cockpit/src/app/layout.tsx
@@ -31,6 +31,14 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
+      <head>
+        {/* Microsoft Clarity — session replay + heatmaps (additive; PostHog stays) */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(c,l,a,r,i,t,y){c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/y6brryt053";y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);})(window,document,"clarity","script","y6brryt053");window.clarity("set","project_id","saas-maker");`,
+          }}
+        />
+      </head>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         <GlobalNamePolyfill />
         <ThemeProvider


### PR DESCRIPTION
Part of the per-product Clarity rollout (#18): the cockpit gets its own project ID (`y6brryt053`) rather than the shared `y39u4kk9oq`, so recordings and heatmaps are product-owned without tag filtering. PostHog is untouched and still loads.

This was sitting uncommitted in the working tree — which is the state that rollout has been left in across roughly a dozen products, one `git checkout` from being lost. Worth noting that #18's own text lists commits as out of scope, which is why none of it has been durable.

Refs #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)