### PR TITLE
tooling: skip repo-scoped label issues in the priority queue sync

### DIFF
--- a/tooling/scripts/github-priority-queue.mjs
+++ b/tooling/scripts/github-priority-queue.mjs
@@ -6,12 +6,14 @@ import { pathToFileURL } from 'node:url';
 const DEFAULT_LIMIT = 1_000;
 const DEFAULT_STATUS_FIELD = 'Status';
 const DEFAULT_DONE_VALUE = 'Done';
+const DEFAULT_SKIP_REPO_LABELS = ['sarthakagrawal927/portfolio:issues'];
 const TOKEN_PATTERNS = [
   /\bgh[opsu]_[A-Za-z0-9_]+\b/g,
   /\bgithub_pat_[A-Za-z0-9_]+\b/g,
   /\bBearer\s+[^\s]+/gi,
 ];
 const VALUED_ARGUMENTS = ['owner', 'project', 'author', 'limit', 'status-field', 'done-value'];
+const REPEATABLE_ARGUMENTS = ['skip-repo-label'];
 
 function usage() {
   return `Usage:
@@ -30,6 +32,10 @@ Options:
   --limit NUMBER         Maximum issues to discover per state (default: ${DEFAULT_LIMIT})
   --status-field NAME    Single-select status field name (default: ${DEFAULT_STATUS_FIELD})
   --done-value NAME      Terminal option name in that field (default: ${DEFAULT_DONE_VALUE})
+  --skip-repo-label R:L  Repo-scoped label that excludes an issue from the queue
+                         (repeatable, e.g. owner/repo:label). Issues in that repo
+                         carrying that label are never added and never flagged as
+                         drift. Defaults to: ${DEFAULT_SKIP_REPO_LABELS.join(', ')}
   --apply                Add missing issues and reconcile status; without this
                          flag the command is read-only
   --help                 Show this help
@@ -42,6 +48,7 @@ export function parseArgs(argv) {
     limit: DEFAULT_LIMIT,
     statusField: DEFAULT_STATUS_FIELD,
     doneValue: DEFAULT_DONE_VALUE,
+    skipRepoLabels: [...DEFAULT_SKIP_REPO_LABELS],
   };
   for (let index = 0; index < argv.length; index += 1) {
     const argument = argv[index];
@@ -54,6 +61,15 @@ export function parseArgs(argv) {
       continue;
     }
     const key = argument.slice(2);
+    if (REPEATABLE_ARGUMENTS.includes(key)) {
+      const value = argv[index + 1];
+      if (!value || value.startsWith('--')) {
+        throw new Error(`Missing value for ${argument}`);
+      }
+      options.skipRepoLabels.push(value);
+      index += 1;
+      continue;
+    }
     if (!VALUED_ARGUMENTS.includes(key)) {
       throw new Error(`Unknown argument: ${argument}`);
     }
@@ -96,7 +112,7 @@ export function buildIssueSearchArgs(author, limit = DEFAULT_LIMIT, state = 'ope
     '--limit',
     String(limit),
     '--json',
-    'url',
+    'url,labels,repository',
   ];
 }
 
@@ -109,6 +125,50 @@ export function sanitizeError(value) {
 export function extractIssueUrls(payload) {
   const rows = Array.isArray(payload) ? payload : [];
   return [...new Set(rows.map((row) => row?.url).filter(Boolean))];
+}
+
+export function parseSkipRepoLabels(entries) {
+  const map = new Map();
+  for (const entry of entries) {
+    const separator = entry.lastIndexOf(':');
+    if (separator <= 0) {
+      throw new Error(`Invalid --skip-repo-label "${entry}" (expected owner/repo:label)`);
+    }
+    const repo = entry.slice(0, separator).trim().toLowerCase();
+    const label = entry.slice(separator + 1).trim().toLowerCase();
+    if (!repo || !repo.includes('/') || !label) {
+      throw new Error(`Invalid --skip-repo-label "${entry}" (expected owner/repo:label)`);
+    }
+    if (!map.has(repo)) map.set(repo, new Set());
+    map.get(repo).add(label);
+  }
+  return map;
+}
+
+export function extractIssueRecords(payload) {
+  const rows = Array.isArray(payload) ? payload : [];
+  const records = [];
+  for (const row of rows) {
+    const url = row?.url;
+    if (!url) continue;
+    records.push({
+      url,
+      repo: String(row?.repository?.nameWithOwner ?? '').toLowerCase(),
+      labels: (row?.labels ?? []).map((label) => String(label?.name ?? label).toLowerCase()),
+    });
+  }
+  return records;
+}
+
+export function extractSkippedUrls(records, skipRepoLabels) {
+  if (!skipRepoLabels || skipRepoLabels.size === 0) return new Set();
+  const skipped = new Set();
+  for (const { url, repo, labels } of records) {
+    const labelSet = skipRepoLabels.get(repo);
+    if (!labelSet) continue;
+    if (labels.some((label) => labelSet.has(label))) skipped.add(url);
+  }
+  return skipped;
 }
 
 export function extractProjectUrls(payload) {
@@ -176,24 +236,28 @@ export function auditProjectItems(payload, { doneValue = DEFAULT_DONE_VALUE } = 
   };
 }
 
-export function planQueueSync(discoveredUrls, projectUrls) {
-  const discovered = [...new Set(discoveredUrls)];
+export function planQueueSync(discoveredUrls, projectUrls, skipUrls = new Set()) {
+  const unique = [...new Set(discoveredUrls)];
+  const skipped = unique.filter((url) => skipUrls.has(url));
+  const discovered = unique.filter((url) => !skipUrls.has(url));
   const missing = discovered.filter((url) => !projectUrls.has(url));
   return {
     discovered,
     missing,
     unchanged: discovered.length - missing.length,
+    skipped: skipped.length,
   };
 }
 
 export function planStatusReconciliation(
   payload,
-  { closedUrls = new Set(), openUrls = new Set(), doneValue = DEFAULT_DONE_VALUE } = {},
+  { closedUrls = new Set(), openUrls = new Set(), doneValue = DEFAULT_DONE_VALUE, skipUrls = new Set() } = {},
 ) {
   const toDone = [];
   const reopened = [];
 
   for (const item of normalizeProjectItems(payload)) {
+    if (skipUrls.has(item.url)) continue;
     const terminal = isTerminalStatus(item.status, doneValue);
     if (closedUrls.has(item.url) && !terminal) {
       toDone.push({ itemId: item.itemId, url: item.url, status: item.status });
@@ -279,11 +343,17 @@ export function syncPriorityQueue(
   if (!projectId) throw new Error('Project lookup failed: no project id returned');
 
   const openResult = runGh(run, buildIssueSearchArgs(options.author, options.limit, 'open'));
-  const discoveredUrls = extractIssueUrls(parseJson(openResult, 'Issue discovery failed'));
+  const openRecords = extractIssueRecords(parseJson(openResult, 'Issue discovery failed'));
+  const discoveredUrls = [...new Set(openRecords.map((record) => record.url))];
   const closedResult = runGh(run, buildIssueSearchArgs(options.author, options.limit, 'closed'));
-  const closedUrls = new Set(
-    extractIssueUrls(parseJson(closedResult, 'Closed issue discovery failed')),
-  );
+  const closedRecords = extractIssueRecords(parseJson(closedResult, 'Closed issue discovery failed'));
+  const closedUrls = new Set(closedRecords.map((record) => record.url));
+
+  const skipRepoLabels = parseSkipRepoLabels(options.skipRepoLabels ?? DEFAULT_SKIP_REPO_LABELS);
+  const skippedUrls = new Set([
+    ...extractSkippedUrls(openRecords, skipRepoLabels),
+    ...extractSkippedUrls(closedRecords, skipRepoLabels),
+  ]);
 
   const itemsResult = runGh(run, [
     'project',
@@ -299,11 +369,12 @@ export function syncPriorityQueue(
   const projectItems = parseJson(itemsResult, 'Project item lookup failed');
   const projectUrls = extractProjectUrls(projectItems);
   const audit = auditProjectItems(projectItems, { doneValue });
-  const plan = planQueueSync(discoveredUrls, projectUrls);
+  const plan = planQueueSync(discoveredUrls, projectUrls, skippedUrls);
   const reconciliation = planStatusReconciliation(projectItems, {
     closedUrls,
     openUrls: new Set(plan.discovered),
     doneValue,
+    skipUrls: skippedUrls,
   });
 
   let added = 0;
@@ -382,6 +453,7 @@ export function syncPriorityQueue(
     missing: plan.missing.length,
     added,
     unchanged: plan.unchanged,
+    skipped: plan.skipped,
     closedPending: reconciliation.toDone.length,
     reconciled,
     reopened: reconciliation.reopened.length,
@@ -391,7 +463,7 @@ export function syncPriorityQueue(
     blockedOrDeferredP0: audit.blockedOrDeferredP0.length,
   };
   write(
-    `Queue sync: mode=${summary.mode} discovered=${summary.discovered} missing=${summary.missing} added=${summary.added} unchanged=${summary.unchanged} closed_pending=${summary.closedPending} reconciled=${summary.reconciled} reopened=${summary.reopened} failed=${summary.failed} review_required=${summary.reviewRequired} missing_size=${summary.missingSize} blocked_or_deferred_p0=${summary.blockedOrDeferredP0}`,
+    `Queue sync: mode=${summary.mode} discovered=${summary.discovered} missing=${summary.missing} added=${summary.added} unchanged=${summary.unchanged} skipped=${summary.skipped} closed_pending=${summary.closedPending} reconciled=${summary.reconciled} reopened=${summary.reopened} failed=${summary.failed} review_required=${summary.reviewRequired} missing_size=${summary.missingSize} blocked_or_deferred_p0=${summary.blockedOrDeferredP0}`,
   );
   for (const item of reconciliation.toDone) {
     write(`Closed issue not ${doneValue} on board: ${item.url} (${item.status || 'no status'})`);

--- a/tooling/test/github-priority-queue.test.mjs
+++ b/tooling/test/github-priority-queue.test.mjs
@@ -4,9 +4,12 @@ import test from 'node:test';
 import {
   auditProjectItems,
   buildIssueSearchArgs,
+  extractIssueRecords,
+  extractSkippedUrls,
   isTerminalStatus,
   normalizeProjectItems,
   parseArgs,
+  parseSkipRepoLabels,
   planQueueSync,
   planStatusReconciliation,
   resolveStatusOption,
@@ -58,14 +61,22 @@ test('parseArgs accepts the status reconciliation flags and defaults them', () =
   assert.equal(defaults.statusField, 'Status');
   assert.equal(defaults.doneValue, 'Done');
   assert.equal(defaults.apply, false);
+  assert.deepEqual(defaults.skipRepoLabels, ['sarthakagrawal927/portfolio:issues']);
 
   const custom = parseArgs([
     '--owner', 'o', '--project', '3', '--author', 'a',
     '--status-field', 'State', '--done-value', 'Shipped', '--apply',
+    '--skip-repo-label', 'org/repo:do-not-queue',
+    '--skip-repo-label', 'org/other:skip',
   ]);
   assert.equal(custom.statusField, 'State');
   assert.equal(custom.doneValue, 'Shipped');
   assert.equal(custom.apply, true);
+  assert.deepEqual(custom.skipRepoLabels, [
+    'sarthakagrawal927/portfolio:issues',
+    'org/repo:do-not-queue',
+    'org/other:skip',
+  ]);
 
   assert.throws(() => parseArgs(['--owner', 'o', '--project', '3', '--author', 'a', '--nope', 'x']),
     /Unknown argument/);
@@ -73,7 +84,7 @@ test('parseArgs accepts the status reconciliation flags and defaults them', () =
 
 test('buildIssueSearchArgs searches one state at a time', () => {
   assert.deepEqual(buildIssueSearchArgs('a', 5, 'closed').join(' '),
-    'search issues --author a --state closed --limit 5 --json url');
+    'search issues --author a --state closed --limit 5 --json url,labels,repository');
   assert.equal(buildIssueSearchArgs('a').includes('open'), true);
   assert.throws(() => buildIssueSearchArgs('a', 5, 'all'), /Unsupported issue state/);
 });
@@ -252,4 +263,140 @@ test('a failed status edit is reported and sets a nonzero exit code', () => {
   assert.equal(result.summary.failed, 1);
   assert.equal(result.exitCode, 1);
   assert.match(lines.join('\n'), /Failed .*issues\/2: denied \[redacted\]/);
+});
+
+const PORTFOLIO_URL = 'https://github.com/sarthakagrawal927/portfolio/issues/28';
+
+test('parseSkipRepoLabels builds a repo-scoped label map and rejects bad entries', () => {
+  const map = parseSkipRepoLabels(['Owner/Repo:Issues', 'org/other:skip']);
+  assert.deepEqual([...map.get('owner/repo')], ['issues']);
+  assert.deepEqual([...map.get('org/other')], ['skip']);
+  assert.equal(map.size, 2);
+
+  assert.throws(() => parseSkipRepoLabels(['no-slash:label']), /Invalid --skip-repo-label/);
+  assert.throws(() => parseSkipRepoLabels(['org/repo:']), /Invalid --skip-repo-label/);
+  assert.throws(() => parseSkipRepoLabels(['just-a-string']), /Invalid --skip-repo-label/);
+});
+
+test('extractIssueRecords reads repo and labels from search rows', () => {
+  const [first, second] = extractIssueRecords([
+    { url: OPEN_URL, repository: { nameWithOwner: 'Owner/Repo' }, labels: [{ name: 'Issues' }] },
+    { url: CLOSED_URL },
+  ]);
+  assert.equal(first.url, OPEN_URL);
+  assert.equal(first.repo, 'owner/repo');
+  assert.deepEqual(first.labels, ['issues']);
+  assert.equal(second.repo, '');
+  assert.deepEqual(second.labels, []);
+});
+
+test('extractSkippedUrls matches repo and label case-insensitively', () => {
+  const records = [
+    { url: OPEN_URL, repo: 'owner/repo', labels: ['issues'] },
+    { url: PORTFOLIO_URL, repo: 'sarthakagrawal927/portfolio', labels: ['issues'] },
+    { url: MISSING_URL, repo: 'sarthakagrawal927/portfolio', labels: ['other'] },
+  ];
+  const skipped = extractSkippedUrls(records, parseSkipRepoLabels(['sarthakagrawal927/portfolio:issues']));
+  assert.deepEqual([...skipped], [PORTFOLIO_URL]);
+  assert.equal(extractSkippedUrls(records, new Map()).size, 0);
+});
+
+test('planQueueSync excludes skipped urls and reports the skipped count', () => {
+  const plan = planQueueSync(
+    [OPEN_URL, PORTFOLIO_URL, MISSING_URL],
+    new Set([OPEN_URL]),
+    new Set([PORTFOLIO_URL]),
+  );
+  assert.deepEqual(plan.discovered, [OPEN_URL, MISSING_URL]);
+  assert.deepEqual(plan.missing, [MISSING_URL]);
+  assert.equal(plan.unchanged, 1);
+  assert.equal(plan.skipped, 1);
+});
+
+test('planStatusReconciliation ignores skipped urls in both directions', () => {
+  const payload = {
+    items: [
+      { id: 'ITEM_done', status: 'Done', content: { url: PORTFOLIO_URL } },
+      { id: 'ITEM_closed', status: 'In Progress', content: { url: CLOSED_URL } },
+    ],
+  };
+  const plan = planStatusReconciliation(payload, {
+    closedUrls: new Set([PORTFOLIO_URL, CLOSED_URL]),
+    openUrls: new Set([PORTFOLIO_URL]),
+    skipUrls: new Set([PORTFOLIO_URL]),
+  });
+  assert.deepEqual(plan.toDone, [{ itemId: 'ITEM_closed', url: CLOSED_URL, status: 'In Progress' }]);
+  assert.deepEqual(plan.reopened, []);
+});
+
+function createSkipRunner() {
+  const calls = [];
+  const run = (command, args) => {
+    calls.push(args.join(' '));
+    const joined = args.join(' ');
+    if (joined.startsWith('api user')) return { status: 0, stdout: 'sarthak' };
+    if (joined.startsWith('project view')) return { status: 0, stdout: '{"id":"PVT_1"}' };
+    if (joined.includes('--state open')) {
+      return {
+        status: 0,
+        stdout: JSON.stringify([
+          { url: OPEN_URL, repository: { nameWithOwner: 'owner/repo' }, labels: [] },
+          {
+            url: PORTFOLIO_URL,
+            repository: { nameWithOwner: 'sarthakagrawal927/portfolio' },
+            labels: [{ name: 'issues' }],
+          },
+        ]),
+      };
+    }
+    if (joined.includes('--state closed')) {
+      return { status: 0, stdout: JSON.stringify([]) };
+    }
+    if (joined.startsWith('project item-list')) {
+      return { status: 0, stdout: JSON.stringify({ items: [] }) };
+    }
+    if (joined.startsWith('project field-list')) return { status: 0, stdout: JSON.stringify(FIELDS) };
+    if (joined.startsWith('project item-add')) return { status: 0, stdout: '{}' };
+    if (joined.startsWith('project item-edit')) return { status: 0, stdout: '{}' };
+    return { status: 1, stdout: '', stderr: `unexpected: ${joined}` };
+  };
+  return { calls, run };
+}
+
+test('apply skips repo-scoped label issues: never adds them and never flags drift', () => {
+  const { calls, run } = createSkipRunner();
+  const lines = [];
+  const result = syncPriorityQueue(
+    { ...OPTIONS, apply: true, skipRepoLabels: ['sarthakagrawal927/portfolio:issues'] },
+    { run, write: (l) => lines.push(l) },
+  );
+
+  assert.equal(result.summary.skipped, 1);
+  assert.equal(result.summary.discovered, 1);
+  assert.equal(result.summary.missing, 1);
+  assert.equal(result.summary.added, 1);
+  assert.equal(result.summary.reopened, 0);
+  assert.equal(result.summary.closedPending, 0);
+  assert.equal(result.exitCode, 0);
+  assert.equal(calls.some((call) => call.includes('portfolio/issues/28')), false);
+  assert.equal(
+    calls.filter((call) => call.startsWith('project item-add')).length,
+    1,
+  );
+  assert.match(lines.join('\n'), /skipped=1/);
+});
+
+test('dry run reports skipped portfolio notes without attempting to add them', () => {
+  const { calls, run } = createSkipRunner();
+  const lines = [];
+  const result = syncPriorityQueue(
+    { ...OPTIONS, apply: false },
+    { run, write: (l) => lines.push(l) },
+  );
+
+  assert.equal(result.summary.mode, 'dry-run');
+  assert.equal(result.summary.skipped, 1);
+  assert.equal(result.summary.missing, 1);
+  assert.equal(result.summary.added, 0);
+  assert.equal(calls.some((call) => call.startsWith('project item-add')), false);
 });


### PR DESCRIPTION
## Summary
- The four portfolio blog-note issues (`sarthakagrawal927/portfolio` #28/#29/#30/#33, label `issues`) stay open as live markers but were removed from the fleet priority board (GitHub Project 3) and must never be re-added or flagged as drift by the sync.
- Adds a generic, repeatable `--skip-repo-label owner/repo:label` CLI flag to `github-priority-queue.mjs`, defaulting to `sarthakagrawal927/portfolio:issues`. Matching issues are excluded from discovery, addition, and **both** reconciliation directions (`toDone` and `reopened`).
- Issue discovery now requests `labels` + `repository` so skip matching is repo-scoped and case-insensitive; the sync summary reports a new `skipped=` count.
- `syncPriorityQueue` applies the default skip set even when called with a bare options object, so the owner's intent holds regardless of entry point.

## Why
`github-priority-queue.mjs` re-adds any open issue authored by the owner. The portfolio notes are intentionally open (published live via issue-pages) but are not fleet work, so they should never appear on the board. A repo-scoped label rule keeps this generic and declarative rather than hardcoding issue numbers.

#### Test plan
- [x] `node --test test/github-priority-queue.test.mjs` — 21/21 pass (8 new skip-rule tests)
- [x] `node --test test/*.test.mjs` — 202/202 pass
- [x] `node scripts/validate-tooling.mjs` — 52 skills, 100 Node scripts, 45 shell scripts validated
- [x] `node scripts/audit.mjs --validate-only` — valid public manifest (30 sites)
- [ ] Live `--apply` sync run confirms `added=0` / `skipped=4` for the portfolio notes (run post-merge)

Generated with [Devin](https://devin.ai)