### PR TITLE
feat(tooling): commit the Apple skills with execution profiles

### DIFF
--- a/tooling/skills/apple-native/SKILL.md
+++ b/tooling/skills/apple-native/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: apple-native
+description: Build, review, test, and qualify Swift or SwiftUI applications across iOS, iPadOS, macOS, and watchOS. Covers Xcode and XcodeGen projects, platform boundaries, entitlements, simulator and physical-device QA, native accessibility, lifecycle, sync, and release preparation. Use for implementation or native product QA, not upload operations.
+---
+
+# Apple-native engineering and QA
+
+## Start with the repository
+
+Read the nearest `AGENTS.md`, `README`, product/design context, project status,
+and the project generator source. Inspect the schemes and targets before
+editing. Check the installed toolchain with read-only commands such as:
+
+```bash
+xcode-select -p
+xcodebuild -version
+xcodebuild -showsdks
+xcodebuild -project <project>.xcodeproj -list
+```
+
+Use the repository's package manager and test scripts. If the repository says
+not to run terminal `xcodebuild`, use its documented Xcode or non-Xcode path.
+Do not weaken signing, entitlements, or production configurations merely to
+make a local build pass; use an explicitly named local-only configuration.
+
+## Implementation rules
+
+- Treat SwiftUI, UIKit, AppKit, and Apple's current design resources as the
+  upstream Apple UI system. Start with native controls, containers, navigation,
+  presentation, typography, symbols, materials, and accessibility behavior; do
+  not import a monolithic third-party visual kit to make an Apple app resemble a
+  web product. Bridge to UIKit or AppKit when SwiftUI lacks a mature native
+  capability. Add a focused package only for a concrete missing behavior, not
+  as the default design language.
+- Keep platform differences behind clear platform boundaries. Share domain
+  logic and design tokens where they are truly shared; do not force iPhone,
+  Mac, and Watch into one cramped screen model.
+- Treat SwiftData/Core Data/CloudKit schema changes as runtime compatibility
+  work. Check optionality, defaults, migrations, containers, environments, and
+  sync behavior rather than trusting compilation.
+- Treat capabilities and entitlements as a contract: iCloud/CloudKit, App
+  Groups, push, Sign in with Apple, HealthKit, widgets, Live Activities, and
+  other services must agree across target settings, entitlements, App IDs, and
+  provisioning profiles.
+- Prefer native controls and platform conventions. Validate Dynamic Type,
+  VoiceOver, keyboard navigation on Mac, pointer/hover behavior, focus, touch
+  targets, reduced motion, dark/light appearance, localization expansion, and
+  permission denial paths.
+- Test real content and lifecycle transitions: empty, loading, error, offline,
+  slow sync, background/foreground, termination/relaunch, device rotation or
+  window resizing, sleep/wake, interrupted sessions, and account changes.
+
+## Verification ladder
+
+Run the smallest relevant check first, then widen only when it passes:
+
+1. Swift package or focused unit tests.
+2. Compile the changed target and its extensions.
+3. UI tests for the primary flow and the most important failure path.
+4. Simulator runs on representative iPhone/iPad/Mac configurations.
+5. Physical-device verification for capabilities that simulators cannot prove:
+   push, CloudKit production behavior, Sign in with Apple, camera, sensors,
+   background execution, Live Activities, Watch communication, and real
+   performance or thermal behavior.
+6. Capture screenshots or recordings with the exact OS, device/window size,
+   build, seed data, and entry path. Keep demo data isolated from user data.
+
+For Mac, inspect compact, standard, wide, and tall windows; menus, commands,
+keyboard shortcuts, focus rings, toolbar states, multi-window behavior,
+sidebar resizing, and full-screen/restore behavior. For Watch, qualify it as a
+focused remote or companion where appropriate, not automatically as a small
+copy of the iPhone app.
+
+## Release preparation handoff
+
+Before handing work to `apple-release`, record:
+
+- source commit and generated-project state;
+- schemes, configurations, bundle IDs, marketing version, and build numbers;
+- target matrix and test commands/results;
+- entitlements and capabilities intentionally required;
+- privacy manifests, usage descriptions, export-compliance facts, and any
+  reviewer test account or notes;
+- known limitations and physical-device checks still pending.
+
+The release skill owns archive, upload, Apple processing, TestFlight, App Review,
+and notarization. This skill owns whether the app is technically and
+experientially ready to enter those gates.
+
+For platform-specific UI decisions, consult Apple's current [Human Interface
+Guidelines](https://developer.apple.com/design/human-interface-guidelines/) and
+keep the project's `DESIGN.md` and product context authoritative where they are
+more specific.

--- a/tooling/skills/apple-native/agents/openai.yaml
+++ b/tooling/skills/apple-native/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Apple Native"
+  short_description: "Build and qualify native Apple apps"
+  default_prompt: "Use $apple-native to build or qualify this Swift, iOS, macOS, or watchOS app."

--- a/tooling/skills/apple-native/execution-profile.json
+++ b/tooling/skills/apple-native/execution-profile.json
@@ -1,0 +1,7 @@
+{
+  "schema": "fleet.skill-execution-profile.v1",
+  "recommended": { "intelligence": "frontier", "reasoning": "high" },
+  "minimum": { "intelligence": "balanced", "reasoning": "high" },
+  "degradation": "ask",
+  "rationale": "Native implementation work turns on judgment a weaker model gets wrong quietly: SwiftData and CloudKit schema edits are runtime compatibility changes that still compile, platform boundaries decide what is genuinely shared versus cramped into one screen model, and entitlements must not be weakened to make a local build pass. High reasoning is the floor because the failure mode is a passing build that breaks users at runtime."
+}

--- a/tooling/skills/apple-platform/SKILL.md
+++ b/tooling/skills/apple-platform/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: apple-platform
+description: Route Apple-native application work and Apple distribution work for iOS, iPadOS, macOS, and watchOS. Use when building Swift or SwiftUI apps, testing native targets, preparing archives, shipping through TestFlight or the App Store, notarizing direct-download Mac software, or diagnosing Apple Developer and App Store Connect blockers.
+---
+
+# Apple platform
+
+Use this as the entry point for Apple work. Route to the smallest focused
+workflow:
+
+| Request | Skill |
+|---|---|
+| Build or review Swift, SwiftUI, UIKit, AppKit, iOS, macOS, or watchOS code | `../apple-native/SKILL.md` |
+| Archive, sign, upload, process, distribute, notarize, submit, or deal with Apple | `../apple-release/SKILL.md` |
+| Native UI direction or polish | `../design-workflow/SKILL.md`, then the native skill |
+
+## Shared operating contract
+
+1. Read the nearest `AGENTS.md`, `README`, `PRODUCT.md`, `DESIGN.md`, and
+   `PROJECT_STATUS.md` before acting. Treat the owning repository as the source
+   of truth.
+2. Identify the project source: `.xcodeproj`, `.xcworkspace`, Swift Package,
+   `project.yml`/XcodeGen, or another generator. Edit the source and regenerate
+   generated projects; never hand-edit generated output.
+3. Keep iOS/iPadOS/watchOS App Store distribution, Mac App Store distribution,
+   and direct-download Developer ID distribution as separate channels. Their
+   entitlements, signing identities, export options, and acceptance gates differ.
+4. Keep receipts separate: source/build, tests, archive, validation/export,
+   upload, Apple processing, compliance, TestFlight assignment/install, App
+   Review, notarization/stapling, and physical-device or clean-machine proof.
+   An upload or passing local test is never a release receipt.
+5. Never read, print, commit, or place Apple passwords, private API keys,
+   provisioning profiles, certificates, or credential contents in source,
+   command arguments, logs, screenshots, or memory. Prefer the existing desktop
+   Keychain or the user's already-configured local key reference and scoped team
+   API keys. The personal Apple Developer/App Store Connect account active on
+   this Mac is the default; do not ask the user to choose an account or silently
+   switch teams.
+6. For drift-prone Apple behavior, check the current official Apple links in the
+   focused skill before relying on remembered commands or requirements. Do not
+   use third-party tutorials as the authority for signing, App Review, or
+   notarization.
+
+## Desktop personal-account mode
+
+Use the user's desktop as the operating environment: installed Xcode, login
+Keychain, connected simulators/devices, and the regular signed-in Chrome profile
+when Apple Developer or App Store Connect requires browser participation. Use a
+clean/isolated browser profile only for an explicitly requested clean-session
+test.
+
+Do one complete read-only preflight before asking anything. Once the user has
+authorized the requested release, carry that authorization through all in-scope
+build, upload, polling, assignment, and verification steps without asking again
+at every stage. Stop only for a genuine external blocker such as missing
+personal-account access, expired/missing credentials, a required Apple
+acceptance/2FA action, or an unavailable physical device; report the blocker and
+the single smallest action needed.
+
+## Completion language
+
+Report exactly which gates passed and which remain pending. Use phrases such as
+`archive validated`, `upload accepted`, `processing VALID`, `internal TestFlight
+installed`, `external beta review approved`, `notarization accepted and ticket
+stapled`, and `App Review accepted`; do not collapse these into `released`.

--- a/tooling/skills/apple-platform/agents/openai.yaml
+++ b/tooling/skills/apple-platform/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Apple Platform"
+  short_description: "Build and ship Apple apps safely"
+  default_prompt: "Use $apple-platform to build, test, or release an iOS or Mac application."

--- a/tooling/skills/apple-platform/execution-profile.json
+++ b/tooling/skills/apple-platform/execution-profile.json
@@ -1,0 +1,7 @@
+{
+  "schema": "fleet.skill-execution-profile.v1",
+  "recommended": { "intelligence": "balanced", "reasoning": "high" },
+  "minimum": { "intelligence": "balanced", "reasoning": "medium" },
+  "degradation": "ask",
+  "rationale": "This is the Apple entry point: it reads the request and routes to the focused implementation or release skill, so most of its own work is dispatch rather than execution. It still carries the shared operating contract, and misrouting release work into the native skill would skip the release gates, so it asks before degrading rather than allowing it silently."
+}

--- a/tooling/skills/apple-release/SKILL.md
+++ b/tooling/skills/apple-release/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: apple-release
+description: "Qualify and deliver Apple applications end to end: Xcode archives, signing and entitlements, App Store Connect uploads, TestFlight internal and external testing, App Review submission, Mac App Store distribution, Developer ID signing, notarization, stapling, Gatekeeper checks, and Apple account/support diagnosis. Use when the user explicitly authorizes an Apple-side release action or asks for release readiness."
+---
+
+# Apple release and distribution
+
+This workflow is intentionally gate-based. Obtain one clear authorization for
+the exact app, platform, version/build, and distribution channel, then carry it
+through every in-scope release step without repeatedly asking for confirmation.
+Do not ask the user for credentials that are already configured on the desktop.
+
+## 1. Preflight
+
+Read the owning repo's `AGENTS.md`, release script, project status, generator
+source, and current branch/CI state. Confirm with read-only inspection:
+
+- active Xcode and SDKs;
+- bundle IDs, schemes, configurations, version, and build number;
+- target graph, extensions, embedded apps, capabilities, entitlements, and
+  provisioning expectations;
+- clean/isolated build and artifact directories;
+- Apple account/team access and the exact credential mechanism, without printing
+  credential contents;
+- current Apple upload requirements and statuses in the official docs linked
+  below.
+
+### Personal desktop defaults
+
+Use the personal Apple Developer/App Store Connect account already configured on
+the user's Mac. Resolve identity from non-secret metadata only: active Xcode
+team, certificate names, App Store Connect app/team metadata, and configured
+Keychain profiles. Do not ask which account to use, switch to another team, or
+request a password/private key when the personal desktop setup is available.
+
+Credential resolution order:
+
+1. Existing Keychain-backed profile or repository-documented secure reference.
+2. A local API-key file already configured by the user on the desktop, accessed
+   without printing or copying its contents.
+3. A hidden interactive credential setup only when no configured mechanism works.
+
+Never put a private key, app-specific password, JWT, or normal Apple password in
+an argument, log, repository file, screenshot, or chat. Preflight all of this
+before the first mutation so a release does not stop halfway for a predictable
+credential or account question.
+
+Do not reuse a build number. Do not assume the team API key's key ID is the
+issuer ID. Do not call a generated `.xcodeproj` the source when the repository
+uses XcodeGen or another generator.
+
+## 2. iOS/iPadOS/watchOS App Store and TestFlight
+
+The normal ladder is:
+
+1. Run the repository's focused tests, target builds, UI tests, and device gates.
+2. Generate the project if required, then create a distribution archive for the
+   intended target and destination. Mac Catalyst/iPad and Mac Catalyst/Mac
+   archives are separate products when applicable.
+3. Validate/export with Xcode's distribution workflow or the repository's
+   proven CLI path. Record validation warnings and errors, not only exit code.
+4. Inspect the resulting IPA/app: version and build, bundle IDs, embedded
+   extensions/watch app, architectures, provisioning, signatures, entitlements,
+   privacy manifests, usage descriptions, `get-task-allow`, and production vs
+   development CloudKit environment.
+5. Upload through the simplest authenticated path supported by the current
+   repository and Apple docs. Xcode is preferred for ordinary distribution;
+   Transporter/JWT or `xcrun altool` may be used when the repo has a tested path.
+   Keep API private keys in their secure store. Team API-key flows require both
+   key ID and issuer ID; app-specific passwords are not interchangeable with
+   team API keys.
+6. Wait for Apple's server-side processing. `upload succeeded` means transfer,
+   not TestFlight availability. Record the Apple build/status and any warnings.
+7. Resolve export-compliance and encryption questions before assigning or
+   submitting the build. A build marked Missing Compliance is not ready.
+8. Add the exact build to an internal TestFlight group, install it, and exercise
+   the real primary journeys on the intended physical device(s).
+9. For external testers, provide beta test information and submit the first
+   build for TestFlight beta review when Apple requires it. Record approval,
+   rejection, or pending status separately from the upload.
+10. For App Review, complete platform-specific metadata, screenshots/previews,
+    age rating, privacy details, export compliance, contact/reviewer notes,
+    durable demo credentials where login is required, and a reproducible test
+    path. Select the processed build, add it to the platform submission, and
+    record App Review status and messages.
+
+After authorization, continue automatically through upload polling, compliance
+checks, build assignment, and available local/browser/device verification. Use
+the regular signed-in Chrome profile for App Store Connect or Developer portal
+steps that cannot be completed through a supported CLI/API. Ask the user only
+when Apple requires an unavoidable human action such as 2FA, an agreement,
+account recovery, or a physical-device interaction that is not available.
+
+## 3. macOS distribution
+
+Choose the channel before signing:
+
+### Mac App Store/TestFlight
+
+Use the Mac App Store distribution configuration and App Store Connect flow.
+The App Store process supplies the equivalent security review; do not invent a
+Developer ID notarization gate for a Mac App Store build. Still verify archive,
+upload, processing, compliance, TestFlight, and App Review gates.
+
+### Direct download
+
+1. Archive/export with a `Developer ID Application` identity and the intended
+   direct-distribution entitlements.
+2. Verify every nested executable and bundle, hardened runtime, secure
+   timestamp, absence of true `com.apple.security.get-task-allow`, correct
+   entitlements, and no debug/provisioning leakage.
+3. Package the app as the intended DMG/ZIP/PKG, then sign the distributable
+   package where the channel requires it.
+4. Submit with `xcrun notarytool` or the Notary API using Keychain-backed
+   credentials. `altool` is not the current notary path.
+5. Read the notary log even after success; warnings can still affect users.
+6. Staple with `xcrun stapler staple`, validate with `xcrun stapler validate`,
+   and check Gatekeeper with `spctl` on a clean or suitably isolated Mac.
+7. Reopen, install, update, uninstall, and launch the exact packaged artifact.
+
+Notarization is automated malware/code-signing assessment, not App Review. A
+notarized DMG is not an App Store release.
+
+## 4. Apple account and support diagnosis
+
+When blocked, classify the blocker before changing anything:
+
+- membership, agreements, tax/banking, legal entity, or compliance review;
+- team role or app access;
+- certificate, App ID, capability, entitlement, or provisioning mismatch;
+- unsupported Xcode/SDK/upload requirement;
+- invalid binary or missing compliance;
+- Apple processing, TestFlight beta review, App Review, or tester assignment;
+- local Keychain, Xcode, network, or credential failure.
+
+Capture the exact platform, version/build, timestamp, delivery ID, status, and
+sanitized log excerpt. Never paste private keys or passwords into a support
+case. Use Apple's Feedback Assistant or Developer Support when App Store
+status is unclear, and include the version/build, upload time, and relevant
+logs as Apple requests.
+
+When a blocker occurs, do not restart the conversation with repeated generic
+questions. Preserve the preflight facts, name the exact failed gate, try all
+safe local alternatives, and return one concise blocker with the smallest
+required user action. Resume from the failed gate after that action instead of
+repeating completed work.
+
+## 5. Release receipt
+
+Return a table or compact checklist with separate states for:
+
+`source` · `tests` · `archive` · `validation/export` · `artifact inspection` ·
+`upload` · `Apple processing` · `export compliance` · `TestFlight assignment` ·
+`physical install/journey` · `external beta review` · `App Review` ·
+`Developer ID signature` · `notarization` · `stapling` · `Gatekeeper/clean Mac`
+
+Only call a channel released when all gates relevant to that channel are proven.
+
+## Current official references
+
+Check these pages live when the workflow is drift-sensitive:
+
+- [Distributing apps for beta testing and releases](https://developer.apple.com/documentation/xcode/distributing-your-app-for-beta-testing-and-releases/)
+- [Preparing apps for distribution](https://developer.apple.com/documentation/xcode/preparing-your-app-for-distribution)
+- [App Store Connect: upload builds](https://developer.apple.com/help/app-store-connect/manage-builds/upload-builds/)
+- [TestFlight overview](https://developer.apple.com/help/app-store-connect/test-a-beta-version/testflight-overview)
+- [App build statuses](https://developer.apple.com/help/app-store-connect/reference/app-build-statuses/)
+- [Export compliance](https://developer.apple.com/help/app-store-connect/manage-app-information/overview-of-export-compliance)
+- [Submitting for App Review](https://developer.apple.com/help/app-store-connect/manage-submissions-to-app-review/overview-of-submitting-for-review/)
+- [App Review Guidelines](https://developer.apple.com/app-store/review/guidelines/)
+- [Generating App Store Connect API tokens](https://developer.apple.com/documentation/appstoreconnectapi/generating-tokens-for-api-requests)
+- [Creating App Store Connect API keys](https://developer.apple.com/documentation/appstoreconnectapi/creating-api-keys-for-app-store-connect-api)
+- [Notarizing macOS software](https://developer.apple.com/documentation/security/notarizing-macos-software-before-distribution)
+- [Customizing notarization](https://developer.apple.com/documentation/security/customizing-the-notarization-workflow)
+- [Capabilities overview](https://developer.apple.com/help/account/capabilities/capabilities-overview)

--- a/tooling/skills/apple-release/agents/openai.yaml
+++ b/tooling/skills/apple-release/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Apple Release"
+  short_description: "Ship through Apple with receipts"
+  default_prompt: "Use $apple-release to qualify or deliver this Apple app through TestFlight, App Review, or notarization."

--- a/tooling/skills/apple-release/execution-profile.json
+++ b/tooling/skills/apple-release/execution-profile.json
@@ -1,0 +1,7 @@
+{
+  "schema": "fleet.skill-execution-profile.v1",
+  "recommended": { "intelligence": "frontier", "reasoning": "high" },
+  "minimum": { "intelligence": "balanced", "reasoning": "high" },
+  "degradation": "deny",
+  "rationale": "Release actions are outward-facing and hard to reverse: App Store Connect uploads, TestFlight distribution, App Review submission, notarization, and stapling, all driven against real signing identities and credentials that must never be printed or copied. The skill is gate-based and keeps distribution channels and receipts separate. Degradation is denied rather than asked because a weaker model driving a signing or submission flow can take an irreversible action before anyone reviews it."
+}

--- a/tooling/test/capability-catalog.test.mjs
+++ b/tooling/test/capability-catalog.test.mjs
@@ -21,7 +21,7 @@ test('standalone capability catalog has valid roots and execution profiles', () 
   assert.equal(catalog.generatedFrom, 'sass-maker/saas-maker/tooling');
 
   const skills = catalog.items.filter((item) => item.type === 'skill');
-  assert.equal(skills.length, 48);
+  assert.equal(skills.length, 51);
   assert.equal(skills.every((skill) => skill.executionProfile), true);
   assert.equal(skills.every((skill) => skill.path.startsWith('skills/')), true);
 


### PR DESCRIPTION
## The bug

`pnpm tooling:check` **failed on the local machine** (exit 1, `tooling/test/capability-catalog.test.mjs`) with:

```
Cataloged skill is missing execution-profile.json.
  skills/apple-native/execution-profile.json
  skills/apple-platform/execution-profile.json
  skills/apple-release/execution-profile.json
```

Cause: those three skills existed only as **untracked working-tree directories**, each with a `SKILL.md` and `agents/openai.yaml` but no `execution-profile.json`. The capability catalog discovers skills by reading `skills/` (`readdirSync`), so it catalogued them and then failed validation. CI stayed green the whole time because CI never saw untracked files — the failure was local-only, and the skills were one `git clean` away from being lost entirely.

## The fix

Adds the missing `execution-profile.json` to each and commits all three skills. No `SKILL.md` content was changed.

| Skill | recommended | minimum | degradation | Why |
|---|---|---|---|---|
| `apple-native` | frontier/high | balanced/high | `ask` | SwiftData/CloudKit schema edits and entitlement changes still compile and fail at runtime; the failure mode is a green build that breaks users |
| `apple-platform` | balanced/high | balanced/medium | `ask` | Mostly a router to the focused skills, but misrouting release work into the native skill would skip the release gates |
| `apple-release` | frontier/high | balanced/high | `deny` | Uploads, TestFlight distribution, App Review submission, and notarization are outward-facing and hard to reverse — a weaker model can take an irreversible action before anyone reviews it |

Also updates the catalog test's expected skill count from 48 to 51.

Skills are auto-discovered by `readdirSync`, so no roster or `AGENTS.md` registration was needed.

## Verification

```
$ pnpm tooling:check
ℹ tests 91 / pass 91 / fail 0
Validated 51 skills, 90 Node scripts, 45 shell scripts, and the AI client
standard with 2 dated exception(s).

$ pnpm lint
Checked 209 files in 44ms. No fixes applied. Found 4 infos.

$ pnpm test
Test Files  9 passed (9) / Tests  43 passed (43)
```

`pnpm tooling:check` now exits 0 locally for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)