### PR TITLE
tooling: agent-ready checks name agreement and HEAD/GET parity

### DIFF
--- a/tooling/docs/agent-indexing-standard.md
+++ b/tooling/docs/agent-indexing-standard.md
@@ -25,6 +25,55 @@ Per public **origin**:
 | Public route markdown | Every **public** sitemap URL has a markdown alternate (`.md` and/or negotiation); audit every small-site route and a deterministic distributed sample for large corpora |
 | SPA honesty | Agent paths never return an HTML SPA shell for missing files |
 | robots + sitemap | Public crawl allowed; `Sitemap:` present; private/auth Disallow |
+| Name agreement | `/llms.txt`, `/api/ai` and JSON-LD all declare the canonical product name |
+| HEAD/GET parity | HEAD returns the same status class as GET on the agent endpoints and a route sample |
+
+### Name agreement
+
+Presence is what gets a surface read; agreement is what makes being read
+resolve to the right product. A surface that publishes two identities scores
+below S no matter how complete its Markdown is.
+
+Canonical name and aliases come from `config/entity-identity-canonical.json`
+(the decision record) layered over `geoIdentities[]` in the Site Health
+catalog (the applied form). The three channels are compared **exactly**, and
+each mismatch is classified:
+
+| Class | Meaning | Effect |
+|---|---|---|
+| `ok` | Channel declares the canonical name | — |
+| `casing` | Same name, different case — usually a repo slug (`posttrainllm`, `DRank`) | Check fails; no S-tier |
+| `slug-leak` | The repo slug where the product has a name (`psi-swarm` for `PSI Swarm`) | Check fails; no S-tier |
+| `retired-alias` | A recorded former name the surface never stopped publishing | Check fails; no S-tier |
+| `unrecorded` | A name that appears in **no** record for this id | Check fails **and floors the tier at C** |
+
+Case is never normalized away: `posttrainllm` and `DRank` differ from canonical
+by case alone and are both slugs leaking onto an agent surface. JSON-LD is read
+from the `WebSite` / `SoftwareApplication` node, never the first `name` in the
+document — that is usually the author's `Person` node and reports false drift
+on every surface that credits one.
+
+`unrecorded` is the only class that is not a record the fleet could correct.
+The surface asserts an identity nothing internal knows about, so an agent that
+reads it resolves to a different product; the rest of the surface being perfect
+does not help, which is why it floors the tier rather than costing one check.
+
+An origin with no canonical record (an ad-hoc URL target) is skipped, not
+failed. `tooling/scripts/entity-identity-live.mjs` shares the same
+classification and additionally probes `<title>` and the pricing declaration.
+
+### HEAD/GET parity
+
+Link checkers, crawlers and agent fetchers commonly send HEAD before GET. A
+GET-only audit scored `sassmaker.com` fully healthy while every interior route
+returned 404 to HEAD (#93). The audit now compares the status **class** of HEAD
+against GET for the four fixed agent endpoints plus a deterministic sample of
+sitemap routes (10), and fails the check on any disagreement.
+
+Each pair differs only in the method — the HEAD carries the same `Accept` as
+the GET it is compared with, so content negotiation is never mistaken for a
+routing defect. Only the sampled routes cost an extra GET; the endpoints reuse
+statuses the audit already collected.
 
 **S+ (agent-native products only):** `skill.md`, `/.well-known/skills/index.json`,
 install scripts, authenticated agent APIs. Karte is the reference.

--- a/tooling/lib/entity-name-agreement.mjs
+++ b/tooling/lib/entity-name-agreement.mjs
@@ -1,0 +1,296 @@
+/**
+ * Name agreement — does a live surface tell an agent the same name the fleet
+ * records say it has?
+ *
+ * agent-ready checked that /llms.txt, /api/ai and JSON-LD are PRESENT. It did
+ * not check that they AGREE, so eight surfaces scored S-tier while publishing a
+ * different product name to agents than the canonical record carries
+ * (sass-maker/saas-maker#94). Presence is what gets a surface read; agreement is
+ * what makes being read resolve to the right entity.
+ *
+ * Canonical order:
+ *   1. tooling/config/entity-identity-canonical.json — the record of what was
+ *      DECIDED, including decisions not yet applied to the catalog.
+ *   2. geoIdentities[] in the site-health catalog — the applied form of those
+ *      decisions, and the only place aliases are enumerated.
+ *
+ * The comparison is deliberately exact. Case is not cosmetic in a brand name:
+ * `posttrainllm` and `drank` differ from canonical by case alone and both are
+ * repo slugs leaking onto an agent surface, so normalizing case away would
+ * silently pass two real defects.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// lib → tooling → saas-maker → fleet root
+const TOOLING_ROOT = resolve(__dirname, '..');
+const FLEET_ROOT = resolve(__dirname, '../../..');
+
+export const CANONICAL_DECISIONS_PATH = join(
+  TOOLING_ROOT,
+  'config/entity-identity-canonical.json'
+);
+export const CATALOG_PATH =
+  process.env.FLEET_PUBLIC_PRODUCTS_PATH ??
+  join(FLEET_ROOT, 'site-health/apps/backend/config/projects.json');
+
+/**
+ * Drift classes, worst last. `unrecorded` is the only one that is not a record
+ * we could correct: the surface asserts a name that exists nowhere internally,
+ * so an agent resolving it lands on something the fleet has no row for.
+ */
+export const DRIFT_CLASSES = ['ok', 'casing', 'slug-leak', 'retired-alias', 'unrecorded'];
+
+const CHANNELS = ['llms.txt', '/api/ai', 'json-ld'];
+
+/** Slug form of a name: lowercase, runs of non-alphanumerics collapsed to `-`. */
+export function slugify(value) {
+  return String(value)
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, '-')
+    .replace(/^-|-$/g, '');
+}
+
+/** A value that is already in slug shape — lowercase, no spaces, hyphen/underscore joined. */
+function looksLikeSlug(value) {
+  return /^[a-z0-9]+(?:[-_.][a-z0-9]+)*$/.test(value);
+}
+
+/**
+ * Classify one observed name against the canonical record.
+ *
+ * @param {string} value observed name, exactly as published
+ * @param {{ name: string, aliases?: string[] }} canonical
+ * @returns {'ok'|'casing'|'slug-leak'|'retired-alias'|'unrecorded'}
+ */
+export function classifyName(value, canonical) {
+  const observed = String(value).trim();
+  const name = String(canonical?.name ?? '').trim();
+  const aliases = (canonical?.aliases ?? []).map((a) => String(a).trim());
+  if (!observed || !name) return 'unrecorded';
+  if (observed === name) return 'ok';
+  if (observed.toLowerCase() === name.toLowerCase()) return 'casing';
+  // A repo slug is classified as a slug leak even when it is a recorded alias:
+  // recording it stops it being unexplained, it does not make it a name the
+  // product goes by. psi-swarm publishes `psi-swarm` where the product is
+  // `PSI Swarm`, and that is a defect in the surface, not in the record.
+  if (looksLikeSlug(observed) && slugify(observed) === slugify(name)) return 'slug-leak';
+  if (aliases.some((alias) => alias === observed)) return 'retired-alias';
+  if (aliases.some((alias) => alias.toLowerCase() === observed.toLowerCase())) {
+    return 'retired-alias';
+  }
+  return 'unrecorded';
+}
+
+/** Worst (last-listed) class in a set. */
+export function worstClass(classes) {
+  let worst = 'ok';
+  for (const value of classes) {
+    if (DRIFT_CLASSES.indexOf(value) > DRIFT_CLASSES.indexOf(worst)) worst = value;
+  }
+  return worst;
+}
+
+/** llms.txt declares the product in its first markdown heading. */
+export function llmsName(text) {
+  if (!text) return null;
+  const line = text.split('\n').find((l) => l.trim().startsWith('#'));
+  return line ? line.replace(/^#+\s*/, '').trim() || null : null;
+}
+
+/** /api/ai declares it as `name` (some surfaces nest it under `product`). */
+export function apiAiName(text) {
+  if (!text) return null;
+  let data = text;
+  if (typeof text === 'string') {
+    try {
+      data = JSON.parse(text);
+    } catch {
+      return null;
+    }
+  }
+  const name = data?.name ?? data?.product?.name ?? null;
+  return typeof name === 'string' && name.trim() ? name.trim() : null;
+}
+
+/**
+ * The name a model reads from markup is the WebSite / application node — NOT
+ * the first `"name"` in the document, which is usually the Person node for the
+ * author and reports false drift on every surface that credits one.
+ * Organization is read only as a fallback, for surfaces that publish no
+ * WebSite/app node at all.
+ */
+export function jsonLdNames(html) {
+  if (!html) return [];
+  const primary = [];
+  const fallback = [];
+  const blocks = html.matchAll(
+    /<script[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi
+  );
+  for (const [, body] of blocks) {
+    let data;
+    try {
+      data = JSON.parse(body);
+    } catch {
+      continue;
+    }
+    const stack = [data];
+    while (stack.length) {
+      const node = stack.pop();
+      if (Array.isArray(node)) stack.push(...node);
+      else if (node && typeof node === 'object') {
+        const types = [node['@type']].flat().filter(Boolean);
+        if (node.name && typeof node.name === 'string') {
+          if (types.some((t) => ['WebSite', 'SoftwareApplication', 'WebApplication'].includes(t))) {
+            primary.push(node.name.trim());
+          } else if (types.includes('Organization')) {
+            fallback.push(node.name.trim());
+          }
+        }
+        stack.push(...Object.values(node));
+      }
+    }
+  }
+  return primary.length ? primary : fallback;
+}
+
+export function jsonLdName(html) {
+  return jsonLdNames(html)[0] ?? null;
+}
+
+/**
+ * Read the canonical identity record: geoIdentities as the applied form, with
+ * entity-identity-canonical.json decisions layered on top so a decision that
+ * has been made but not yet written into the catalog still governs.
+ *
+ * @returns {Map<string, { id: string, name: string, aliases: string[], origin: string|null }>}
+ */
+export function loadCanonicalIdentities({
+  catalogPath = CATALOG_PATH,
+  decisionsPath = CANONICAL_DECISIONS_PATH,
+} = {}) {
+  const identities = new Map();
+
+  if (existsSync(catalogPath)) {
+    const catalog = JSON.parse(readFileSync(catalogPath, 'utf8'));
+    for (const entry of catalog.geoIdentities ?? []) {
+      if (!entry?.id || !entry?.name) continue;
+      identities.set(entry.id, {
+        id: entry.id,
+        name: entry.name,
+        aliases: [...(entry.aliases ?? [])],
+        origin: entry.origin ?? null,
+      });
+    }
+  }
+
+  if (existsSync(decisionsPath)) {
+    const decisions = JSON.parse(readFileSync(decisionsPath, 'utf8'));
+    for (const decision of decisions.decisions ?? []) {
+      if (!decision?.id) continue;
+      const current = identities.get(decision.id) ?? {
+        id: decision.id,
+        name: decision.name ?? null,
+        aliases: [],
+        origin: decision.canonicalUrl ?? null,
+      };
+      const aliases = new Set(current.aliases);
+      for (const alias of decision.addAliases ?? []) aliases.add(alias);
+      if (decision.name && decision.name !== current.name) {
+        // A decided rename the catalog has not caught up with yet. The name it
+        // replaced stays resolvable as an alias when the decision retired it.
+        if (decision.retireNameToAlias && current.name) aliases.add(current.name);
+        current.name = decision.name;
+      }
+      if (!current.name) continue;
+      identities.set(decision.id, {
+        ...current,
+        aliases: [...aliases],
+        origin: decision.canonicalUrl ?? current.origin,
+      });
+    }
+  }
+
+  return identities;
+}
+
+/** Look an identity up by registry id, falling back to the origin's host. */
+export function canonicalIdentityFor(identities, { id, origin } = {}) {
+  if (id && identities.has(id)) return identities.get(id);
+  if (!origin) return null;
+  let host;
+  try {
+    host = new URL(origin).host;
+  } catch {
+    return null;
+  }
+  for (const identity of identities.values()) {
+    if (!identity.origin) continue;
+    try {
+      if (new URL(identity.origin).host === host) return identity;
+    } catch {
+      /* a malformed origin in the record is not this check's problem */
+    }
+  }
+  return null;
+}
+
+/**
+ * Grade the three agent-readable channels against the canonical record.
+ *
+ * Any drift fails the check, which is what stops a name-drifting surface
+ * scoring S-tier. `unrecorded` drift is reported as an identity conflict —
+ * the caller floors the tier on it, because a surface asserting a name that
+ * exists in no record resolves to a different product entirely.
+ *
+ * @param {{ canonical: object|null, observed: Record<string, string|null> }} input
+ */
+export function gradeNameAgreement({ canonical, observed }) {
+  if (!canonical) {
+    return {
+      status: 'skip',
+      detail: 'no canonical identity record for this origin',
+      data: { channels: [] },
+    };
+  }
+  const channels = [];
+  for (const channel of CHANNELS) {
+    const value = observed?.[channel];
+    if (value == null || value === '') continue;
+    channels.push({ channel, value, class: classifyName(value, canonical) });
+  }
+  if (channels.length === 0) {
+    return {
+      status: 'skip',
+      detail: `no name declared on any channel (canonical "${canonical.name}")`,
+      data: { canonicalId: canonical.id, canonicalName: canonical.name, channels: [] },
+    };
+  }
+  const drift = channels.filter((c) => c.class !== 'ok');
+  const worst = worstClass(channels.map((c) => c.class));
+  const data = {
+    canonicalId: canonical.id,
+    canonicalName: canonical.name,
+    worst,
+    identityConflict: worst === 'unrecorded',
+    channels,
+  };
+  if (drift.length === 0) {
+    return {
+      status: 'pass',
+      detail: `${channels.length} channel(s) declare "${canonical.name}"`,
+      data,
+    };
+  }
+  return {
+    status: 'fail',
+    detail:
+      `canonical "${canonical.name}" · ` +
+      drift.map((c) => `${c.channel}="${c.value}" (${c.class})`).join(', ') +
+      (worst === 'unrecorded' ? ' — identity conflict' : ''),
+    data,
+  };
+}

--- a/tooling/lib/head-parity.mjs
+++ b/tooling/lib/head-parity.mjs
@@ -1,0 +1,107 @@
+/**
+ * HEAD/GET parity — does a route answer the same to a HEAD probe as to a GET?
+ *
+ * The blind spot this closes (sass-maker/saas-maker#93): sassmaker.com returned
+ * 404 to HEAD on every interior route while returning 200 to GET, and scored
+ * S-tier, because the auditor only ever probed with GET. Link checkers, crawlers
+ * and agent fetchers commonly send HEAD first; those clients saw a directory
+ * whose pages did not exist.
+ *
+ * Each pair differs only in the method: the HEAD request carries the same
+ * Accept header as the GET it is compared with, so content negotiation is never
+ * mistaken for a routing defect.
+ *
+ * Cost control: the compared set is the fixed agent endpoints — whose GET
+ * statuses the audit already has — plus a small deterministic sample of sitemap
+ * routes. That is enough to catch a whole-site routing asymmetry, which is how
+ * this class of defect always presents, without doubling a 250-route sweep.
+ */
+
+/** 200 → 2, 404 → 4, network error → 0. */
+export function statusClass(status) {
+  const value = Number(status) || 0;
+  return value > 0 ? Math.floor(value / 100) : 0;
+}
+
+/**
+ * @param {{
+ *   probes: Array<{ url: string, label?: string, status: number, accept?: string }>,
+ *   head: (url: string, accept?: string) => Promise<{ status: number, error?: string }>,
+ *   concurrency?: number,
+ * }} input
+ */
+export async function gradeHeadParity({ probes, head, concurrency = 4 }) {
+  const comparable = (probes ?? []).filter(
+    (probe) => probe?.url && statusClass(probe.status) !== 0
+  );
+  if (comparable.length === 0) {
+    return {
+      status: 'skip',
+      detail: 'no GET-probed routes available to compare',
+      data: { checked: 0, matched: 0, mismatches: [] },
+    };
+  }
+
+  const results = await mapLimit(comparable, concurrency, async (probe) => {
+    const response = await head(probe.url, probe.accept);
+    const headStatus = Number(response?.status) || 0;
+    return {
+      url: probe.url,
+      label: probe.label ?? pathOf(probe.url),
+      get: Number(probe.status) || 0,
+      head: headStatus,
+      matched: statusClass(headStatus) === statusClass(probe.status),
+    };
+  });
+
+  const mismatches = results
+    .filter((result) => !result.matched)
+    .map(({ label, get, head: headStatus }) => ({
+      route: label,
+      get,
+      head: headStatus,
+    }));
+  const matched = results.length - mismatches.length;
+
+  if (mismatches.length === 0) {
+    return {
+      status: 'pass',
+      detail: `${matched}/${results.length} probed routes answer HEAD as they answer GET`,
+      data: { checked: results.length, matched, mismatches: [] },
+    };
+  }
+  return {
+    status: 'fail',
+    detail:
+      `${mismatches.length}/${results.length} routes disagree between HEAD and GET: ` +
+      mismatches
+        .slice(0, 5)
+        .map((m) => `${m.route} HEAD ${m.head || 'err'} vs GET ${m.get}`)
+        .join(', ') +
+      (mismatches.length > 5 ? `, +${mismatches.length - 5} more` : ''),
+    data: { checked: results.length, matched, mismatches: mismatches.slice(0, 20) },
+  };
+}
+
+function pathOf(url) {
+  try {
+    return new URL(url).pathname;
+  } catch {
+    return url;
+  }
+}
+
+async function mapLimit(values, limit, mapper) {
+  const results = new Array(values.length);
+  let next = 0;
+  async function worker() {
+    while (next < values.length) {
+      const index = next++;
+      results[index] = await mapper(values[index]);
+    }
+  }
+  await Promise.all(
+    Array.from({ length: Math.max(1, Math.min(limit, values.length)) }, () => worker())
+  );
+  return results;
+}

--- a/tooling/scripts/entity-identity-live.mjs
+++ b/tooling/scripts/entity-identity-live.mjs
@@ -39,6 +39,13 @@ import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
+import {
+  apiAiName,
+  classifyName,
+  jsonLdNames,
+  llmsName,
+} from '../lib/entity-name-agreement.mjs';
+
 const repoRoot = path.resolve(import.meta.dirname, '../..');
 const fleetRoot = path.resolve(repoRoot, '..');
 const catalogPath = path.resolve(
@@ -66,56 +73,11 @@ async function get(url) {
   }
 }
 
-/** llms.txt declares the product in its first markdown heading. */
-function llmsName(text) {
-  if (!text) return null;
-  const line = text.split('\n').find((l) => l.trim().startsWith('#'));
-  return line ? line.replace(/^#+\s*/, '').trim() || null : null;
-}
-
-function apiName(text) {
-  if (!text) return null;
-  try {
-    const data = JSON.parse(text);
-    return data.name ?? data.product?.name ?? null;
-  } catch {
-    return null;
-  }
-}
-
 /**
- * The name a model reads from markup is the WebSite / app node — NOT the first
- * "name" in the document, which is usually the Person node for the author and
- * will produce a false mismatch on every surface that credits one.
+ * Name extraction and drift classification are shared with agent-ready's
+ * auditor (tooling/lib/entity-name-agreement.mjs) so the two tools cannot
+ * disagree about what a surface declares or how a mismatch is classified.
  */
-function jsonLdNames(html) {
-  if (!html) return [];
-  const names = [];
-  const blocks = html.matchAll(
-    /<script[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi
-  );
-  for (const [, body] of blocks) {
-    let data;
-    try {
-      data = JSON.parse(body);
-    } catch {
-      continue;
-    }
-    const stack = [data];
-    while (stack.length) {
-      const node = stack.pop();
-      if (Array.isArray(node)) stack.push(...node);
-      else if (node && typeof node === 'object') {
-        const types = [node['@type']].flat().filter(Boolean);
-        if (types.some((t) => ['WebSite', 'SoftwareApplication', 'WebApplication'].includes(t))) {
-          if (node.name) names.push(String(node.name));
-        }
-        stack.push(...Object.values(node));
-      }
-    }
-  }
-  return names;
-}
 
 /** Fixed, not random: a stable control path keeps runs comparable. */
 const CONTROL_PATH = 'a7f3c9';
@@ -241,13 +203,12 @@ async function probeSurface(surface) {
 
   const observed = {
     'llms.txt': llmsName(llms),
-    '/api/ai': apiName(api),
+    '/api/ai': apiAiName(api),
     'json-ld': jsonLdNames(html)[0] ?? null,
   };
   const title = pageTitle(html);
   const titleDrift = titleVerdict(title, surface.name, surface.aliases);
 
-  const known = new Set([surface.name, ...surface.aliases].map((n) => n.toLowerCase()));
   const drift = Object.entries(observed).filter(([, value]) => value && value !== surface.name);
 
   return {
@@ -255,19 +216,15 @@ async function probeSurface(surface) {
     observed,
     title,
     drift: drift
-      .map(([channel, value]) => {
+      .map(([channel, value]) => ({
         // Case is not cosmetic in a brand name: "posttrainllm" is the repo
-        // slug leaking into an agent surface, not the product. Classify it
-        // rather than normalizing it away, or a focus-tier product publishing
-        // its slug to every agent endpoint reads as passing.
-        const kind =
-          value.toLowerCase() === surface.name.toLowerCase()
-            ? 'casing'
-            : known.has(value.toLowerCase())
-              ? 'retired-alias'
-              : 'unrecorded';
-        return { channel, value, kind };
-      })
+        // slug leaking into an agent surface, not the product. Classified
+        // rather than normalized away, or a focus-tier product publishing its
+        // slug to every agent endpoint reads as passing.
+        channel,
+        value,
+        kind: classifyName(value, surface),
+      }))
       .concat(titleDrift ?? []),
     pricingState: surface.pricing.state,
     pricingProbe,

--- a/tooling/skills/agent-ready/SKILL.md
+++ b/tooling/skills/agent-ready/SKILL.md
@@ -43,8 +43,22 @@ node skills/agent-ready/scripts/agent-index-audit.mjs --all --json
 | `sitemap` | `sitemap.xml` or `sitemap-index.xml` |
 | `route_markdown` | Public sitemap routes resolve as Markdown; large corpora use a deterministic 250-route sample |
 | `catalog_integrity` | Every bounded `/api/ai` surface has a same-origin, readable Markdown target listed in the sitemap |
+| `name_agreement` | `/llms.txt`, `/api/ai` and JSON-LD all declare the canonical product name |
+| `head_parity` | HEAD returns the same status class as GET on the agent endpoints and a 10-route sample |
 
 Implementation kit: `lib/agent-surfaces/`.
+
+Presence is not identity: a surface that publishes a different product name to
+agents than the canonical record carries cannot score S-tier, whatever its
+Markdown coverage. Mismatches are classified `casing`, `slug-leak`,
+`retired-alias` or `unrecorded`; an `unrecorded` name — one that appears in no
+record for that id — floors the tier at C. Canonical names come from
+`config/entity-identity-canonical.json` over the Site Health catalog's
+`geoIdentities[]`. Full rules in
+[`docs/agent-indexing-standard.md`](../../docs/agent-indexing-standard.md).
+
+`head_parity` closes the matching blind spot on verbs: a route that answers 200
+to GET and 404 to HEAD is invisible to the crawlers that probe with HEAD first.
 
 The audit reports and the Fleet visibility ledger retain:
 

--- a/tooling/skills/agent-ready/scripts/agent-index-audit.mjs
+++ b/tooling/skills/agent-ready/scripts/agent-index-audit.mjs
@@ -20,8 +20,13 @@
  * Required checks: llms.txt, /api/ai, homepage markdown, not-SPA-fake,
  * robots (User-agent + Sitemap line), AI-crawler access (GPTBot/ClaudeBot/
  * OAI-SearchBot/PerplexityBot not disallowed), sitemap (real XML, same-host
- * <loc> entries). If /api/ai advertises llmsFull, that URL must resolve.
+ * <loc> entries), name agreement across the agent channels, and HEAD/GET
+ * parity. If /api/ai advertises llmsFull, that URL must resolve.
  * Bonus (reported, not required): /skill.md, IndexNow key file.
+ *
+ * Presence is not identity: the audit also checks that /llms.txt, /api/ai and
+ * JSON-LD AGREE on the product name, because eight surfaces scored S-tier while
+ * publishing a name the fleet has no record of.
  */
 
 import { readFileSync, existsSync } from 'node:fs';
@@ -35,6 +40,15 @@ import {
   configuredProbeConcurrency,
   withTransientRetries,
 } from '../../../lib/agent-probe-retry.mjs';
+import {
+  apiAiName,
+  canonicalIdentityFor,
+  gradeNameAgreement,
+  jsonLdName,
+  llmsName,
+  loadCanonicalIdentities,
+} from '../../../lib/entity-name-agreement.mjs';
+import { gradeHeadParity } from '../../../lib/head-parity.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 // scripts → agent-ready → skills → tooling → saas-maker → fleet root
@@ -51,6 +65,12 @@ const MAX_PUBLIC_ROUTES = 50_000;
 const MAX_SITEMAP_BYTES = 50 * 1024 * 1024;
 const MAX_ROUTE_PROBES = 250;
 const MAX_CATALOG_SURFACES = 1_000;
+// How many sitemap routes the HEAD/GET parity check compares, on top of the
+// four fixed agent endpoints (whose GET statuses this audit already has). A
+// HEAD/GET asymmetry is a routing property of the host rather than of one page,
+// so a small deterministic sample finds it without doubling the 250-route
+// Markdown sweep.
+const MAX_HEAD_ROUTE_PROBES = 10;
 const PROBE_CONCURRENCY = configuredProbeConcurrency(
   process.env.FLEET_AGENT_PROBE_CONCURRENCY,
 );
@@ -70,6 +90,8 @@ const REQUIRED_CHECKS = [
   'sitemap',
   'route_markdown',
   'catalog_integrity',
+  'name_agreement',
+  'head_parity',
 ];
 
 async function main() {
@@ -82,12 +104,13 @@ async function main() {
   }
 
   const indexNowKey = loadIndexNowKey();
+  const identities = loadCanonicalIdentities();
 
   const results = [];
   for (const t of targets) {
     process.stderr.write(`Auditing ${t.name} (${t.origin})…\n`);
     try {
-      results.push(await auditOrigin(t, { indexNowKey }));
+      results.push(await auditOrigin(t, { indexNowKey, identities }));
     } catch (err) {
       results.push({
         name: t.name,
@@ -188,7 +211,12 @@ function summarizeResult(result) {
  * the general-purpose --json response exceed child-process output buffers.
  */
 function metricResult(result) {
-  const includedData = new Set(['route_markdown', 'catalog_integrity']);
+  const includedData = new Set([
+    'route_markdown',
+    'catalog_integrity',
+    'name_agreement',
+    'head_parity',
+  ]);
   return {
     ...summarizeResult(result),
     pass: result.pass,
@@ -251,7 +279,7 @@ function resolveTargets(args) {
       console.error(`Product ${p.id} has no url in the registry`);
       process.exit(2);
     }
-    return [{ name: p.name || p.id, origin }];
+    return [{ name: p.name || p.id, origin, id: p.id }];
   }
 
   if (args.all) {
@@ -264,10 +292,10 @@ function resolveTargets(args) {
 }
 
 /**
- * @param {{ name: string, origin: string }} target
+ * @param {{ name: string, origin: string, id?: string }} target
  */
-async function auditOrigin(target, { indexNowKey } = {}) {
-  const { origin, name } = target;
+async function auditOrigin(target, { indexNowKey, identities } = {}) {
+  const { origin, name, id } = target;
   const checks = {};
 
   // --- llms.txt ---
@@ -335,6 +363,31 @@ async function auditOrigin(target, { indexNowKey } = {}) {
   const homepage = await probe(`${origin}/`, { accept: 'text/html' });
   checks.jsonld = gradeJsonLd(homepage);
 
+  // --- name agreement: do the agent channels declare the canonical name? ---
+  const canonical = identities
+    ? canonicalIdentityFor(identities, { id, origin })
+    : null;
+  checks.name_agreement = gradeNameAgreement({
+    canonical,
+    observed: {
+      'llms.txt': llmsName(llms.ok && !llms.isHtml ? llms.bodyFull : null),
+      '/api/ai': apiAiName(apiAi.ok && !apiAi.isHtml ? apiAi.bodyFull : null),
+      'json-ld': jsonLdName(homepage.isHtml ? homepage.bodyFull : null),
+    },
+  });
+
+  // --- HEAD/GET parity on already-probed URLs ---
+  checks.head_parity = await gradeHeadParity({
+    probes: await headParityTargets(
+      origin,
+      { llms, apiAi, robots, homepage },
+      sitemap,
+      cachedProbe,
+    ),
+    head: (url, accept) => probeHead(url, accept),
+    concurrency: PROBE_CONCURRENCY,
+  });
+
   if (indexNowKey) {
     const keyProbe = await probe(`${origin}/${indexNowKey}.txt`);
     const keyOk = keyProbe.ok && !keyProbe.isHtml && keyProbe.bodyFull?.trim() === indexNowKey;
@@ -353,18 +406,76 @@ async function auditOrigin(target, { indexNowKey } = {}) {
   const passCount = applicable.filter((k) => checks[k]?.status === 'pass').length;
   const failCount = applicable.filter((k) => checks[k]?.status === 'fail').length;
   const score = Math.round((passCount / applicable.length) * 100);
-  const tier =
-    failCount === 0 ? 'S' : passCount >= 5 ? 'A' : passCount >= 3 ? 'B' : 'C';
+  // A surface publishing a name that exists in no fleet record is not partially
+  // agent-ready: an agent that reads it resolves to a different product, so the
+  // rest of the surface being perfect does not help. That floors the tier rather
+  // than costing one check (sass-maker/saas-maker#94).
+  const identityConflict = checks.name_agreement?.data?.identityConflict === true;
+  const tier = identityConflict
+    ? 'C'
+    : failCount === 0
+      ? 'S'
+      : passCount >= 5
+        ? 'A'
+        : passCount >= 3
+          ? 'B'
+          : 'C';
 
   return {
     name,
     origin,
+    ...(id ? { id } : {}),
     tier,
     score,
     pass: passCount,
     fail: failCount,
     checks,
   };
+}
+
+/**
+ * URLs to compare HEAD against GET for.
+ *
+ * Every pair differs only in the method: the HEAD carries the same Accept the
+ * GET carried. Comparing a Markdown-negotiated GET against a bare HEAD reports
+ * negotiation as a routing defect — two fleet surfaces answer 404 to
+ * `Accept: text/markdown` on a route that exists, which is a negotiation
+ * choice, not the missing-asset failure this check is for.
+ *
+ * The four fixed agent endpoints reuse statuses already collected, so they cost
+ * one HEAD each and no extra GET. The route sample is the only place a GET is
+ * re-issued (bare, as a crawler sends it) and it is capped at
+ * MAX_HEAD_ROUTE_PROBES routes drawn from the same deterministic sample the
+ * Markdown sweep used.
+ */
+async function headParityTargets(origin, endpoints, sitemap, cachedProbe) {
+  const targets = [
+    {
+      url: `${origin}/`,
+      label: '/',
+      status: endpoints.homepage?.status,
+      accept: 'text/html',
+    },
+    { url: `${origin}/llms.txt`, label: '/llms.txt', status: endpoints.llms?.status },
+    {
+      url: `${origin}/api/ai`,
+      label: '/api/ai',
+      status: endpoints.apiAi?.status,
+      accept: 'application/json',
+    },
+    { url: `${origin}/robots.txt`, label: '/robots.txt', status: endpoints.robots?.status },
+  ];
+
+  const sampled = evenlySample(
+    evenlySample(sitemap.urls ?? [], MAX_ROUTE_PROBES),
+    MAX_HEAD_ROUTE_PROBES,
+  );
+  for (const url of sampled) {
+    if (targets.some((target) => target.url === url)) continue;
+    const response = await cachedProbe(url);
+    targets.push({ url, label: new URL(url).pathname, status: response.status });
+  }
+  return targets;
 }
 
 function gradeAgentText(probe, { requireHash }) {
@@ -1081,6 +1192,38 @@ async function probe(url, options = {}) {
   return withTransientRetries(() => probeOnce(url, options));
 }
 
+/**
+ * Status-only HEAD probe. No body is read, so this is the cheapest request the
+ * audit makes; it exists to catch hosts that resolve a path for GET but not for
+ * HEAD (sass-maker/saas-maker#93).
+ */
+async function probeHead(url, accept) {
+  return withTransientRetries(async () => {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+    try {
+      const res = await fetch(url, {
+        method: 'HEAD',
+        redirect: 'follow',
+        signal: ctrl.signal,
+        headers: {
+          'User-Agent': UA,
+          ...(accept ? { Accept: accept } : {}),
+        },
+      });
+      return {
+        ok: res.ok,
+        status: res.status,
+        retryAfter: res.headers.get('retry-after'),
+      };
+    } catch (err) {
+      return { ok: false, status: 0, error: String(err?.message || err) };
+    } finally {
+      clearTimeout(timer);
+    }
+  });
+}
+
 async function probeOnce(url, { accept, retainFullBody = false } = {}) {
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
@@ -1161,9 +1304,11 @@ function printScoreboard(results) {
       pad('robots', 7) +
       pad('ai-ok', 6) +
       pad('sitemap', 8) +
+      pad('name', 6) +
+      pad('head', 6) +
       'jsonld'
   );
-  console.log('-'.repeat(104));
+  console.log('-'.repeat(116));
 
   for (const r of sorted) {
     if (r.error) {
@@ -1186,6 +1331,8 @@ function printScoreboard(results) {
         pad(mark('robots'), 7) +
         pad(mark('ai_access'), 6) +
         pad(mark('sitemap'), 8) +
+        pad(mark('name_agreement'), 6) +
+        pad(mark('head_parity'), 6) +
         mark('jsonld')
     );
   }

--- a/tooling/test/entity-name-agreement.test.mjs
+++ b/tooling/test/entity-name-agreement.test.mjs
@@ -1,0 +1,191 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import {
+  apiAiName,
+  classifyName,
+  canonicalIdentityFor,
+  gradeNameAgreement,
+  jsonLdName,
+  llmsName,
+  loadCanonicalIdentities,
+  slugify,
+} from '../lib/entity-name-agreement.mjs';
+
+const kinetic = { id: 'email-manager', name: 'Kinetic', aliases: ['Email Manager'] };
+const psiSwarm = { id: 'psi-swarm', name: 'PSI Swarm', aliases: ['psi-swarm'] };
+const hobbies = { id: 'significanthobbies', name: 'Significant Hobbies', aliases: [] };
+
+test('a surface publishing the canonical name on every channel agrees', () => {
+  const check = gradeNameAgreement({
+    canonical: kinetic,
+    observed: { 'llms.txt': 'Kinetic', '/api/ai': 'Kinetic', 'json-ld': 'Kinetic' },
+  });
+  assert.equal(check.status, 'pass');
+  assert.equal(check.data.worst, 'ok');
+  assert.equal(check.data.identityConflict, false);
+});
+
+test('a retired alias is drift, not agreement', () => {
+  // email-manager: the rename to Kinetic shipped; llms.txt and /api/ai still
+  // say "Email Manager", which the record keeps only as a retired alias.
+  const check = gradeNameAgreement({
+    canonical: kinetic,
+    observed: {
+      'llms.txt': 'Email Manager',
+      '/api/ai': 'Email Manager',
+      'json-ld': 'Kinetic',
+    },
+  });
+  assert.equal(check.status, 'fail');
+  assert.equal(check.data.worst, 'retired-alias');
+  assert.equal(check.data.identityConflict, false);
+  assert.deepEqual(
+    check.data.channels.map((c) => c.class),
+    ['retired-alias', 'retired-alias', 'ok']
+  );
+});
+
+test('a repo slug is a slug leak even when the record lists it as an alias', () => {
+  // Recording the slug stops it being unexplained; it does not make it a name
+  // the product goes by, so it stays a defect in the surface.
+  assert.equal(classifyName('psi-swarm', psiSwarm), 'slug-leak');
+  const check = gradeNameAgreement({
+    canonical: psiSwarm,
+    observed: { 'llms.txt': 'psi-swarm', '/api/ai': 'psi-swarm', 'json-ld': 'psi-swarm' },
+  });
+  assert.equal(check.status, 'fail');
+  assert.equal(check.data.worst, 'slug-leak');
+});
+
+test('a name in no record at all is an identity conflict', () => {
+  // significanthobbies declares "Live" — a different fleet product, and a name
+  // that appears in no record for this id.
+  const check = gradeNameAgreement({
+    canonical: hobbies,
+    observed: {
+      'llms.txt': 'Live by Significant Hobbies',
+      '/api/ai': 'Live',
+      'json-ld': 'Significant Hobbies',
+    },
+  });
+  assert.equal(check.status, 'fail');
+  assert.equal(check.data.worst, 'unrecorded');
+  assert.equal(check.data.identityConflict, true);
+  assert.match(check.detail, /identity conflict/);
+});
+
+test('case is classified, never normalized away', () => {
+  assert.equal(classifyName('posttrainllm', { name: 'PostTrainLLM', aliases: [] }), 'casing');
+  assert.equal(classifyName('DRank', { name: 'Drank', aliases: [] }), 'casing');
+  const check = gradeNameAgreement({
+    canonical: { id: 'drank', name: 'Drank', aliases: [] },
+    observed: { 'llms.txt': 'DRank', '/api/ai': 'DRank', 'json-ld': 'Drank' },
+  });
+  assert.equal(check.status, 'fail');
+  assert.equal(check.data.worst, 'casing');
+});
+
+test('the canonical name is not confused with an alias it contains', () => {
+  // "Pace" is a substring of "HeyPace"; a loose compare would score the
+  // compliant surface as publishing the retired name.
+  assert.equal(classifyName('HeyPace', { name: 'HeyPace', aliases: ['Pace'] }), 'ok');
+  assert.equal(classifyName('Pace', { name: 'HeyPace', aliases: ['Pace'] }), 'retired-alias');
+});
+
+test('an origin with no canonical record is skipped, not failed', () => {
+  const check = gradeNameAgreement({ canonical: null, observed: { 'llms.txt': 'Whatever' } });
+  assert.equal(check.status, 'skip');
+});
+
+test('a surface declaring no name anywhere is skipped — absence is another check', () => {
+  const check = gradeNameAgreement({
+    canonical: kinetic,
+    observed: { 'llms.txt': null, '/api/ai': null, 'json-ld': null },
+  });
+  assert.equal(check.status, 'skip');
+  assert.deepEqual(check.data.channels, []);
+});
+
+test('slugify collapses punctuation so a slug leak is recognised', () => {
+  assert.equal(slugify('PSI Swarm'), 'psi-swarm');
+  assert.equal(slugify('Anime List'), 'anime-list');
+});
+
+test('llms.txt name comes from the first markdown heading', () => {
+  assert.equal(llmsName('# Kinetic\n\n> Remember the email.\n'), 'Kinetic');
+  assert.equal(llmsName('\n\n## Live by Significant Hobbies\ntext'), 'Live by Significant Hobbies');
+  assert.equal(llmsName('no heading here'), null);
+  assert.equal(llmsName(null), null);
+});
+
+test('/api/ai name reads name, or product.name, and never throws on junk', () => {
+  assert.equal(apiAiName('{"name":"Kinetic","surfaces":[]}'), 'Kinetic');
+  assert.equal(apiAiName('{"product":{"name":"Kinetic"}}'), 'Kinetic');
+  assert.equal(apiAiName('<!doctype html>'), null);
+  assert.equal(apiAiName(null), null);
+});
+
+test('JSON-LD reads the WebSite node, not the author Person node', () => {
+  // The regression this guards: the first "name" in the document is usually the
+  // Person node crediting the author, which reports false drift everywhere.
+  const html = `<script type="application/ld+json">${JSON.stringify({
+    '@graph': [
+      { '@type': 'Person', name: 'Sarthak Agrawal' },
+      { '@type': 'WebSite', name: 'Kinetic' },
+    ],
+  })}</script>`;
+  assert.equal(jsonLdName(html), 'Kinetic');
+});
+
+test('JSON-LD falls back to Organization only when no WebSite/app node exists', () => {
+  const orgOnly = `<script type="application/ld+json">${JSON.stringify({
+    '@type': 'Organization',
+    name: 'SaaS Maker',
+  })}</script>`;
+  assert.equal(jsonLdName(orgOnly), 'SaaS Maker');
+  assert.equal(jsonLdName('<html><body>no markup</body></html>'), null);
+});
+
+test('a decided-but-unapplied rename governs, and retires the old name to an alias', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'entity-identity-'));
+  const catalogPath = join(dir, 'projects.json');
+  const decisionsPath = join(dir, 'canonical.json');
+  writeFileSync(
+    catalogPath,
+    JSON.stringify({
+      geoIdentities: [
+        { id: 'email-manager', name: 'Email Manager', origin: 'https://mail.example.com' },
+      ],
+    })
+  );
+  writeFileSync(
+    decisionsPath,
+    JSON.stringify({
+      decisions: [
+        {
+          id: 'email-manager',
+          name: 'Kinetic',
+          retireNameToAlias: true,
+          canonicalUrl: 'https://mail.example.com',
+        },
+      ],
+    })
+  );
+
+  const identities = loadCanonicalIdentities({ catalogPath, decisionsPath });
+  const identity = identities.get('email-manager');
+  assert.equal(identity.name, 'Kinetic');
+  assert.deepEqual(identity.aliases, ['Email Manager']);
+  assert.equal(classifyName('Email Manager', identity), 'retired-alias');
+
+  // A URL target with no registry id still resolves by host.
+  assert.equal(
+    canonicalIdentityFor(identities, { origin: 'https://mail.example.com' })?.name,
+    'Kinetic'
+  );
+  assert.equal(canonicalIdentityFor(identities, { origin: 'https://unknown.example' }), null);
+});

--- a/tooling/test/head-parity.test.mjs
+++ b/tooling/test/head-parity.test.mjs
@@ -1,0 +1,133 @@
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import test from 'node:test';
+
+import { gradeHeadParity, statusClass } from '../lib/head-parity.mjs';
+
+test('a host that answers HEAD as it answers GET passes', async () => {
+  const check = await gradeHeadParity({
+    probes: [
+      { url: 'https://example.com/', label: '/', status: 200 },
+      { url: 'https://example.com/llms.txt', label: '/llms.txt', status: 200 },
+    ],
+    head: async () => ({ status: 200 }),
+  });
+  assert.equal(check.status, 'pass');
+  assert.equal(check.data.checked, 2);
+  assert.deepEqual(check.data.mismatches, []);
+});
+
+test('HEAD 404 against GET 200 fails the route and names it', async () => {
+  // The #93 blind spot: sassmaker.com interior routes returned 404 to HEAD and
+  // 200 to GET, and a GET-only audit scored the site fully healthy.
+  const check = await gradeHeadParity({
+    probes: [
+      { url: 'https://sassmaker.com/', label: '/', status: 200 },
+      { url: 'https://sassmaker.com/learnings', label: '/learnings', status: 200 },
+      { url: 'https://sassmaker.com/projects', label: '/projects', status: 200 },
+    ],
+    head: async (url) => ({ status: url.endsWith('/') ? 200 : 404 }),
+  });
+  assert.equal(check.status, 'fail');
+  assert.equal(check.data.checked, 3);
+  assert.deepEqual(check.data.mismatches, [
+    { route: '/learnings', get: 200, head: 404 },
+    { route: '/projects', get: 200, head: 404 },
+  ]);
+  assert.match(check.detail, /\/learnings HEAD 404 vs GET 200/);
+});
+
+test('a route that 404s to both verbs is consistent, not a parity failure', async () => {
+  assert.equal(statusClass(404), 4);
+  assert.equal(statusClass(0), 0);
+  const check = await gradeHeadParity({
+    probes: [{ url: 'https://example.com/gone', label: '/gone', status: 404 }],
+    head: async () => ({ status: 404 }),
+  });
+  assert.equal(check.status, 'pass');
+});
+
+test('status classes are compared, not exact codes', async () => {
+  // A 200 that becomes a 204 to HEAD is the same class and not a defect; a 200
+  // that becomes a 500 is.
+  const same = await gradeHeadParity({
+    probes: [{ url: 'https://example.com/x', label: '/x', status: 200 }],
+    head: async () => ({ status: 204 }),
+  });
+  assert.equal(same.status, 'pass');
+  const different = await gradeHeadParity({
+    probes: [{ url: 'https://example.com/x', label: '/x', status: 200 }],
+    head: async () => ({ status: 500 }),
+  });
+  assert.equal(different.status, 'fail');
+});
+
+test('the HEAD carries the same Accept as the GET it is compared with', async () => {
+  // Comparing a Markdown-negotiated GET against a bare HEAD reports negotiation
+  // as a routing defect: anime.significanthobbies.com answers 404 to
+  // `Accept: text/markdown` on routes that exist, and 200 to a bare HEAD.
+  const sent = [];
+  const check = await gradeHeadParity({
+    probes: [
+      { url: 'https://example.com/api/ai', label: '/api/ai', status: 200, accept: 'application/json' },
+      { url: 'https://example.com/robots.txt', label: '/robots.txt', status: 200 },
+    ],
+    head: async (url, accept) => {
+      sent.push([new URL(url).pathname, accept]);
+      return { status: 200 };
+    },
+  });
+  assert.equal(check.status, 'pass');
+  assert.deepEqual(sent.sort(), [
+    ['/api/ai', 'application/json'],
+    ['/robots.txt', undefined],
+  ]);
+});
+
+test('a route GET could not reach at all is not compared', async () => {
+  const check = await gradeHeadParity({
+    probes: [{ url: 'https://example.com/x', label: '/x', status: 0 }],
+    head: async () => {
+      throw new Error('HEAD must not be issued for an unreachable GET');
+    },
+  });
+  assert.equal(check.status, 'skip');
+});
+
+test('a HEAD that cannot connect fails against a reachable GET', async () => {
+  const check = await gradeHeadParity({
+    probes: [{ url: 'https://example.com/x', label: '/x', status: 200 }],
+    head: async () => ({ status: 0, error: 'ECONNRESET' }),
+  });
+  assert.equal(check.status, 'fail');
+  assert.match(check.detail, /HEAD err vs GET 200/);
+});
+
+test('end to end against a server that resolves a path for GET but not HEAD', async () => {
+  const server = createServer((req, res) => {
+    // The shape of the Cloudflare Pages defect: the extensionless path is
+    // resolved to an emitted .html asset for GET, and missed for HEAD.
+    if (req.url === '/learnings' && req.method === 'HEAD') {
+      res.writeHead(404).end();
+      return;
+    }
+    res.writeHead(200, { 'content-type': 'text/html' }).end('<!doctype html><title>ok</title>');
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const base = `http://127.0.0.1:${server.address().port}`;
+  try {
+    const probes = [];
+    for (const path of ['/', '/learnings']) {
+      const response = await fetch(`${base}${path}`);
+      probes.push({ url: `${base}${path}`, label: path, status: response.status });
+    }
+    const check = await gradeHeadParity({
+      probes,
+      head: async (url) => ({ status: (await fetch(url, { method: 'HEAD' })).status }),
+    });
+    assert.equal(check.status, 'fail');
+    assert.deepEqual(check.data.mismatches, [{ route: '/learnings', get: 200, head: 404 }]);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});


### PR DESCRIPTION
Closes #94.

`agent-ready` checked that `/llms.txt`, `/api/ai` and JSON-LD are **present**. It did not check that they **agree**, so eight registry surfaces scored S-tier / 100% while publishing a different product name to agents than the canonical record carries. Two required checks close that class of blind spot, and the second one closes #93's verb blind spot in the auditor (the showcase fix itself is separate).

## What changed

- **`name_agreement`** (required). Reads the name each channel declares — `/llms.txt` first `#` heading, `/api/ai` `.name`, and the JSON-LD `WebSite`/`SoftwareApplication` node (never the first `name` in the document, which is usually the author's `Person` node) — and compares it **exactly** to `tooling/config/entity-identity-canonical.json` layered over `geoIdentities[]`. Mismatches are classified `casing`, `slug-leak`, `retired-alias`, `unrecorded`.
- **`head_parity`** (required). Issues HEAD against the four fixed agent endpoints plus a deterministic 10-route sitemap sample and fails when the status class differs from GET.
- Extraction and classification moved to `tooling/lib/entity-name-agreement.mjs` and are now shared with `tooling/scripts/entity-identity-live.mjs`, so the auditor and the live probe cannot disagree about what a surface declares. `psi-swarm` reclassifies there from `retired-alias` to `slug-leak`.
- Rules written into `tooling/docs/agent-indexing-standard.md` (S-tier checklist + two new sections) and `tooling/skills/agent-ready/SKILL.md`.

## Scoring

| Situation | Penalty |
| --- | --- |
| Any channel non-`ok` | `name_agreement` fails → a required check fails → **cannot be S-tier**; score loses 1/11 |
| Any channel `unrecorded` | the above **plus the tier is floored at C** |
| No canonical record for the origin (ad-hoc URL target) | `skip` — not applicable, like `llms_full` |
| HEAD status class ≠ GET status class on any probed URL | `head_parity` fails → cannot be S-tier |

`unrecorded` is the only class that is not a record the fleet could correct: the surface asserts an identity nothing internal knows about, so an agent that reads it resolves to a different product and the rest of the surface being perfect does not help. That is why it floors the tier instead of costing one check. Case is classified, never normalized away — `posttrainllm` and `DRank` differ from canonical by case alone and are both repo slugs leaking onto an agent surface.

`REQUIRED_CHECKS` goes 9 → 11, so a fully compliant surface still scores 100%; the denominator moved, not the bar.

## Cost of the HEAD probe

Bounded on purpose. The four endpoints reuse GET statuses the audit already collected, so they cost one body-less HEAD each and no extra GET; only the 10 sampled routes (drawn from the same deterministic sample the Markdown sweep uses) re-issue a GET. A HEAD/GET asymmetry is a routing property of the host rather than of one page, so a sample finds it without doubling a 250-route sweep.

Each pair differs **only in the method**: the HEAD carries the same `Accept` as the GET it is compared with. An earlier revision compared a Markdown-negotiated GET against a bare HEAD and reported two surfaces as broken — `ai-gateway.sassmaker.com` and `anime.significanthobbies.com` answer 404 to `Accept: text/markdown` on routes that exist, which is a negotiation choice, not the missing-asset failure this check is for.

## Evidence — the 8 surfaces from #94, probed live 2026-09-06

Before column is `origin/main`'s auditor, after column is this branch, same run.

| Surface | canonical | `/llms.txt` | `/api/ai` | json-ld | worst class | before | after |
| --- | --- | --- | --- | --- | --- | --- | --- |
| `significanthobbies` | Significant Hobbies | `Live by Significant Hobbies` | `Live` | ok | **unrecorded** | A 70% | C 58% |
| `email-manager` | Kinetic | `Email Manager` | `Email Manager` | ok | **retired-alias** | S 100% | A 92% |
| `free-ai` | Free AI | `AI Gateway` | `AI Gateway` | ok | **retired-alias** | S 100% | A 92% |
| `anime-list` | Anime List | `Anime List by Significant Hobbies` | `Anime List by Significant Hobbies` | ok | **retired-alias** | S 100% | A 92% |
| `pace` | HeyPace | `Pace` | `Pace` | `Pace` | **retired-alias** | S 100% | A 92% |
| `psi-swarm` | PSI Swarm | `psi-swarm` | `psi-swarm` | `psi-swarm` | **slug-leak** | S 100% | A 92% |
| `posttrainllm` | PostTrainLLM | `posttrainllm` | `posttrainllm` | ok | **casing** | S 100% | A 92% |
| `drank` | Drank | `DRank` | `DRank` | ok | **casing** | S 100% | A 92% |

Every classification matches the table in #94. `significanthobbies` was already A (70%) on main for unrelated reasons (its sitemap points at a foreign host), and the identity conflict now floors it at C.

One finding beyond #94: **`significanthobbies.com/` returns 401 to HEAD and 200 to GET** (deterministic, any UA). `head_parity` fails there. No other surface among the eight disagrees between the verbs.

## Tests

`tooling/test/entity-name-agreement.test.mjs` and `tooling/test/head-parity.test.mjs` — 22 new cases covering agree, retired alias, slug leak, casing, unrecorded, alias-inside-canonical (`Pace` vs `HeyPace`), `Person`-node JSON-LD, decided-but-unapplied rename, HEAD≠GET (both directions), status-class comparison, Accept forwarding, and an end-to-end case against a local server that resolves a path for GET but not for HEAD.

`node --test test/*.test.mjs` → 195 pass. `scripts/audit.mjs --validate-only` and `scripts/validate-tooling.mjs` clean.

## Not in scope

The per-surface content fixes are the owning repos' work: Significant-Hobbies/email-manager#49, Significant-Hobbies/significanthobbies#148 and live#7 are in flight. `free-ai`, `anime-list`, `pace`, `psi-swarm`, `posttrainllm` and `drank` still need the same treatment, and `drank` needs a ruling on whether canonical is `Drank` or `DRank` — there the live site may be right and the catalog wrong.
