### PR TITLE
feat(priority-queue): reconcile closed issues and schedule the sync

### DIFF
--- a/tooling/scripts/github-priority-queue.mjs
+++ b/tooling/scripts/github-priority-queue.mjs
@@ -4,29 +4,45 @@ import { spawnSync } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
 
 const DEFAULT_LIMIT = 1_000;
+const DEFAULT_STATUS_FIELD = 'Status';
+const DEFAULT_DONE_VALUE = 'Done';
 const TOKEN_PATTERNS = [
   /\bgh[opsu]_[A-Za-z0-9_]+\b/g,
   /\bgithub_pat_[A-Za-z0-9_]+\b/g,
   /\bBearer\s+[^\s]+/gi,
 ];
+const VALUED_ARGUMENTS = ['owner', 'project', 'author', 'limit', 'status-field', 'done-value'];
 
 function usage() {
   return `Usage:
   node saas-maker/tooling/scripts/github-priority-queue.mjs \\
     --owner OWNER --project NUMBER --author LOGIN [--apply]
 
+Reconciles a GitHub Project against the author's issues in both directions:
+adds open issues that are missing, and moves items whose issue is already
+closed to the terminal status. Items that are terminal on the board while
+their issue is open are reported for human review and never changed.
+
 Options:
-  --owner OWNER     GitHub Project owner login (required)
-  --project NUMBER  GitHub Project number (required)
-  --author LOGIN    Issue author login (required)
-  --limit NUMBER    Maximum authored issues to discover (default: ${DEFAULT_LIMIT})
-  --apply           Add missing issues; without this flag the command is read-only
-  --help            Show this help
+  --owner OWNER          GitHub Project owner login (required)
+  --project NUMBER       GitHub Project number (required)
+  --author LOGIN         Issue author login (required)
+  --limit NUMBER         Maximum issues to discover per state (default: ${DEFAULT_LIMIT})
+  --status-field NAME    Single-select status field name (default: ${DEFAULT_STATUS_FIELD})
+  --done-value NAME      Terminal option name in that field (default: ${DEFAULT_DONE_VALUE})
+  --apply                Add missing issues and reconcile status; without this
+                         flag the command is read-only
+  --help                 Show this help
 `;
 }
 
 export function parseArgs(argv) {
-  const options = { apply: false, limit: DEFAULT_LIMIT };
+  const options = {
+    apply: false,
+    limit: DEFAULT_LIMIT,
+    statusField: DEFAULT_STATUS_FIELD,
+    doneValue: DEFAULT_DONE_VALUE,
+  };
   for (let index = 0; index < argv.length; index += 1) {
     const argument = argv[index];
     if (argument === '--apply') {
@@ -38,14 +54,16 @@ export function parseArgs(argv) {
       continue;
     }
     const key = argument.slice(2);
-    if (!['owner', 'project', 'author', 'limit'].includes(key)) {
+    if (!VALUED_ARGUMENTS.includes(key)) {
       throw new Error(`Unknown argument: ${argument}`);
     }
     const value = argv[index + 1];
     if (!value || value.startsWith('--')) {
       throw new Error(`Missing value for ${argument}`);
     }
-    options[key] = value;
+    if (key === 'status-field') options.statusField = value;
+    else if (key === 'done-value') options.doneValue = value;
+    else options[key] = value;
     index += 1;
   }
 
@@ -64,14 +82,17 @@ export function parseArgs(argv) {
   return options;
 }
 
-export function buildIssueSearchArgs(author, limit = DEFAULT_LIMIT) {
+export function buildIssueSearchArgs(author, limit = DEFAULT_LIMIT, state = 'open') {
+  if (!['open', 'closed'].includes(state)) {
+    throw new Error(`Unsupported issue state: ${state}`);
+  }
   return [
     'search',
     'issues',
     '--author',
     author,
     '--state',
-    'open',
+    state,
     '--limit',
     String(limit),
     '--json',
@@ -91,12 +112,7 @@ export function extractIssueUrls(payload) {
 }
 
 export function extractProjectUrls(payload) {
-  const rows = Array.isArray(payload) ? payload : payload?.items ?? [];
-  return new Set(
-    rows
-      .map((row) => row?.content?.url ?? row?.url)
-      .filter(Boolean),
-  );
+  return new Set(normalizeProjectItems(payload).map((item) => item.url));
 }
 
 function projectField(item, name) {
@@ -104,29 +120,49 @@ function projectField(item, name) {
   return item?.[name] ?? item?.[normalized] ?? item?.[normalized.replaceAll(' ', '_')];
 }
 
-export function auditProjectItems(payload) {
+export function normalizeProjectItems(payload) {
   const rows = Array.isArray(payload) ? payload : payload?.items ?? [];
+  const items = [];
+  for (const row of rows) {
+    const url = row?.content?.url ?? row?.url;
+    if (!url) continue;
+    items.push({
+      itemId: row?.id ?? '',
+      url,
+      status: String(projectField(row, 'Status') ?? ''),
+      priority: String(projectField(row, 'Priority') ?? ''),
+      reasoningComplexity: String(projectField(row, 'Reasoning complexity') ?? ''),
+      size: String(projectField(row, 'Size') ?? ''),
+      labels: (row?.labels ?? row?.content?.labels ?? []).map((label) =>
+        String(label?.name ?? label).toLowerCase(),
+      ),
+    });
+  }
+  return items;
+}
+
+export function isTerminalStatus(status, doneValue = DEFAULT_DONE_VALUE) {
+  return String(status ?? '').trim().toLowerCase() === String(doneValue).trim().toLowerCase();
+}
+
+export function auditProjectItems(payload, { doneValue = DEFAULT_DONE_VALUE } = {}) {
   const findings = {
     missingPriority: [],
     missingReasoningComplexity: [],
+    missingSize: [],
     blockedOrDeferredP0: [],
   };
 
-  for (const item of rows) {
-    const url = item?.content?.url ?? item?.url;
-    if (!url) continue;
-    const priority = projectField(item, 'Priority');
-    const reasoningComplexity = projectField(item, 'Reasoning complexity');
-    const labels = (item?.labels ?? item?.content?.labels ?? []).map((label) =>
-      String(label?.name ?? label).toLowerCase(),
-    );
-    if (!priority) findings.missingPriority.push(url);
-    if (!reasoningComplexity) findings.missingReasoningComplexity.push(url);
+  for (const item of normalizeProjectItems(payload)) {
+    if (isTerminalStatus(item.status, doneValue)) continue;
+    if (!item.priority) findings.missingPriority.push(item.url);
+    if (!item.reasoningComplexity) findings.missingReasoningComplexity.push(item.url);
+    if (!item.size) findings.missingSize.push(item.url);
     if (
-      String(priority).startsWith('P0') &&
-      (labels.includes('blocked') || labels.includes('deferred'))
+      item.priority.startsWith('P0') &&
+      (item.labels.includes('blocked') || item.labels.includes('deferred'))
     ) {
-      findings.blockedOrDeferredP0.push(url);
+      findings.blockedOrDeferredP0.push(item.url);
     }
   }
 
@@ -135,6 +171,7 @@ export function auditProjectItems(payload) {
     reviewRequired: new Set([
       ...findings.missingPriority,
       ...findings.missingReasoningComplexity,
+      ...findings.missingSize,
     ]).size,
   };
 }
@@ -147,6 +184,47 @@ export function planQueueSync(discoveredUrls, projectUrls) {
     missing,
     unchanged: discovered.length - missing.length,
   };
+}
+
+export function planStatusReconciliation(
+  payload,
+  { closedUrls = new Set(), openUrls = new Set(), doneValue = DEFAULT_DONE_VALUE } = {},
+) {
+  const toDone = [];
+  const reopened = [];
+
+  for (const item of normalizeProjectItems(payload)) {
+    const terminal = isTerminalStatus(item.status, doneValue);
+    if (closedUrls.has(item.url) && !terminal) {
+      toDone.push({ itemId: item.itemId, url: item.url, status: item.status });
+      continue;
+    }
+    if (openUrls.has(item.url) && terminal) {
+      reopened.push({ itemId: item.itemId, url: item.url });
+    }
+  }
+
+  return { toDone, reopened };
+}
+
+export function resolveStatusOption(payload, statusField, doneValue) {
+  const fields = Array.isArray(payload) ? payload : payload?.fields ?? [];
+  const field = fields.find(
+    (candidate) =>
+      String(candidate?.name ?? '').trim().toLowerCase() ===
+      String(statusField).trim().toLowerCase(),
+  );
+  if (!field) throw new Error(`Project has no field named ${statusField}`);
+  if (!Array.isArray(field.options)) {
+    throw new Error(`Field ${statusField} is not a single-select field`);
+  }
+  const option = field.options.find(
+    (candidate) =>
+      String(candidate?.name ?? '').trim().toLowerCase() ===
+      String(doneValue).trim().toLowerCase(),
+  );
+  if (!option) throw new Error(`Field ${statusField} has no option named ${doneValue}`);
+  return { fieldId: field.id, optionId: option.id };
 }
 
 function runGh(run, args) {
@@ -175,6 +253,9 @@ export function syncPriorityQueue(
   options,
   { run = spawnSync, write = (line) => console.log(line) } = {},
 ) {
+  const statusField = options.statusField ?? DEFAULT_STATUS_FIELD;
+  const doneValue = options.doneValue ?? DEFAULT_DONE_VALUE;
+
   const identity = runGh(run, ['api', 'user', '--jq', '.login']);
   if (!identity.ok) {
     throw new Error(`GitHub authentication unavailable: ${identity.stderr || 'run gh auth login'}`);
@@ -194,9 +275,15 @@ export function syncPriorityQueue(
       `GitHub Project access unavailable. Authorize it with: gh auth refresh -h github.com -s project (${project.stderr || 'project lookup failed'})`,
     );
   }
+  const projectId = parseJson(project, 'Project lookup failed')?.id;
+  if (!projectId) throw new Error('Project lookup failed: no project id returned');
 
-  const searchResult = runGh(run, buildIssueSearchArgs(options.author, options.limit));
-  const discoveredUrls = extractIssueUrls(parseJson(searchResult, 'Issue discovery failed'));
+  const openResult = runGh(run, buildIssueSearchArgs(options.author, options.limit, 'open'));
+  const discoveredUrls = extractIssueUrls(parseJson(openResult, 'Issue discovery failed'));
+  const closedResult = runGh(run, buildIssueSearchArgs(options.author, options.limit, 'closed'));
+  const closedUrls = new Set(
+    extractIssueUrls(parseJson(closedResult, 'Closed issue discovery failed')),
+  );
 
   const itemsResult = runGh(run, [
     'project',
@@ -211,11 +298,18 @@ export function syncPriorityQueue(
   ]);
   const projectItems = parseJson(itemsResult, 'Project item lookup failed');
   const projectUrls = extractProjectUrls(projectItems);
-  const audit = auditProjectItems(projectItems);
+  const audit = auditProjectItems(projectItems, { doneValue });
   const plan = planQueueSync(discoveredUrls, projectUrls);
+  const reconciliation = planStatusReconciliation(projectItems, {
+    closedUrls,
+    openUrls: new Set(plan.discovered),
+    doneValue,
+  });
 
   let added = 0;
+  let reconciled = 0;
   const failures = [];
+
   if (options.apply) {
     for (const url of plan.missing) {
       const result = runGh(run, [
@@ -232,6 +326,54 @@ export function syncPriorityQueue(
       if (result.ok) added += 1;
       else failures.push({ url, error: result.stderr || 'GitHub command failed' });
     }
+
+    if (reconciliation.toDone.length > 0) {
+      let target = null;
+      try {
+        const fields = parseJson(
+          runGh(run, [
+            'project',
+            'field-list',
+            String(options.project),
+            '--owner',
+            options.owner,
+            '--limit',
+            String(options.limit),
+            '--format',
+            'json',
+          ]),
+          'Project field lookup failed',
+        );
+        target = resolveStatusOption(fields, statusField, doneValue);
+      } catch (error) {
+        failures.push({ url: `field:${statusField}`, error: sanitizeError(error?.message ?? error) });
+      }
+
+      if (target) {
+        for (const item of reconciliation.toDone) {
+          if (!item.itemId) {
+            failures.push({ url: item.url, error: 'Project item id unavailable' });
+            continue;
+          }
+          const result = runGh(run, [
+            'project',
+            'item-edit',
+            '--id',
+            item.itemId,
+            '--project-id',
+            projectId,
+            '--field-id',
+            target.fieldId,
+            '--single-select-option-id',
+            target.optionId,
+            '--format',
+            'json',
+          ]);
+          if (result.ok) reconciled += 1;
+          else failures.push({ url: item.url, error: result.stderr || 'GitHub command failed' });
+        }
+      }
+    }
   }
 
   const summary = {
@@ -240,16 +382,26 @@ export function syncPriorityQueue(
     missing: plan.missing.length,
     added,
     unchanged: plan.unchanged,
+    closedPending: reconciliation.toDone.length,
+    reconciled,
+    reopened: reconciliation.reopened.length,
     failed: failures.length,
     reviewRequired: audit.reviewRequired + (options.apply ? added : plan.missing.length),
+    missingSize: audit.missingSize.length,
     blockedOrDeferredP0: audit.blockedOrDeferredP0.length,
   };
   write(
-    `Queue sync: mode=${summary.mode} discovered=${summary.discovered} missing=${summary.missing} added=${summary.added} unchanged=${summary.unchanged} failed=${summary.failed} review_required=${summary.reviewRequired} blocked_or_deferred_p0=${summary.blockedOrDeferredP0}`,
+    `Queue sync: mode=${summary.mode} discovered=${summary.discovered} missing=${summary.missing} added=${summary.added} unchanged=${summary.unchanged} closed_pending=${summary.closedPending} reconciled=${summary.reconciled} reopened=${summary.reopened} failed=${summary.failed} review_required=${summary.reviewRequired} missing_size=${summary.missingSize} blocked_or_deferred_p0=${summary.blockedOrDeferredP0}`,
   );
+  for (const item of reconciliation.toDone) {
+    write(`Closed issue not ${doneValue} on board: ${item.url} (${item.status || 'no status'})`);
+  }
+  for (const item of reconciliation.reopened) {
+    write(`Review ${item.url}: board says ${doneValue} but the issue is open`);
+  }
   for (const failure of failures) write(`Failed ${failure.url}: ${failure.error}`);
 
-  return { summary, failures, exitCode: failures.length > 0 ? 1 : 0 };
+  return { summary, failures, reconciliation, audit, exitCode: failures.length > 0 ? 1 : 0 };
 }
 
 function main() {

--- a/tooling/scripts/install-priority-queue-schedule.mjs
+++ b/tooling/scripts/install-priority-queue-schedule.mjs
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const DEFAULT_LABEL = 'com.sarthak.priority-queue-sync';
+const DEFAULT_HOUR = 9;
+const DEFAULT_MINUTE = 20;
+const DEFAULT_PATH = '/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin';
+const VALUED_ARGUMENTS = ['owner', 'project', 'author', 'label', 'hour', 'minute', 'path'];
+
+function usage() {
+  return `Usage:
+  node saas-maker/tooling/scripts/install-priority-queue-schedule.mjs \\
+    --owner OWNER --project NUMBER --author LOGIN [--hour 9] [--minute 20]
+
+Installs a per-user launchd agent that runs github-priority-queue.mjs --apply
+once a day, using the operator's existing gh authentication. No token, secret,
+or credential is written by this script.
+
+Options:
+  --owner OWNER     GitHub Project owner login (required)
+  --project NUMBER  GitHub Project number (required)
+  --author LOGIN    Issue author login (required)
+  --label LABEL     launchd label (default: ${DEFAULT_LABEL})
+  --hour HOUR       Local hour to run, 0-23 (default: ${DEFAULT_HOUR})
+  --minute MINUTE   Local minute to run, 0-59 (default: ${DEFAULT_MINUTE})
+  --path PATH       PATH given to the agent (default: homebrew and system bins)
+  --uninstall       Remove the agent and its plist
+  --dry-run         Print the plist and the launchctl plan without writing
+  --help            Show this help
+`;
+}
+
+export function parseArgs(argv) {
+  const options = {
+    label: DEFAULT_LABEL,
+    hour: DEFAULT_HOUR,
+    minute: DEFAULT_MINUTE,
+    path: DEFAULT_PATH,
+    uninstall: false,
+    dryRun: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === '--uninstall') {
+      options.uninstall = true;
+      continue;
+    }
+    if (argument === '--dry-run') {
+      options.dryRun = true;
+      continue;
+    }
+    if (argument === '--help') {
+      options.help = true;
+      continue;
+    }
+    const key = argument.slice(2);
+    if (!VALUED_ARGUMENTS.includes(key)) {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+    const value = argv[index + 1];
+    if (!value || value.startsWith('--')) {
+      throw new Error(`Missing value for ${argument}`);
+    }
+    options[key] = value;
+    index += 1;
+  }
+
+  if (options.help) return options;
+  if (!options.uninstall) {
+    for (const key of ['owner', 'project', 'author']) {
+      if (!options[key]) throw new Error(`Missing required argument: --${key}`);
+    }
+    if (!/^\d+$/.test(String(options.project))) {
+      throw new Error('--project must be a positive integer');
+    }
+  }
+  options.hour = Number(options.hour);
+  options.minute = Number(options.minute);
+  if (!Number.isInteger(options.hour) || options.hour < 0 || options.hour > 23) {
+    throw new Error('--hour must be an integer between 0 and 23');
+  }
+  if (!Number.isInteger(options.minute) || options.minute < 0 || options.minute > 59) {
+    throw new Error('--minute must be an integer between 0 and 59');
+  }
+  if (!/^[A-Za-z0-9._-]+$/.test(options.label)) {
+    throw new Error('--label must be a plain launchd label');
+  }
+  return options;
+}
+
+export function escapeXml(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+}
+
+export function buildCommand({ syncScript, owner, project, author, logPath }) {
+  const parts = [
+    'exec node',
+    JSON.stringify(syncScript),
+    '--owner',
+    JSON.stringify(String(owner)),
+    '--project',
+    JSON.stringify(String(project)),
+    '--author',
+    JSON.stringify(String(author)),
+    '--apply',
+    '>>',
+    JSON.stringify(logPath),
+    '2>&1',
+  ];
+  return parts.join(' ');
+}
+
+export function buildPlist({ label, command, hour, minute, path, home, logPath }) {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${escapeXml(label)}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/zsh</string>
+    <string>-lc</string>
+    <string>${escapeXml(command)}</string>
+  </array>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key>
+    <integer>${hour}</integer>
+    <key>Minute</key>
+    <integer>${minute}</integer>
+  </dict>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>${escapeXml(path)}</string>
+    <key>HOME</key>
+    <string>${escapeXml(home)}</string>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>${escapeXml(logPath)}</string>
+  <key>StandardErrorPath</key>
+  <string>${escapeXml(logPath)}</string>
+  <key>RunAtLoad</key>
+  <false/>
+  <key>ProcessType</key>
+  <string>Background</string>
+</dict>
+</plist>
+`;
+}
+
+export function planLaunchctl(label, plistPath, uid) {
+  return {
+    bootout: ['bootout', `gui/${uid}/${label}`],
+    bootstrap: ['bootstrap', `gui/${uid}`, plistPath],
+    kickstart: ['kickstart', '-p', `gui/${uid}/${label}`],
+  };
+}
+
+export function installSchedule(
+  options,
+  {
+    run = spawnSync,
+    write = (line) => console.log(line),
+    writeFile = writeFileSync,
+    remove = rmSync,
+    makeDirectory = mkdirSync,
+    home = process.env.HOME ?? '',
+    uid = process.getuid?.() ?? 0,
+    scriptDirectory = dirname(fileURLToPath(import.meta.url)),
+  } = {},
+) {
+  if (!home) throw new Error('HOME is not set; cannot resolve the LaunchAgents directory');
+
+  const agentsDirectory = join(home, 'Library', 'LaunchAgents');
+  const plistPath = join(agentsDirectory, `${options.label}.plist`);
+  const logPath = join(home, 'Library', 'Logs', `${options.label}.log`);
+  const syncScript = resolve(scriptDirectory, 'github-priority-queue.mjs');
+  const plan = planLaunchctl(options.label, plistPath, uid);
+
+  if (options.uninstall) {
+    if (options.dryRun) {
+      write(`Would run: launchctl ${plan.bootout.join(' ')}`);
+      write(`Would remove ${plistPath}`);
+      return { plistPath, logPath, uninstalled: false };
+    }
+    run('launchctl', plan.bootout, { encoding: 'utf8' });
+    remove(plistPath, { force: true });
+    write(`Removed ${options.label} and ${plistPath}`);
+    return { plistPath, logPath, uninstalled: true };
+  }
+
+  const command = buildCommand({
+    syncScript,
+    owner: options.owner,
+    project: options.project,
+    author: options.author,
+    logPath,
+  });
+  const plist = buildPlist({
+    label: options.label,
+    command,
+    hour: options.hour,
+    minute: options.minute,
+    path: options.path,
+    home,
+    logPath,
+  });
+
+  if (options.dryRun) {
+    write(plist.trimEnd());
+    write(`Would write ${plistPath}`);
+    write(`Would run: launchctl ${plan.bootout.join(' ')}`);
+    write(`Would run: launchctl ${plan.bootstrap.join(' ')}`);
+    return { plistPath, logPath, plist, installed: false };
+  }
+
+  makeDirectory(agentsDirectory, { recursive: true });
+  makeDirectory(dirname(logPath), { recursive: true });
+  writeFile(plistPath, plist, 'utf8');
+
+  run('launchctl', plan.bootout, { encoding: 'utf8' });
+  const bootstrap = run('launchctl', plan.bootstrap, { encoding: 'utf8' });
+  if (bootstrap.status !== 0) {
+    throw new Error(
+      `launchctl bootstrap failed: ${String(bootstrap.stderr ?? '').trim() || 'unknown error'}`,
+    );
+  }
+
+  write(
+    `Installed ${options.label}: daily at ${String(options.hour).padStart(2, '0')}:${String(options.minute).padStart(2, '0')} local`,
+  );
+  write(`Plist ${plistPath}`);
+  write(`Log ${logPath}`);
+  return { plistPath, logPath, plist, installed: true };
+}
+
+function main() {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    if (options.help) {
+      process.stdout.write(usage());
+      return;
+    }
+    installSchedule(options);
+  } catch (error) {
+    console.error(String(error?.message ?? error));
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) main();

--- a/tooling/test/github-priority-queue.test.mjs
+++ b/tooling/test/github-priority-queue.test.mjs
@@ -1,0 +1,255 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  auditProjectItems,
+  buildIssueSearchArgs,
+  isTerminalStatus,
+  normalizeProjectItems,
+  parseArgs,
+  planQueueSync,
+  planStatusReconciliation,
+  resolveStatusOption,
+  sanitizeError,
+  syncPriorityQueue,
+} from '../scripts/github-priority-queue.mjs';
+
+const OPEN_URL = 'https://github.com/owner/repo/issues/1';
+const CLOSED_URL = 'https://github.com/owner/repo/issues/2';
+const MISSING_URL = 'https://github.com/owner/repo/issues/3';
+
+const ITEMS = {
+  items: [
+    {
+      id: 'ITEM_open',
+      status: 'Todo',
+      priority: 'P1 — Next',
+      'reasoning complexity': 'R2 — Judgment',
+      size: 'M — 1–2 days',
+      content: { url: OPEN_URL },
+    },
+    {
+      id: 'ITEM_closed',
+      status: 'In Progress',
+      priority: 'P2 — Soon',
+      'reasoning complexity': 'R1 — Routine',
+      size: 'XS — under 1 hr',
+      content: { url: CLOSED_URL },
+    },
+  ],
+};
+
+const FIELDS = {
+  fields: [
+    { id: 'PVTF_title', name: 'Title', type: 'ProjectV2Field' },
+    {
+      id: 'PVTSSF_status',
+      name: 'Status',
+      options: [
+        { id: 'opt_todo', name: 'Todo' },
+        { id: 'opt_done', name: 'Done' },
+      ],
+    },
+  ],
+};
+
+test('parseArgs accepts the status reconciliation flags and defaults them', () => {
+  const defaults = parseArgs(['--owner', 'o', '--project', '3', '--author', 'a']);
+  assert.equal(defaults.statusField, 'Status');
+  assert.equal(defaults.doneValue, 'Done');
+  assert.equal(defaults.apply, false);
+
+  const custom = parseArgs([
+    '--owner', 'o', '--project', '3', '--author', 'a',
+    '--status-field', 'State', '--done-value', 'Shipped', '--apply',
+  ]);
+  assert.equal(custom.statusField, 'State');
+  assert.equal(custom.doneValue, 'Shipped');
+  assert.equal(custom.apply, true);
+
+  assert.throws(() => parseArgs(['--owner', 'o', '--project', '3', '--author', 'a', '--nope', 'x']),
+    /Unknown argument/);
+});
+
+test('buildIssueSearchArgs searches one state at a time', () => {
+  assert.deepEqual(buildIssueSearchArgs('a', 5, 'closed').join(' '),
+    'search issues --author a --state closed --limit 5 --json url');
+  assert.equal(buildIssueSearchArgs('a').includes('open'), true);
+  assert.throws(() => buildIssueSearchArgs('a', 5, 'all'), /Unsupported issue state/);
+});
+
+test('normalizeProjectItems reads item ids and single-select values', () => {
+  const [first] = normalizeProjectItems(ITEMS);
+  assert.equal(first.itemId, 'ITEM_open');
+  assert.equal(first.url, OPEN_URL);
+  assert.equal(first.reasoningComplexity, 'R2 — Judgment');
+  assert.deepEqual(normalizeProjectItems({ items: [{ id: 'x' }] }), []);
+});
+
+test('isTerminalStatus compares case and whitespace insensitively', () => {
+  assert.equal(isTerminalStatus(' done ', 'Done'), true);
+  assert.equal(isTerminalStatus('Todo', 'Done'), false);
+  assert.equal(isTerminalStatus('', 'Done'), false);
+});
+
+test('planStatusReconciliation flags closed issues and never auto-reopens', () => {
+  const plan = planStatusReconciliation(ITEMS, {
+    closedUrls: new Set([CLOSED_URL]),
+    openUrls: new Set([OPEN_URL]),
+  });
+  assert.deepEqual(plan.toDone, [
+    { itemId: 'ITEM_closed', url: CLOSED_URL, status: 'In Progress' },
+  ]);
+  assert.deepEqual(plan.reopened, []);
+
+  const inverted = planStatusReconciliation(
+    { items: [{ id: 'ITEM_done', status: 'Done', content: { url: OPEN_URL } }] },
+    { closedUrls: new Set(), openUrls: new Set([OPEN_URL]) },
+  );
+  assert.deepEqual(inverted.toDone, []);
+  assert.deepEqual(inverted.reopened, [{ itemId: 'ITEM_done', url: OPEN_URL }]);
+});
+
+test('auditProjectItems ignores terminal items and reports missing size', () => {
+  const audit = auditProjectItems({
+    items: [
+      { id: 'a', status: 'Done', content: { url: CLOSED_URL } },
+      { id: 'b', status: 'Todo', content: { url: OPEN_URL } },
+    ],
+  });
+  assert.deepEqual(audit.missingPriority, [OPEN_URL]);
+  assert.deepEqual(audit.missingSize, [OPEN_URL]);
+  assert.equal(audit.reviewRequired, 1);
+});
+
+test('auditProjectItems still flags blocked or deferred P0 work', () => {
+  const audit = auditProjectItems({
+    items: [
+      {
+        id: 'a',
+        status: 'Todo',
+        priority: 'P0 — Now',
+        'reasoning complexity': 'R1 — Routine',
+        size: 'S — half day',
+        labels: [{ name: 'Blocked' }],
+        content: { url: OPEN_URL },
+      },
+    ],
+  });
+  assert.deepEqual(audit.blockedOrDeferredP0, [OPEN_URL]);
+  assert.equal(audit.reviewRequired, 0);
+});
+
+test('planQueueSync only reports issues absent from the project', () => {
+  const plan = planQueueSync([OPEN_URL, MISSING_URL], new Set([OPEN_URL]));
+  assert.deepEqual(plan.missing, [MISSING_URL]);
+  assert.equal(plan.unchanged, 1);
+});
+
+test('resolveStatusOption locates the field and terminal option', () => {
+  assert.deepEqual(resolveStatusOption(FIELDS, 'status', 'done'), {
+    fieldId: 'PVTSSF_status',
+    optionId: 'opt_done',
+  });
+  assert.throws(() => resolveStatusOption(FIELDS, 'Missing', 'Done'), /no field named Missing/);
+  assert.throws(() => resolveStatusOption(FIELDS, 'Title', 'Done'), /not a single-select/);
+  assert.throws(() => resolveStatusOption(FIELDS, 'Status', 'Shipped'), /no option named Shipped/);
+});
+
+test('sanitizeError redacts credentials', () => {
+  assert.equal(sanitizeError('failed ghp_abc123 here'), 'failed [redacted] here');
+  assert.equal(sanitizeError('auth Bearer xyz'), 'auth [redacted]');
+});
+
+function createRunner() {
+  const calls = [];
+  const run = (command, args) => {
+    calls.push(args.join(' '));
+    const joined = args.join(' ');
+    if (joined.startsWith('api user')) return { status: 0, stdout: 'sarthak' };
+    if (joined.startsWith('project view')) return { status: 0, stdout: '{"id":"PVT_1"}' };
+    if (joined.includes('--state open')) {
+      return { status: 0, stdout: JSON.stringify([{ url: OPEN_URL }, { url: MISSING_URL }]) };
+    }
+    if (joined.includes('--state closed')) {
+      return { status: 0, stdout: JSON.stringify([{ url: CLOSED_URL }]) };
+    }
+    if (joined.startsWith('project item-list')) {
+      return { status: 0, stdout: JSON.stringify(ITEMS) };
+    }
+    if (joined.startsWith('project field-list')) {
+      return { status: 0, stdout: JSON.stringify(FIELDS) };
+    }
+    if (joined.startsWith('project item-add')) return { status: 0, stdout: '{}' };
+    if (joined.startsWith('project item-edit')) return { status: 0, stdout: '{}' };
+    return { status: 1, stdout: '', stderr: `unexpected: ${joined}` };
+  };
+  return { calls, run };
+}
+
+const OPTIONS = { owner: 'o', project: 3, author: 'a', limit: 100 };
+
+test('dry run reports both directions without mutating the project', () => {
+  const { calls, run } = createRunner();
+  const lines = [];
+  const result = syncPriorityQueue({ ...OPTIONS, apply: false }, { run, write: (l) => lines.push(l) });
+
+  assert.equal(result.summary.mode, 'dry-run');
+  assert.equal(result.summary.missing, 1);
+  assert.equal(result.summary.added, 0);
+  assert.equal(result.summary.closedPending, 1);
+  assert.equal(result.summary.reconciled, 0);
+  assert.equal(result.exitCode, 0);
+  assert.equal(calls.some((call) => call.startsWith('project item-add')), false);
+  assert.equal(calls.some((call) => call.startsWith('project item-edit')), false);
+  assert.match(lines.join('\n'), /Closed issue not Done on board/);
+});
+
+test('apply adds missing issues and moves closed issues to Done', () => {
+  const { calls, run } = createRunner();
+  const result = syncPriorityQueue({ ...OPTIONS, apply: true }, { run, write: () => {} });
+
+  assert.equal(result.summary.added, 1);
+  assert.equal(result.summary.reconciled, 1);
+  assert.equal(result.summary.failed, 0);
+  assert.equal(result.exitCode, 0);
+  assert.equal(calls.filter((call) => call.startsWith('project item-add')).length, 1);
+  const edit = calls.find((call) => call.startsWith('project item-edit'));
+  assert.match(edit, /--id ITEM_closed/);
+  assert.match(edit, /--project-id PVT_1/);
+  assert.match(edit, /--field-id PVTSSF_status/);
+  assert.match(edit, /--single-select-option-id opt_done/);
+});
+
+test('apply skips the field lookup when nothing is stale', () => {
+  const { calls, run } = createRunner();
+  const noStale = { items: [ITEMS.items[0]] };
+  const patched = (command, args) => {
+    if (args.join(' ').startsWith('project item-list')) {
+      return { status: 0, stdout: JSON.stringify(noStale) };
+    }
+    return run(command, args);
+  };
+  const result = syncPriorityQueue({ ...OPTIONS, apply: true }, { run: patched, write: () => {} });
+
+  assert.equal(result.summary.closedPending, 0);
+  assert.equal(result.summary.reconciled, 0);
+  assert.equal(calls.some((call) => call.startsWith('project field-list')), false);
+});
+
+test('a failed status edit is reported and sets a nonzero exit code', () => {
+  const { run } = createRunner();
+  const patched = (command, args) => {
+    if (args.join(' ').startsWith('project item-edit')) {
+      return { status: 1, stdout: '', stderr: 'denied ghp_secret' };
+    }
+    return run(command, args);
+  };
+  const lines = [];
+  const result = syncPriorityQueue({ ...OPTIONS, apply: true }, { run: patched, write: (l) => lines.push(l) });
+
+  assert.equal(result.summary.reconciled, 0);
+  assert.equal(result.summary.failed, 1);
+  assert.equal(result.exitCode, 1);
+  assert.match(lines.join('\n'), /Failed .*issues\/2: denied \[redacted\]/);
+});

--- a/tooling/test/install-priority-queue-schedule.test.mjs
+++ b/tooling/test/install-priority-queue-schedule.test.mjs
@@ -1,0 +1,149 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildCommand,
+  buildPlist,
+  escapeXml,
+  installSchedule,
+  parseArgs,
+  planLaunchctl,
+} from '../scripts/install-priority-queue-schedule.mjs';
+
+const REQUIRED = ['--owner', 'o', '--project', '3', '--author', 'a'];
+
+test('parseArgs defaults to a daily morning run', () => {
+  const options = parseArgs(REQUIRED);
+  assert.equal(options.hour, 9);
+  assert.equal(options.minute, 20);
+  assert.equal(options.label, 'com.sarthak.priority-queue-sync');
+  assert.equal(options.uninstall, false);
+  assert.equal(options.dryRun, false);
+});
+
+test('parseArgs rejects out-of-range times and unsafe labels', () => {
+  assert.throws(() => parseArgs([...REQUIRED, '--hour', '24']), /--hour must be/);
+  assert.throws(() => parseArgs([...REQUIRED, '--minute', '60']), /--minute must be/);
+  assert.throws(() => parseArgs([...REQUIRED, '--label', 'a b/c']), /plain launchd label/);
+  assert.throws(() => parseArgs([...REQUIRED, '--nope', 'x']), /Unknown argument/);
+});
+
+test('parseArgs does not require project identity to uninstall', () => {
+  const options = parseArgs(['--uninstall']);
+  assert.equal(options.uninstall, true);
+  assert.equal(options.owner, undefined);
+});
+
+test('escapeXml neutralizes plist markup', () => {
+  assert.equal(escapeXml('a & b <c>'), 'a &amp; b &lt;c&gt;');
+});
+
+test('buildCommand quotes every operator-supplied value', () => {
+  const command = buildCommand({
+    syncScript: '/tmp/dir with space/sync.mjs',
+    owner: 'o',
+    project: 3,
+    author: 'a',
+    logPath: '/tmp/log with space.log',
+  });
+  assert.match(command, /^exec node "\/tmp\/dir with space\/sync\.mjs"/);
+  assert.match(command, /--apply >> "\/tmp\/log with space\.log" 2>&1$/);
+});
+
+test('buildPlist emits a calendar interval and no credentials', () => {
+  const plist = buildPlist({
+    label: 'com.example.job',
+    command: 'exec node "/tmp/sync.mjs" --apply',
+    hour: 7,
+    minute: 5,
+    path: '/opt/homebrew/bin:/usr/bin',
+    home: '/Users/example',
+    logPath: '/Users/example/Library/Logs/com.example.job.log',
+  });
+  assert.match(plist, /<key>Label<\/key>\n  <string>com\.example\.job<\/string>/);
+  assert.match(plist, /<key>Hour<\/key>\n    <integer>7<\/integer>/);
+  assert.match(plist, /<key>Minute<\/key>\n    <integer>5<\/integer>/);
+  assert.match(plist, /<key>RunAtLoad<\/key>\n  <false\/>/);
+  assert.doesNotMatch(plist, /token|secret|password|Bearer/i);
+});
+
+test('planLaunchctl targets the per-user gui domain', () => {
+  const plan = planLaunchctl('com.example.job', '/tmp/com.example.job.plist', 501);
+  assert.deepEqual(plan.bootout, ['bootout', 'gui/501/com.example.job']);
+  assert.deepEqual(plan.bootstrap, ['bootstrap', 'gui/501', '/tmp/com.example.job.plist']);
+});
+
+function harness(overrides = {}) {
+  const calls = [];
+  const written = [];
+  const removed = [];
+  const lines = [];
+  return {
+    calls,
+    written,
+    removed,
+    lines,
+    deps: {
+      run: (command, args) => {
+        calls.push(`${command} ${args.join(' ')}`);
+        return { status: 0, stdout: '', stderr: '' };
+      },
+      write: (line) => lines.push(line),
+      writeFile: (path, contents) => written.push({ path, contents }),
+      remove: (path) => removed.push(path),
+      makeDirectory: () => {},
+      home: '/Users/example',
+      uid: 501,
+      scriptDirectory: '/repo/tooling/scripts',
+      ...overrides,
+    },
+  };
+}
+
+test('dry run writes nothing and bootstraps nothing', () => {
+  const { calls, written, lines, deps } = harness();
+  const result = installSchedule({ ...parseArgs(REQUIRED), dryRun: true }, deps);
+
+  assert.equal(result.installed, false);
+  assert.deepEqual(calls, []);
+  assert.deepEqual(written, []);
+  assert.match(lines.join('\n'), /Would write \/Users\/example\/Library\/LaunchAgents/);
+});
+
+test('install writes the plist then reloads the agent', () => {
+  const { calls, written, deps } = harness();
+  const result = installSchedule(parseArgs(REQUIRED), deps);
+
+  assert.equal(result.installed, true);
+  assert.equal(written.length, 1);
+  assert.equal(
+    written[0].path,
+    '/Users/example/Library/LaunchAgents/com.sarthak.priority-queue-sync.plist',
+  );
+  assert.match(written[0].contents, /github-priority-queue\.mjs/);
+  assert.deepEqual(calls, [
+    'launchctl bootout gui/501/com.sarthak.priority-queue-sync',
+    'launchctl bootstrap gui/501 /Users/example/Library/LaunchAgents/com.sarthak.priority-queue-sync.plist',
+  ]);
+});
+
+test('a failed bootstrap is surfaced, not silently ignored', () => {
+  const { deps } = harness({
+    run: (_command, args) =>
+      args[0] === 'bootstrap'
+        ? { status: 5, stdout: '', stderr: 'Load failed' }
+        : { status: 0, stdout: '', stderr: '' },
+  });
+  assert.throws(() => installSchedule(parseArgs(REQUIRED), deps), /bootstrap failed: Load failed/);
+});
+
+test('uninstall boots out the agent and removes the plist', () => {
+  const { calls, removed, deps } = harness();
+  const result = installSchedule(parseArgs(['--uninstall']), deps);
+
+  assert.equal(result.uninstalled, true);
+  assert.deepEqual(calls, ['launchctl bootout gui/501/com.sarthak.priority-queue-sync']);
+  assert.deepEqual(removed, [
+    '/Users/example/Library/LaunchAgents/com.sarthak.priority-queue-sync.plist',
+  ]);
+});

--- a/tooling/test/structure.test.mjs
+++ b/tooling/test/structure.test.mjs
@@ -23,6 +23,7 @@ const activeScripts = new Set([
   'geo-observatory-record.mjs',
   'git-health.sh',
   'github-priority-queue.mjs',
+  'install-priority-queue-schedule.mjs',
   'install-skill-run-hook.mjs',
   'link-project-agent-assets.sh',
   'unlink-project-agent-assets.sh',


### PR DESCRIPTION
## Why

`github-priority-queue.mjs` only ever *added* missing open issues. An issue closed at the source stayed on the board as Todo or In Progress indefinitely — two rows had drifted that way within three days (`kith#4`, `agent-office#58`). Separately, the audit counted all 404 Done rows toward `review_required`, drowning the signal from the ~34 rows that actually need review.

## What

- Discover closed issues too, and move their board items to the terminal status.
- Report the inverse drift (board says Done, issue is open) **without changing it** — reopening or closing an issue is a human decision. This immediately surfaced `agent-office#57`, which was auto-closed by a `Closes` keyword and deliberately reopened.
- Skip terminal items in the audit, and audit the new `Size` field.
- `--status-field` / `--done-value` so the terminal state is not hardcoded.
- Lazy field lookup: a clean run costs no extra API call.

`install-priority-queue-schedule.mjs` installs a per-user launchd agent that runs the sync daily using the operator's existing `gh` authentication. launchd rather than a scheduled workflow because Actions would need a cross-org PAT with `project` scope, and `check-github-actions-policy.mjs` caps schedules at weekly. **The installer writes no credential of any kind.**

## Verification

- 25 new tests; `tooling:check` green on this branch (68 tests, 88 Node scripts validated).
- Dry run asserted to issue zero mutations; a failed status edit asserted to redact credentials and exit nonzero.
- Live: applied against project 3 (10 items added, 2 stale rows reconciled, 0 failures), and the launchd agent verified end to end with `last exit code = 0`.

Branched from latest `origin/main` in a separate worktree to avoid disturbing the concurrent `fix/report-absent-cf-targets` session in the main checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)