### PR TITLE
Stop requiring web CI from native app repositories

### DIFF
--- a/tooling/scripts/deploy-health.sh
+++ b/tooling/scripts/deploy-health.sh
@@ -162,6 +162,26 @@ is_local_only_project() {
   return 1
 }
 
+is_native_app_project() {
+  # A project whose deploy source is a different repository is a native app:
+  # the shipped web surface is built by a landing factory (ios-landings), and
+  # the repository itself holds the Swift app, released through TestFlight by
+  # hand. Such a repository is not expected to carry web CI or a deploy
+  # entrypoint, so requiring either reports a permanent false failure.
+  local repo="$1"
+  local relative_repo
+
+  relative_repo="${repo#"$ROOT"/}"
+  [[ -f "$TARGETS_FILE" ]] || return 1
+  jq -e --arg repo "$relative_repo" '
+    any(.projects[]?;
+      .repo == $repo
+      and (.sourcePath // "") != ""
+      and .sourcePath != .repo
+    )
+  ' "$TARGETS_FILE" >/dev/null 2>&1
+}
+
 is_canonical_deploy_project() {
   local repo="$1"
   local relative_repo
@@ -332,6 +352,11 @@ check_github_actions() {
       continue
     fi
 
+    if is_native_app_project "$repo"; then
+      record "OK" "$repo is a native app deployed from its landing factory; GitHub Actions not required"
+      continue
+    fi
+
     slug="$(github_slug_for_repo "$repo" || true)"
 
     if [[ -z "$slug" ]]; then
@@ -461,6 +486,11 @@ check_project_standards() {
 
     if ! is_canonical_deploy_project "$repo"; then
       record "OK" "$repo is outside canonical deploy scope; deploy standard not required"
+      continue
+    fi
+
+    if is_native_app_project "$repo"; then
+      record "OK" "$repo is a native app deployed from its landing factory; web deploy standard not required"
       continue
     fi
 

--- a/tooling/scripts/fleet-health.sh
+++ b/tooling/scripts/fleet-health.sh
@@ -56,6 +56,7 @@ dirty=0
 ci_red=0
 ci_unknown=0
 ci_off=0
+ci_none=0
 total=0
 
 for project in $PROJECTS; do
@@ -102,7 +103,15 @@ for project in $PROJECTS; do
 
   # CI check via gh
   ci_state="unknown"
-  if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  # A repository with no workflow files has no CI to judge. Several Fleet
+  # projects are native apps released through TestFlight by hand, so this is a
+  # deliberate state rather than a broken one — report it as such instead of
+  # folding it into "unknown" alongside genuinely unclear CI.
+  if [[ -z "$(find "$dir/.github/workflows" -maxdepth 1 -type f \( -name '*.yml' -o -name '*.yaml' \) 2>/dev/null)" ]]; then
+    ci_state="none"
+    ci_none=$((ci_none + 1))
+    notes="${notes:+$notes }no workflows"
+  elif command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
     url=$(git -C "$dir" remote get-url origin 2>/dev/null || true)
     slug=""
     case "$url" in
@@ -181,6 +190,9 @@ echo ""
 summary="Summary: $total projects — $clean clean, $dirty dirty, $ci_red CI-red, $ci_unknown CI-unknown"
 if [[ "$ci_off" -gt 0 ]]; then
   summary="$summary, $ci_off Actions-disabled"
+fi
+if [[ "$ci_none" -gt 0 ]]; then
+  summary="$summary, $ci_none no-workflows"
 fi
 echo "$summary"
 


### PR DESCRIPTION
## Problem

Six projects are Swift apps released through TestFlight by hand. Their shipped
web surface is built by the **ios-landings** factory, not by their own
repository. Both health scripts judged them as web projects, producing 11
permanent false failures:

```
FAIL journal has no GitHub Actions workflow files
FAIL journal has no deploy entrypoint
FAIL journal has no GitHub Actions runs on main
FAIL anchor  has no GitHub Actions workflow files
FAIL anchor  has no deploy entrypoint
FAIL anchor  has no GitHub Actions runs on main
FAIL kith    has no deploy entrypoint
FAIL setline has no deploy entrypoint
FAIL indulge has no deploy entrypoint
```

## The marker already exists

Those repos are exactly the ones whose `sourcePath` names a **different**
repository than their `repo`:

```
setline  repo=setline  sourcePath=ios-landings
journal  repo=journal  sourcePath=ios-landings
kith     repo=kith     sourcePath=ios-landings
motion   repo=motion   sourcePath=ios-landings
indulge  repo=indulge  sourcePath=ios-landings
anchor   repo=anchor   sourcePath=ios-landings
```

No new catalog field needed. `calorie` is deliberately **not** in this set — it
owns a Worker and its own CI, and is unaffected.

## Change

- `deploy-health.sh`: new `is_native_app_project()`; such repos skip the
  workflow-files, deploy-entrypoint and Actions-runs checks with an OK record.
- `fleet-health.sh` is directory-driven, not catalog-driven, so it instead
  separates **"no workflow files at all"** from **"CI state unclear"**. A repo
  with no workflows now reports `none`:

```
Summary: 58 projects — 55 clean, 3 dirty, 0 CI-red, 3 CI-unknown, 2 Actions-disabled, 4 no-workflows
```

## Result

Deploy standards + Actions failures: **19 → 11**. What remains is genuine:

| Remaining | Repos |
|---|---|
| no deploy entrypoint | recipe-dashboard, mobile-dev-cockpit, local-ai-video-studio, agent-office, reddit-insights |
| Worker deploys missing `--tag` | aliveville, mobile-dev-cockpit, chatgpt-connections, reddit-insights |
| no CI at all | gitstat — deliberately still failing: a web app with a live Pages deployment and no CI |

🤖 Generated with [Claude Code](https://claude.com/claude-code)