### PR TITLE
Detect SHA tagging in committed deploy scripts

### DIFF
--- a/tooling/scripts/deploy-health.sh
+++ b/tooling/scripts/deploy-health.sh
@@ -265,8 +265,12 @@ project_has_worker_sha_tag() {
   local file
 
   while IFS= read -r -d '' file; do
+    # The SHA may be spelled as a shell command (`git rev-parse HEAD`) or as
+    # argv in a Node deploy script (`run('git', ['rev-parse', 'HEAD'])`), so
+    # match rev-parse followed by HEAD across quotes and commas. This does not
+    # match `rev-parse --abbrev-ref HEAD`, which yields a branch name.
     if grep -Fq -- '--tag' "$file" &&
-      grep -Eiq 'github\.sha|GITHUB_SHA|git rev-parse HEAD' "$file"; then
+      grep -Eiq 'github\.sha|GITHUB_SHA|rev-parse['"'"'",[:space:]]+HEAD' "$file"; then
       return 0
     fi
   done < <(
@@ -280,6 +284,16 @@ project_has_worker_sha_tag() {
         -not -path '*/out/*' \
         -not -path '*/build/*' \
         -print0
+      # Several projects keep the wrangler invocation in a committed deploy
+      # script rather than inline in a workflow or package.json — for example
+      # chatgpt-connections/scripts/deploy.mjs, which passes
+      # `--tag <git rev-parse HEAD>`. Scanning only workflows and package.json
+      # reported those as untagged while the Cloudflare parity check in this
+      # same run resolved their live version's SHA, so the two halves
+      # contradicted each other.
+      find "$repo/scripts" -maxdepth 2 -type f \
+        \( -name '*.mjs' -o -name '*.js' -o -name '*.ts' -o -name '*.sh' \) \
+        -print0 2>/dev/null
     }
   )
 


### PR DESCRIPTION
## Problem

The Worker SHA-tag check had two blind spots:

1. It scanned only `.github/workflows/*` and `package.json` files — not
   committed deploy scripts.
2. It matched only the shell spelling `git rev-parse HEAD`.

`chatgpt-connections` shows why that matters. `scripts/deploy.mjs`:

```js
const sha = run('git', ['rev-parse', 'HEAD']);
...
['exec', 'wrangler', 'deploy', '--tag', sha]
```

It tags correctly, yet the standards section reported
`FAIL chatgpt-connections Worker deploys do not record the Git SHA with --tag`
while the **Cloudflare section of the same run** resolved its live version's
SHA:

```
OK chatgpt-connections Worker fleet-chatgpt-connections deployed 1025111 from main at 100%
```

Two halves of one report contradicting each other is worse than either being
wrong alone.

## Fix

- also scan `scripts/` for `.mjs`, `.js`, `.ts`, `.sh`
- match `rev-parse` followed by `HEAD` across quotes and commas, so the argv
  form counts

Deliberately still **not** matched: `rev-parse --abbrev-ref HEAD`, which yields
a branch name, not a SHA.

## Result

Standards failures **11 → 9**. `aliveville`, `mobile-dev-cockpit` and
`reddit-insights` remain, and those are genuine — verified separately:
aliveville has a root `wrangler.jsonc` Worker with no committed deploy path at
all (its only wrangler invocation is `pages deploy`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)