### PR TITLE
chore(tooling): ratify the canonical model-calling standard

### DIFF
--- a/tooling/config/ai-client-standard.json
+++ b/tooling/config/ai-client-standard.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
-  "status": "unratified",
-  "ratifiedAt": null,
+  "status": "ratified",
+  "ratifiedAt": "2026-08-29",
   "recommendedBy": "tooling/docs/ai-client-standard.md",
   "issue": "https://github.com/sass-maker/saas-maker/issues/61",
   "canonical": {
@@ -28,7 +28,11 @@
     "retiredHosts": []
   },
   "detection": {
-    "canonicalPackages": ["ai", "@ai-sdk/openai-compatible", "@ai-sdk/react"],
+    "canonicalPackages": [
+      "ai",
+      "@ai-sdk/openai-compatible",
+      "@ai-sdk/react"
+    ],
     "providerSdkPackages": [
       "openai",
       "@openai/agents",
@@ -55,7 +59,9 @@
       "api.perplexity.ai",
       "api.x.ai"
     ],
-    "scanIgnorePaths": ["tooling/test/fixtures/ai-client-audit"],
+    "scanIgnorePaths": [
+      "tooling/test/fixtures/ai-client-audit"
+    ],
     "gatewayEnvNames": [
       "AI_GATEWAY_URL",
       "AI_GATEWAY_BASE_URL",
@@ -95,5 +101,7 @@
       "note": "A vendored .next/standalone/package.json restates the dependency set. The audit skips .next, node_modules, and dist so the stale copy never reaches a verdict.",
       "blockedOn": "none"
     }
-  ]
+  ],
+  "ratifiedBy": "owner decision on https://github.com/sass-maker/saas-maker/issues/61",
+  "ratifiedDecision": "Every Fleet project that calls a hosted model goes through the free-ai gateway (ai-gateway.sassmaker.com) via its OpenAI-compatible paths. In JavaScript and TypeScript the client is the Vercel AI SDK at the pinned canonical versions. Runtimes without a JavaScript client still target the gateway; only the client library differs. Calling a provider API host directly is non-compliant regardless of which client library is used."
 }

--- a/tooling/docs/ai-client-standard.md
+++ b/tooling/docs/ai-client-standard.md
@@ -1,10 +1,21 @@
-# The canonical model-calling client — recommendation, not yet a rule
+# The canonical model-calling client — ratified
 
-**Status: recommendation, pending owner ratification.** Nothing here is
-enforced. `config/ai-client-standard.json` carries `"status": "unratified"` and
-`"ratifiedAt": null`, and the audit reports drift against it without failing any
-build. Picking the architecture is an owner decision; this document supplies the
-measurement and the trade-offs so that decision can be made on evidence.
+**Status: ratified 2026-08-29 by the owner on issue #61.**
+`config/ai-client-standard.json` carries `"status": "ratified"`.
+
+The rule: **every Fleet project that calls a hosted model goes through the
+free-ai gateway** (`ai-gateway.sassmaker.com`) via its OpenAI-compatible paths.
+In JavaScript and TypeScript the client is the Vercel AI SDK at the pinned
+canonical versions. Runtimes without a JavaScript client still target the
+gateway; only the client library differs. **Calling a provider API host directly
+is non-compliant regardless of which client library is used** — that is the gap
+the audit found in ten projects, including all three that were otherwise
+"compliant" on packages alone.
+
+Drift is still *reported rather than failed*, deliberately: 19 projects are
+hand-rolled today, and reddening `tooling:check` on known debt would train
+everyone to ignore it. Blocking findings remain narrow — a credential literal in
+tracked source, or a reference to a retired gateway host.
 
 Tracked by [issue #61](https://github.com/sass-maker/saas-maker/issues/61).
 
@@ -140,8 +151,9 @@ date. Two stand today:
 
 - **`rolepatch` pin convergence.** It declares `ai@^6.0.97` and
   `@ai-sdk/openai-compatible@^2.0.41` as ranges rather than exact pins. That is
-  a change in another repository and it is blocked on ratification — converging
-  onto an unratified pin would be enforcing a decision nobody has made.
+  a change in another repository, so it stays out of this repo's diff. It is
+  unblocked now that the standard is ratified and should be converged in
+  `rolepatch` itself.
 - **The stale `.next/standalone` copy in `rolepatch`** restates the dependency
   set from a build. The audit skips `.next`, so it never reaches a verdict and
   needs no cleanup to keep the report honest.

--- a/tooling/reports/ai-clients/latest.json
+++ b/tooling/reports/ai-clients/latest.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 1,
   "schema": "fleet.ai-client-audit.v1",
-  "generatedAt": "2026-08-29T12:44:23.625Z",
+  "generatedAt": "2026-08-29T16:19:05.884Z",
   "standard": {
-    "status": "unratified",
-    "ratifiedAt": null,
+    "status": "ratified",
+    "ratifiedAt": "2026-08-29",
     "option": "vercel-ai-sdk",
     "packages": {
       "ai": "6.0.168",
@@ -12,7 +12,7 @@
     },
     "issue": "https://github.com/sass-maker/saas-maker/issues/61"
   },
-  "advisory": true,
+  "advisory": false,
   "summary": {
     "projects": 56,
     "scanned": 56,
@@ -197,7 +197,7 @@
       "declared": [],
       "evidence": {
         "manifests": 1,
-        "filesScanned": 43,
+        "filesScanned": 52,
         "truncated": false,
         "gatewayHostFiles": 0,
         "providerHostFiles": 0,

--- a/tooling/scripts/ai-client-audit.mjs
+++ b/tooling/scripts/ai-client-audit.mjs
@@ -782,7 +782,13 @@ function renderText(report, { compact = false } = {}) {
     lines.push('', 'Blocking:');
     for (const entry of report.blocking) lines.push(`  - [${entry.code}] ${entry.message}`);
   } else {
-    lines.push('', 'No blocking findings. Drift is advisory until the standard is ratified.');
+    lines.push(
+      '',
+      report.advisory
+        ? 'No blocking findings. Drift is advisory until the standard is ratified.'
+        : 'No blocking findings. The standard is ratified; drift is a real gap to close, '
+          + 'but it is reported rather than failed so the gate does not redden on known debt.'
+    );
   }
   return lines.join('\n');
 }

--- a/tooling/test/ai-client-audit.test.mjs
+++ b/tooling/test/ai-client-audit.test.mjs
@@ -56,12 +56,14 @@ function auditFixtures(ids) {
   });
 }
 
-test('the shipped standard validates and is still unratified', () => {
+test('the shipped standard validates and is ratified with a date', () => {
   const { valid, problems } = validateStandard(standard);
   assert.deepEqual(problems, []);
   assert.equal(valid, true);
-  assert.equal(standard.status, 'unratified');
-  assert.equal(standard.ratifiedAt, null);
+  assert.equal(standard.status, 'ratified');
+  assert.match(standard.ratifiedAt, /^\d{4}-\d{2}-\d{2}$/u);
+  assert.equal(standard.canonical.option, 'vercel-ai-sdk');
+  assert.equal(standard.gateway.host, 'ai-gateway.sassmaker.com');
 });
 
 test('validateStandard rejects loose pins, undated exceptions, and claimed ratification', () => {
@@ -79,7 +81,15 @@ test('validateStandard rejects loose pins, undated exceptions, and claimed ratif
 
   const claimed = structuredClone(standard);
   claimed.status = 'ratified';
+  claimed.ratifiedAt = null;
   assert.match(validateStandard(claimed).problems.join('\n'), /requires ratifiedAt/u);
+
+  const staleUnratified = structuredClone(standard);
+  staleUnratified.status = 'unratified';
+  assert.match(
+    validateStandard(staleUnratified).problems.join('\n'),
+    /must carry ratifiedAt: null/u
+  );
 });
 
 test('package manifests are read across the workspace and skip build output', () => {
@@ -226,7 +236,7 @@ test('classifyProject needs no filesystem and covers every verdict name', () => 
   assert.deepEqual([...seen].sort(), [...VERDICTS].sort());
 });
 
-test('the report summarises every verdict bucket and stays advisory while unratified', () => {
+test('the report summarises every verdict bucket and is binding once ratified', () => {
   const report = auditFixtures([
     'compliant-project',
     'drifted-project',
@@ -235,8 +245,8 @@ test('the report summarises every verdict bucket and stays advisory while unrati
     'plain-project',
   ]);
   assert.equal(report.schema, 'fleet.ai-client-audit.v1');
-  assert.equal(report.advisory, true);
-  assert.equal(report.standard.status, 'unratified');
+  assert.equal(report.advisory, false);
+  assert.equal(report.standard.status, 'ratified');
   assert.deepEqual(report.summary, {
     projects: 5,
     scanned: 5,


### PR DESCRIPTION
## The decision

Owner call on #61:

> All should be using my free-AI endpoint, sdk vercel is fine across

Recorded as the ratified rule: **every Fleet project that calls a hosted model goes through the free-ai gateway** (`ai-gateway.sassmaker.com`) via its OpenAI-compatible paths. In JS/TS the client is the Vercel AI SDK at the pinned canonical versions. Runtimes without a JavaScript client still target the gateway; only the client library differs.

The consequence worth stating explicitly, now written into the config and the doc: **calling a provider API host directly is non-compliant regardless of client library.** That is the real gap the audit surfaced — ten projects call provider hosts directly, including all three that looked "compliant" on declared packages alone. Package choice was never the problem; gateway adoption is.

## What changed

- **config** — `status: ratified`, `ratifiedAt: 2026-08-29`, plus `ratifiedBy` and the decision text.
- **docs** — rewritten from "recommendation, not yet a rule" to the ratified rule, including why drift stays reported rather than failed, and the `rolepatch` follow-up unblocked.
- **script** — the summary line "Drift is advisory until the standard is ratified" was unconditional, so it printed a falsehood the moment the standard was ratified. It now branches on `report.advisory`.
- **tests** — three tests hardcoded the shipped standard as unratified. They now assert the ratified contract; the rejection case that depended on the shipped file being unratified builds its own invalid clone, so it still covers both directions (`ratified` without a date, and `unratified` with one).
- **report** — regenerated via `pnpm tooling:ai-clients`; `advisory` is now `false`.

## Enforcement posture — deliberately unchanged

Drift is still **reported, not failed**. 19 projects are hand-rolled today; reddening `tooling:check` on known debt trains everyone to ignore it. Blocking findings stay narrow: a credential literal in tracked source, or a reference to a retired gateway host. Say the word if you'd rather it hard-fail and we can flip it once the migration lands.

## Verification

```
$ pnpm tooling:check
ℹ tests 91 / pass 91 / fail 0
AI client audit — standard ratified (option: vercel-ai-sdk)
No blocking findings. The standard is ratified; drift is a real gap to close,
but it is reported rather than failed so the gate does not redden on known debt.

$ pnpm lint
Checked 209 files in 52ms. No fixes applied. Found 4 infos.

$ pnpm test
Test Files  9 passed (9) / Tests  43 passed (43)
```

Refs #61 — the issue stays open until the 29 non-compliant projects are actually migrated onto the gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)