### PR TITLE
Audit fleet projects by their real directory names

### DIFF
--- a/tooling/scripts/fleet-health.sh
+++ b/tooling/scripts/fleet-health.sh
@@ -48,15 +48,6 @@ else
   PROJECTS=$(get_projects)
 fi
 
-repo_dir_for_project() {
-  case "$1" in
-    # ai-game was renamed to aliveville; the local checkout retains its old directory name.
-    aliveville) printf 'ai-game\n' ;;
-    tinygpt) printf 'posttrainllm\n' ;;
-    *) printf '%s\n' "$1" ;;
-  esac
-}
-
 printf '%-20s %-10s %-8s %-8s %s\n' "PROJECT" "BRANCH" "GIT" "CI" "NOTES"
 printf '%-20s %-10s %-8s %-8s %s\n' "-------" "------" "---" "--" "-----"
 
@@ -67,7 +58,7 @@ ci_unknown=0
 total=0
 
 for project in $PROJECTS; do
-  dir="$ROOT/$(repo_dir_for_project "$project")"
+  dir="$ROOT/$project"
   total=$((total + 1))
   notes=""
 


### PR DESCRIPTION
`fleet-health.sh` was silently skipping **aliveville** on every run.

`get_projects()` builds the project list by taking the basename of each
directory under `~/Desktop/fleet` that contains a `.git`. Those names are
already directory names, but `repo_dir_for_project()` then rewrote
`aliveville` to `ai-game` — a directory that no longer exists since the
checkout was renamed — so the row printed `no .git dir` and the project was
excluded from the git/CI summary. The `tinygpt -> posttrainllm` entry was
dead for the same reason: `tinygpt` is never in the input list.

Removed the mapping and indexed straight off the discovered name.

Verified:

```
$ bash saas-maker/tooling/scripts/fleet-health.sh --no-fetch --only aliveville,posttrainllm,saas-maker
aliveville           main       clean    green
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)