### PR TITLE
Report repositories with Actions disabled

### DIFF
--- a/tooling/scripts/deploy-health.sh
+++ b/tooling/scripts/deploy-health.sh
@@ -339,6 +339,15 @@ check_github_actions() {
       continue
     fi
 
+    # A repository with Actions switched off has no CI evidence to compare, and
+    # any stranded workflow_dispatch run on it cannot be cancelled (HTTP 500)
+    # or deleted (HTTP 403). Report the state rather than a stale-run failure.
+    actions_enabled="$(gh api "repos/$slug/actions/permissions" --jq '.enabled' 2>/dev/null || true)"
+    if [[ "$actions_enabled" == "false" ]]; then
+      record "OK" "$repo has Actions disabled; CI state is not tracked"
+      continue
+    fi
+
     head_sha="$(origin_main_sha "$repo" || true)"
 
     if [[ -z "$head_sha" ]]; then

--- a/tooling/scripts/fleet-health.sh
+++ b/tooling/scripts/fleet-health.sh
@@ -55,6 +55,7 @@ clean=0
 dirty=0
 ci_red=0
 ci_unknown=0
+ci_off=0
 total=0
 
 for project in $PROJECTS; do
@@ -111,36 +112,49 @@ for project in $PROJECTS; do
     slug="${slug%.git}"
 
     if [[ -n "$slug" ]]; then
-      # Judge repository CI from pushes to main. Scheduled data refreshes are
-      # operational signals and must not replace the product's current CI state.
-      ci_record=$(gh run list -R "$slug" --branch main --event push --limit 1 \
-        --json conclusion,headSha --jq '.[0] | [.conclusion // "none", .headSha // ""] | @tsv' \
-        2>/dev/null || true)
-      read -r conclusion ci_sha <<< "$ci_record"
-      main_sha=$(git -C "$dir" rev-parse origin/main 2>/dev/null || true)
-      if [[ -n "$ci_sha" && -n "$main_sha" && "$ci_sha" != "$main_sha" ]]; then
-        ci_state="unknown"
-        ci_unknown=$((ci_unknown + 1))
-        notes="${notes:+$notes }CI stale"
+      # A repository with Actions switched off has no CI state to judge.
+      # Report that plainly rather than counting it as unknown: otherwise a
+      # deliberately disabled repository looks identical to one whose CI is
+      # silently broken. Note that workflow_dispatch against a disabled
+      # repository strands a run in `queued` that cannot be cancelled (HTTP
+      # 500) or deleted (HTTP 403), which is how this state usually surfaces.
+      actions_enabled=$(gh api "repos/$slug/actions/permissions" --jq '.enabled' 2>/dev/null || true)
+      if [[ "$actions_enabled" == "false" ]]; then
+        ci_state="off"
+        ci_off=$((ci_off + 1))
+        notes="${notes:+$notes }Actions disabled"
       else
-        case "$conclusion" in
-          success) ci_state="green" ;;
-          failure|timed_out|action_required|startup_failure)
-            ci_state="red"
-            ci_red=$((ci_red + 1))
-            notes="${notes:+$notes }CI failing"
-            ;;
-          cancelled)
-            ci_state="unknown"
-            ci_unknown=$((ci_unknown + 1))
-            notes="${notes:+$notes }CI cancelled"
-            ;;
-          none|"")
-            ci_state="unknown"
-            ci_unknown=$((ci_unknown + 1))
-            ;;
-          *) ci_state="$conclusion" ;;
-        esac
+        # Judge repository CI from pushes to main. Scheduled data refreshes are
+        # operational signals and must not replace the product's current CI state.
+        ci_record=$(gh run list -R "$slug" --branch main --event push --limit 1 \
+          --json conclusion,headSha --jq '.[0] | [.conclusion // "none", .headSha // ""] | @tsv' \
+          2>/dev/null || true)
+        read -r conclusion ci_sha <<< "$ci_record"
+        main_sha=$(git -C "$dir" rev-parse origin/main 2>/dev/null || true)
+        if [[ -n "$ci_sha" && -n "$main_sha" && "$ci_sha" != "$main_sha" ]]; then
+          ci_state="unknown"
+          ci_unknown=$((ci_unknown + 1))
+          notes="${notes:+$notes }CI stale"
+        else
+          case "$conclusion" in
+            success) ci_state="green" ;;
+            failure|timed_out|action_required|startup_failure)
+              ci_state="red"
+              ci_red=$((ci_red + 1))
+              notes="${notes:+$notes }CI failing"
+              ;;
+            cancelled)
+              ci_state="unknown"
+              ci_unknown=$((ci_unknown + 1))
+              notes="${notes:+$notes }CI cancelled"
+              ;;
+            none|"")
+              ci_state="unknown"
+              ci_unknown=$((ci_unknown + 1))
+              ;;
+            *) ci_state="$conclusion" ;;
+          esac
+        fi
       fi
     else
       ci_unknown=$((ci_unknown + 1))
@@ -164,7 +178,11 @@ for project in $PROJECTS; do
 done
 
 echo ""
-echo "Summary: $total projects — $clean clean, $dirty dirty, $ci_red CI-red, $ci_unknown CI-unknown"
+summary="Summary: $total projects — $clean clean, $dirty dirty, $ci_red CI-red, $ci_unknown CI-unknown"
+if [[ "$ci_off" -gt 0 ]]; then
+  summary="$summary, $ci_off Actions-disabled"
+fi
+echo "$summary"
 
 if [[ $ci_red -gt 0 ]]; then
   exit 1


### PR DESCRIPTION
## Problem

`reel-pipeline` and `mobile-dev-cockpit` have Actions disabled at the repository
level (`{"enabled": false}`), which is deliberate. Both health scripts misread
that:

- `fleet-health.sh` counted them as **CI-unknown**
- `deploy-health.sh` emitted `WARN ... has no recent Actions run at origin/main`

So two intentional states showed up as two permanent defects.

## Change

Both scripts now query `repos/<slug>/actions/permissions`:

```
mobile-dev-cockpit   main       clean    off      Actions disabled
open-historia        main       clean    green     ahead=2 behind=4
reel-pipeline        main       clean    off      Actions disabled

Summary: 4 projects — 3 clean, 1 dirty, 0 CI-red, 0 CI-unknown, 2 Actions-disabled
```

```
OK reel-pipeline has Actions disabled; CI state is not tracked
OK mobile-dev-cockpit has Actions disabled; CI state is not tracked
```

Detected live rather than recorded in `projects.json`, so the reports
self-correct if Actions is re-enabled and there is no catalog field to drift.

## Why name it instead of hiding it

A `workflow_dispatch` against a disabled repository creates a run that is
queued and never scheduled — and it cannot be cancelled (HTTP 500) or deleted
(HTTP 403). Both repos have one stranded from `2026-08-20T17:15:45Z`, and their
last completed CI is 2026-07-24. "Actions disabled" explains that; "CI unknown"
does not.

## Verification

Ran both scripts. The ahead/behind remote-sync reporting still works for
non-exempt repos (see open-historia above), which an early version of this
change would have skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)