### PR TITLE
feat(skills): four explicit modes for Clarity fleet health

### DIFF
--- a/tooling/PROJECT_STATUS.md
+++ b/tooling/PROJECT_STATUS.md
@@ -1,6 +1,6 @@
 # SaaS Maker Tooling — PROJECT STATUS
 
-Last updated: 2026-09-01
+Last updated: 2026-09-06
 
 ## Why / What
 
@@ -33,6 +33,16 @@ owned by individual products.
 
 ## Timeline
 
+- 2026-09-06 — Gave the Clarity Fleet Health skill four explicit modes:
+  `source-audit` (credential-free), `cached-health` (no network),
+  `provider-refresh` (explicit live Data Export sweep), and optional
+  `mcp-investigation`, which is never the fleet pass/fail gate. Routed both
+  Clarity skills from the `site-health` parent skill by intent, and indexed the
+  operator protocol in `docs/clarity-fleet-health.md`. The matching Site Health
+  collector reports every canonical identity as measured, cached, unavailable,
+  unwired, inactive, or failed in one bounded summary. Verified: 195 tooling
+  tests, the tooling validator (52 skills), and a real 56-product source audit
+  with no blocking findings. Refs sass-maker/saas-maker#89.
 - 2026-09-01 — Added a credential-free Clarity capability desired-state
   contract covering 17 automatic, provider, source, operator, and
   infrastructure features. The source audit now validates and reports the

--- a/tooling/README.md
+++ b/tooling/README.md
@@ -103,6 +103,11 @@ The separate [`config/clarity-journeys.json`](config/clarity-journeys.json)
 records one live-root-backed Smart Event and funnel candidate per wired product,
 or an explicit rendered-discovery blocker when stable action text was absent.
 
+The audit is the credential-free `source-audit` mode of the `clarity-fleet-health`
+skill. Its other modes — cached counts, an explicit live refresh, and optional
+MCP follow-up — are indexed in
+[`docs/clarity-fleet-health.md`](docs/clarity-fleet-health.md).
+
 `footer-source-audit.mjs` reads a caller-owned manifest of relative source
 paths and verifies that each named browser surface loads the project strip
 before Ask AI, carries both loaders, and has no active `data-compose=false`

--- a/tooling/docs/clarity-fleet-health.md
+++ b/tooling/docs/clarity-fleet-health.md
@@ -1,0 +1,64 @@
+# Clarity fleet health
+
+Fleet keeps one Microsoft Clarity project per catalog identity. Two skills own
+different halves of that, and they must not be confused:
+
+| Skill | Owns |
+| --- | --- |
+| `clarity-fleet-rollout` | Creating projects, assigning IDs, wiring source, repairing receipt drift — all mutations |
+| `clarity-fleet-health` | Repeatable read-only health checks across every identity |
+
+This page is the operator index for the health half. The full protocol is
+[`skills/clarity-fleet-health/SKILL.md`](../skills/clarity-fleet-health/SKILL.md).
+
+## Four modes, in escalation order
+
+| Mode | Command | Touches |
+| --- | --- | --- |
+| `source-audit` | `pnpm --dir saas-maker tooling:clarity` | Files only — no token, no network |
+| `cached-health` | `pnpm --dir site-health clarity -- status-all` | Local snapshots only |
+| `provider-refresh` | `pnpm --dir site-health clarity -- fetch-all --days 3` | One bounded Data Export request per eligible current project |
+| `mcp-investigation` | `@microsoft/clarity-mcp-server`, one project | Optional follow-up, never the pass/fail gate |
+
+Only an explicit refresh / retest-live / test-every-application request
+authorizes `provider-refresh`. "Check Clarity" means `cached-health`.
+
+## What this repository owns
+
+| File | Role |
+| --- | --- |
+| `config/clarity-projects.json` | The canonical receipt (`fleet.clarity-registry.v2`) — identity, Clarity ID, hostname, `browserSurfaces`, and the exclusion reason for every unwired product |
+| `config/clarity-capabilities.json` | Capability policy split by mode: automatic, provider, source, operator, infrastructure |
+| `config/clarity-journeys.json` | Per-product conversion events and funnels, defined from real routes |
+| `scripts/clarity-audit.mjs` | The credential-free `source-audit` implementation |
+| `templates/clarity-snippet.html` | The standard loader used when wiring a surface |
+
+SaaS Maker Tooling **never** handles or stores a Clarity token. Token
+resolution, provider requests, and snapshot persistence live in Site Health.
+
+## The six reported classes
+
+Every canonical identity lands in exactly one: `measured`, `cached`,
+`unavailable`, `unwired`, `inactive`, or `failed`. A run reports all of them —
+one missing token or provider failure never erases the other projects.
+
+`unwired` and `inactive` are passes when the receipt records a reason (local
+only, native only, private, retired, no browser surface). A receipt entry with
+no catalog project is drift and reports as `failed`, not as a quiet exclusion.
+
+The bounded summary schema (`site-health.clarity-fleet-collection.v2`), the
+state-to-class mapping, and the markdown table format are documented once, in
+Site Health: `site-health/docs/clarity-fleet-health.md`.
+
+## Boundaries
+
+- No recordings, heatmaps, URLs, visitor identifiers, or raw provider payloads
+  leave a health run — in any mode.
+- No project creation, token generation, source wiring change, deploy, or
+  schedule installation. Those are `clarity-fleet-rollout` or separate,
+  separately authorized work.
+- MCP output is exploratory evidence. The deterministic Data Export adapter is
+  the fleet health authority.
+- `uniqueBrowsers` counts browser/device identities, never registered users.
+- Source wiring, provider settings, deployment, and observed traffic are four
+  separate gates; evidence for one never proves another.

--- a/tooling/skills/clarity-fleet-health/SKILL.md
+++ b/tooling/skills/clarity-fleet-health/SKILL.md
@@ -9,30 +9,123 @@ Account for every canonical product without pretending every product should be
 tracked. Local-only, native-only, private, inactive, and deliberately
 analytics-free products can pass with an explicit unwired reason.
 
-## Choose the evidence mode
+## Pick one mode
 
-Run commands from the Fleet root.
+Run commands from the Fleet root. Escalate only as far as the question needs:
+**source-audit** answers wiring questions with no credentials at all,
+**cached-health** answers "what are the numbers" with no network, and
+**provider-refresh** is the only mode that spends provider quota.
 
-### Source integrity
+| Mode | Touches | Use it for |
+| --- | --- | --- |
+| `source-audit` | Files only | ID ownership, duplicate/retired IDs, declared entrypoints, undeclared loaders, capability policy validity |
+| `cached-health` | Local snapshots | Current counts and per-project state without a provider call |
+| `provider-refresh` | Clarity Data Export | An explicitly requested live refresh across every eligible current product |
+| `mcp-investigation` | Clarity MCP, one project | A focused follow-up question after aggregate evidence points somewhere |
 
-For ID ownership, duplicate IDs, retired shared IDs, declared entrypoints, and
-undeclared loaders:
+Never start at `provider-refresh` because the user said "check Clarity". Only an
+explicit refresh, retest-live, or test-every-application request authorizes it.
+
+---
+
+## Mode 1 — `source-audit` (credential-free)
+
+**Inputs:** the sibling Fleet checkouts. No token, no network, no provider.
 
 ```bash
 pnpm --dir saas-maker tooling:clarity
 ```
 
-This is credential-free and read-only. It accounts for all registry entries
-and verifies declared source files in available sibling checkouts. It also
-validates `saas-maker/tooling/config/clarity-capabilities.json`, which separates
-automatic, provider, source, operator, and infrastructure capabilities. A
-desired assignment is policy, not proof that the provider setting is enabled.
+**Checks:** every registry entry is accounted for; every declared entrypoint
+exists in an available sibling checkout; no duplicate or retired shared ID
+survives on a wired surface; and per the browser-surface policy, each identity
+declares its landing, browser-app, combined, or explicit no-browser-surface
+coverage. It also validates
+`saas-maker/tooling/config/clarity-capabilities.json`, which separates
+automatic, provider, source, operator, and infrastructure capabilities.
 
-### Provider capability audit
+**Output:** a per-identity source verdict. A `desired` capability assignment is
+policy — it is not proof that the provider setting is enabled.
+
+**Safety:** read-only. Safe to run unprompted whenever Clarity comes up.
+
+---
+
+## Mode 2 — `cached-health` (no network)
+
+**Inputs:** the last bounded local snapshots in Site Health's store. Resolves no
+token and issues no provider request — that is asserted by test, not convention.
+
+```bash
+pnpm --dir site-health clarity -- status-all
+pnpm --dir site-health clarity:table            # same run as a markdown table
+pnpm --dir site-health clarity -- status <project-id>
+```
+
+**Output:** one bounded JSON summary
+(`site-health.clarity-fleet-collection.v2`, `mode: cached-health`) with one row
+per canonical identity, or the same data as a markdown table. Schema and the
+six classes: [Clarity fleet health](../../docs/clarity-fleet-health.md).
+
+**Safety:** use this first when the user asks for current counts without
+explicitly asking for a live refresh. Say plainly when a number is cached and
+how old it is; a stale snapshot under a weekly cadence means "it isn't Monday",
+not "the refresh failed".
+
+---
+
+## Mode 3 — `provider-refresh` (explicit, spends quota)
+
+**Inputs:** project-scoped private Data Export tokens, resolved by Site Health
+from private environment, Infisical, or the macOS Keychain. Tokens are never
+passed on a command line, never printed, and never persisted by this skill.
+
+```bash
+pnpm --dir site-health clarity -- fetch-all --days 1
+pnpm --dir site-health clarity -- fetch-all --days 3 --format markdown
+pnpm --dir site-health clarity -- fetch <project-id> --days 1
+```
+
+**Behavior:** at most one Data Export request per eligible current project, run
+sequentially. Missing tokens and provider failures do not stop the run: the
+affected project is reported `unavailable` or `failed` and the rest continue.
+Exclusions never reach the adapter.
+
+**Output:** the same bounded summary with `mode: provider-refresh`. Only
+normalized aggregates are stored.
+
+**Safety:** Microsoft permits roughly ten export requests per project per day,
+and the widest window the API serves is three days. Do not retry failures in the
+same run. Prefer one project when one project is the question.
+
+---
+
+## Mode 4 — `mcp-investigation` (optional, never a gate)
+
+**Inputs:** an MCP client that is already configured, and one project's private
+`CLARITY_API_TOKEN` already available in the environment.
+
+The official `@microsoft/clarity-mcp-server` is an MCP stdio server, not a
+human-facing reporting CLI. Register it in the client's MCP configuration with
+the token supplied through the server's environment — never as a command-line
+argument, and never inside a file that gets committed.
+
+**Use it only** for a focused follow-up on one project after aggregate evidence
+already identified it. Ask one bounded question; record one bounded conclusion.
+
+**Safety:** MCP output is exploratory evidence, not the fleet health result. The
+deterministic Data Export adapter in `cached-health` and `provider-refresh` is
+the authority. Do not retain session recordings, heatmaps, URLs, visitor
+identifiers, or raw provider payloads. If the user explicitly requests a
+targeted recording investigation, keep it to the selected project.
+
+---
+
+## Related, but not a mode: provider settings audit
 
 Use the signed-in Clarity workspace when the user asks to enable or verify the
-full feature set. Audit one project before batching and keep these gates
-separate:
+full feature set. That is capability adoption, not health measurement; audit one
+project before batching and keep these gates separate:
 
 1. **Automatic baseline:** recordings, heatmaps, behavioral/frustration
    insights, Copilot, automatic Smart Events, benchmarks, and citations after
@@ -50,70 +143,24 @@ funnel. Prefer one primary conversion event and one truthful multi-step funnel;
 mark a single-action surface not applicable instead of inventing steps. Keep
 provider state `unverified` until the saved setting is reread from Clarity.
 
-### Cached traffic health
-
-For a no-network inventory of the latest Site Health snapshots:
-
-```bash
-pnpm --dir site-health clarity -- status-all
-```
-
-This mode must not resolve tokens or call Microsoft. Use it first when the user
-asks for current counts without explicitly requesting a live refresh.
-
-### Live fleet refresh
-
-When the user explicitly asks to refresh, retest live, or test every
-application, run:
-
-```bash
-pnpm --dir site-health clarity -- fetch-all --days 1
-```
-
-The request authorizes at most one Data Export request per eligible current
-project. The collector runs projects sequentially, continues after missing
-tokens or provider failures, stores only bounded aggregate snapshots, and
-returns one result for every canonical identity. Do not retry failures in the
-same run: Microsoft permits only ten export requests per project per day.
-
-For one product, prefer:
-
-```bash
-pnpm --dir site-health clarity -- status <project-id>
-pnpm --dir site-health clarity -- fetch <project-id> --days 1
-```
-
-## MCP role
-
-The official `@microsoft/clarity-mcp-server` is an MCP stdio server, not a
-normal human-facing reporting CLI. Use it only for a focused follow-up on one
-project when an MCP client and that project's private `CLARITY_API_TOKEN` are
-already available. Never pass the token as a command-line argument. Treat MCP
-answers as exploratory evidence; the deterministic Site Health Data Export
-adapter is the fleet health authority.
-
-Do not retain session recordings, heatmaps, URLs, visitor identifiers, or raw
-provider payloads in a fleet sweep. If the user explicitly requests a targeted
-recording investigation, keep it to the selected project and record only a
-bounded conclusion.
-
 ## Interpret and report
 
-Use these states without collapsing them:
+Every canonical identity lands in exactly one of six reported classes:
 
-- `measured`: the live aggregate request succeeded.
-- `fresh`, `stale`, or `not-measured`: cached Site Health state.
-- `unavailable`: an eligible product lacks a resolvable private token.
-- `failed`: Clarity rejected or could not serve the request.
+- `measured`: a live aggregate request succeeded this run.
+- `cached`: stored aggregate evidence exists and no provider call was made.
+- `unavailable`: eligible, but no resolvable private token and no snapshot.
 - `unwired`: the canonical receipt intentionally records no tracked surface.
 - `inactive`: the identity is retained but excluded from live refresh.
-- `not-cataloged`: receipt/catalog drift that needs repair.
-- `desired`: the capability policy calls for adoption, but provider state is
-  not yet verified.
-- `conditional`: adoption requires real project evidence such as a GA4
-  property, consent flow, or stable internal IPv4 range.
-- `blocked`: adoption needs separately authorized infrastructure or spend.
-- `provider-verified`: the saved Clarity setting was reread after mutation.
+- `failed`: Clarity rejected or could not serve the request — or the receipt has
+  no catalog project, which is drift that needs repair, not a quiet pass.
+
+The collector's detailed state travels alongside the class, so do not collapse
+`fresh`, `stale`, `not-measured`, or `not-cataloged` when they matter. Capability
+states stay separate again: `desired` (policy, provider unverified),
+`conditional` (needs a real GA4 property, consent flow, or stable internal IPv4
+range), `blocked` (needs separately authorized infrastructure or spend), and
+`provider-verified` (the saved setting was reread after mutation).
 
 Report totals first, then failures and unavailable eligible products, then
 intentional exclusions. Call `uniqueBrowsers` unique browser/device identities,
@@ -123,3 +170,5 @@ others.
 
 Use `clarity-fleet-rollout` for creating projects, changing IDs, wiring source,
 or repairing receipt drift. Those mutations require their own authorization.
+This skill never creates a project, generates a token, edits source wiring,
+deploys a product, or installs a schedule.

--- a/tooling/skills/site-health/SKILL.md
+++ b/tooling/skills/site-health/SKILL.md
@@ -15,7 +15,8 @@ one you need, not all of them.
 | SEO content sufficiency: article inventory, competitive intent/page gaps, comparison/alternative/use-case pages, create or publish missing pages | `skills/content-coverage/SKILL.md` |
 | Performance: Core Web Vitals, Lighthouse distributions, "why is X slow" | `psi-swarm/SKILL.md` (standalone product; exposed through the skill symlink) |
 | Outcome trends: SERP classes over time, "did results move", weekly run | `skills/geo-observatory/SKILL.md` |
-| Microsoft Clarity: sessions, browser counts, missing tracking, source integrity, or fleet-wide Clarity testing | `../clarity-fleet-health/SKILL.md` |
+| Microsoft Clarity health: sessions, browser counts, missing tracking, source integrity, feature adoption, or fleet-wide Clarity testing | `../clarity-fleet-health/SKILL.md` — pick its mode: `source-audit` (credential-free wiring), `cached-health` (counts, no network), `provider-refresh` (explicit live refresh only), `mcp-investigation` (optional, one project) |
+| Microsoft Clarity setup: creating projects, assigning IDs, wiring a surface, repairing receipt drift | `../clarity-fleet-rollout/SKILL.md` |
 | Canonical-root crawl and source fixes | Run `node scripts/ahrefs-site-audit-health.mjs`, then apply every **error** action in the owning repo. The working path is the local sitemap crawl. Ahrefs Health Scores are optional and currently blocked (Infisical `AHREFS_API_KEY` returns 401). See [canonical-root site audit](../../docs/ahrefs-site-audit.md). Do not deploy. Do not invent ratings. |
 | Public usability: click around, guest journeys, blank/broken pages, navigation, search/detail, downloads, primary product actions | `skills/public-product-smoke/SKILL.md` |
 


### PR DESCRIPTION
Skill half of #89. The collector half is `sass-maker/site-health#486`.

## Why

The skill described its evidence sources but never named them as modes, so "check Clarity" could escalate straight to a live provider sweep that spends quota. This names four modes and puts them in escalation order, cheapest first, each with its inputs, command, output, and safety boundary.

## The four modes

| Mode | Touches | Authorized by |
| --- | --- | --- |
| `source-audit` | Files only — no token, no network | Any Clarity question; safe unprompted |
| `cached-health` | Local snapshots only | "What are the numbers" — this is what "check Clarity" means |
| `provider-refresh` | One bounded Data Export request per eligible current project | Only an explicit refresh / retest-live / test-every-application request |
| `mcp-investigation` | Clarity MCP, one project | A focused follow-up after aggregate evidence points somewhere |

`source-audit` verifies every catalog identity is wired with its project id and its landing / browser-app / combined / explicit no-browser-surface coverage, per the #90 policy. `provider-refresh` resolves tokens only through Site Health (private env, Infisical, or Keychain) — SaaS Maker Tooling never handles or stores one. `mcp-investigation` is documented as exploratory evidence and explicitly **never** the fleet pass/fail gate; the deterministic Data Export adapter is the authority.

## Also in this PR

- Report the six classes the collector now emits — `measured`, `cached`, `unavailable`, `unwired`, `inactive`, `failed` — without collapsing the detailed states behind them.
- Keep the provider **settings** audit (site-health#485 territory) as clearly-labelled related work rather than a health mode, so capability adoption is not confused with health measurement.
- Route both Clarity skills from the `site-health` parent skill by intent: health → `clarity-fleet-health` with its mode named, setup/repair → `clarity-fleet-rollout`.
- `tooling/docs/clarity-fleet-health.md` (66 lines): operator index — the two skills' split, the four modes, what this repo owns (receipt, capability policy, journeys, audit script, snippet template), the six classes, boundaries. It points at Site Health for the one canonical copy of the summary schema rather than repeating it.
- `tooling/README.md` one-line pointer; `tooling/PROJECT_STATUS.md` timeline entry.

## How verified

- `node scripts/validate-tooling.mjs` — 52 skills, 100 Node scripts, 45 shell scripts; the new relative doc link resolves.
- `node --test test/*.test.mjs` — **195 tooling tests pass**.
- `node scripts/audit.mjs --validate-only` and `node scripts/check-docs.mjs` pass.
- **Real `source-audit` run** against the live Fleet root: 56 recorded products, 56 distinct Clarity projects, 0 with no Clarity ID, every claim verified against the source it names, 17 capabilities / 546 desired assignments, 38 ready journeys, **no blocking findings**.
- Biome ignores `tooling/`, so there is nothing to lint in this diff (all five files are markdown).

Refs #89 — closing is left to the owner until the Site Health half merges and the deployment/provider-reread gates in #90 are separately cleared.
