### PR TITLE
Scope deploy-guard CI evidence to literal job directories

### DIFF
--- a/tooling/scripts/fleet-deploy-guard.sh
+++ b/tooling/scripts/fleet-deploy-guard.sh
@@ -150,7 +150,7 @@ try {
   }
   let scripts = {};
   if (fs.existsSync('package.json')) scripts = JSON.parse(fs.readFileSync('package.json', 'utf8')).scripts || {};
-  function validates(command, allowScripts, seen = new Set()) {
+  function validates(command, allowScripts, seen = new Set(), pytestOnly = false) {
     // Reject quoting/comments rather than interpreting an echo containing a
     // convincing-looking command, interpolation, or a commented-out validator.
     if (/["'`#;|<>$\\]/.test(command) || /&/.test(command.replaceAll('&&', ''))) return false;
@@ -158,8 +158,9 @@ try {
     return command.split(/&&|\n/).some(raw => {
       const line = raw.trim();
       if (/(?:^|\s)(?:--help|--version|-h|-V)(?:\s|$)/.test(line)) return false;
-      if (/^(?:uv run )?(?:pytest(?:\s|$)|python(?:3)? -m pytest(?:\s|$))/.test(line) ||
-          /^(?:cargo|swift|go) test(?:\s|$)/.test(line) ||
+      if (/^(?:uv run )?(?:pytest(?:\s|$)|python(?:3)? -m pytest(?:\s|$))/.test(line)) return true;
+      if (pytestOnly) return false;
+      if (/^(?:cargo|swift|go) test(?:\s|$)/.test(line) ||
           /^node --test(?:\s|$)/.test(line) ||
           /^(?:vitest|jest)(?:\s|$)/.test(line) ||
           /^(?:astro|vite|next) build(?:\s|$)/.test(line)) return true;
@@ -178,7 +179,7 @@ try {
         /(?:^|\n)\s*(?:-\s*)?shell\s*:/.test(source)) return [];
     const lines = source.split(/\r?\n/);
     const headers = lines.flatMap((line, i) => /^jobs:\s*(?:#.*)?$/.test(line) ? [i] : []);
-    if (headers.length !== 1) return [];
+    if (headers.length !== 1 || lines.slice(0, headers[0]).some(line => /^defaults\s*:/.test(line))) return [];
     const jobs = [];
     const jobIds = new Set();
     let job;
@@ -197,7 +198,22 @@ try {
     const eligible = [];
     for (const body of jobs) {
       // A dependency can implicitly skip a job even without an explicit if.
-      if (body.some(line => /^    (?:if|continue-on-error|needs|strategy|uses|defaults)\s*:/.test(line))) continue;
+      if (body.some(line => /^    (?:if|continue-on-error|needs|strategy|uses)\s*:/.test(line))) continue;
+      // Only this literal defaults mapping is understood. Directory-scoped
+      // jobs can prove direct pytest, never scripts from the root package.json.
+      const defaults = body.flatMap((line, i) => /^    defaults\s*:/.test(line) ? [i] : []);
+      let jobDirectory = false;
+      if (defaults.length) {
+        if (defaults.length !== 1) continue;
+        const start = defaults[0];
+        let end = start + 1;
+        while (end < body.length && !/^    \S/.test(body[end])) end++;
+        const mapping = body.slice(start, end);
+        if (mapping.length !== 3 || !/^    defaults:\s*$/.test(mapping[0]) ||
+            !/^      run:\s*$/.test(mapping[1]) ||
+            !/^        working-directory:\s*[A-Za-z0-9_./-]+\s*$/.test(mapping[2])) continue;
+        jobDirectory = true;
+      }
       const starts = body.flatMap((line, i) => /^    steps:\s*(?:#.*)?$/.test(line) ? [i] : []);
       if (starts.length !== 1) continue;
       const steps = [];
@@ -210,8 +226,12 @@ try {
       }
       for (const block of steps) {
         if (block.some(line => /^(?:      - |        )(?:if|continue-on-error|uses)\s*:/.test(line))) continue;
+        const directories = block.filter(line => /^(?:      - |        )working-directory\s*:/.test(line));
+        if (directories.length > 1 || directories.some(line =>
+            !/^(?:      - |        )working-directory:\s*[A-Za-z0-9_./-]+\s*$/.test(line))) continue;
+        const directoryScoped = jobDirectory || directories.length === 1;
         const commands = runBlocks(block.join('\n'));
-        if (commands.length === 1) eligible.push(commands[0]);
+        if (commands.length === 1) eligible.push({ command: commands[0], directoryScoped });
       }
     }
     return eligible;
@@ -228,7 +248,8 @@ try {
       fail(`${file}: ${run.status || 'unknown'}/${run.conclusion || 'none'} (run ${run.id})`);
     }
     const source = fs.readFileSync(path.resolve(file), 'utf8');
-    if (unconditionalRunBlocks(source).some(block => validates(block, !/working-directory\s*:/.test(source)))) validationCount++;
+    if (unconditionalRunBlocks(source).some(block =>
+        validates(block.command, !block.directoryScoped, new Set(), block.directoryScoped))) validationCount++;
   }
   if (!validationCount) fail('unknown: no successful source-backed build/test push workflow');
   console.log(`green for ${sha.slice(0, 8)}: ${latest.size} push workflows, ${validationCount} build/test definitions`);

--- a/tooling/skills/fleet-deploy-guard/SKILL.md
+++ b/tooling/skills/fleet-deploy-guard/SKILL.md
@@ -61,6 +61,12 @@ conventional block mappings: `jobs` at column 0, literal job IDs at 2, job field
 at 4, step list items at 6 and step fields at 8. Dependency-gated jobs (`needs`),
 matrices, aliases/merge keys, quoted mapping keys, custom shells and unsupported
 layouts remain unknown. Directory-dependent package scripts remain unsupported.
+A conventional job `defaults.run.working-directory` containing one unquoted,
+literal path can qualify a direct `pytest`, `python -m pytest` or `uv run pytest`
+command. Its root package scripts are never inferred. Literal step directories
+use the same restriction. Directory scope stays within its job/step, so an
+unrelated Python job cannot disable root package-script evidence. Dynamic paths,
+unknown default mappings and workflow-level defaults remain unknown.
 Shell early exits, conditional programs, failure masking, pipelines, redirection,
 interpolation and opaque/reusable validation fail closed. This remains a narrow
 source-definition check, not a general YAML/shell interpreter or runtime test

--- a/tooling/test/fleet-deploy-guard.test.mjs
+++ b/tooling/test/fleet-deploy-guard.test.mjs
@@ -253,3 +253,56 @@ test('quoted control keys, custom shells and duplicate job ids remain unknown', 
   }
   rejected({ ciSource: ciSource + '  validate:\n    if: false\n    steps:\n      - run: pnpm quality\n' }, /no successful source-backed/);
 });
+
+
+const pythonDirectoryJob = `  python:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: python/ingest
+    steps:
+      - run: uv run pytest -q --cov=example --cov-fail-under=55
+`;
+
+test('unrelated job directory does not disable root package script evidence', () => {
+  const source = ciSource + pythonDirectoryJob.replace('uv run pytest -q --cov=example --cov-fail-under=55', 'echo setup');
+  const result = exercise({ ciSource: source });
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+});
+
+test('literal job directory admits direct pytest without interpreting package wrappers', () => {
+  const source = 'name: CI\non: [push]\njobs:\n' + pythonDirectoryJob;
+  const result = exercise({ ciSource: source });
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  for (const command of ['pnpm quality', 'node scripts/run-tests.mjs', 'cargo test', 'echo pytest']) {
+    rejected({ ciSource: source.replace('uv run pytest -q --cov=example --cov-fail-under=55', command) }, /no successful source-backed/);
+  }
+});
+
+test('unknown directories and default mappings cannot establish test evidence', () => {
+  const source = 'name: CI\non: [push]\njobs:\n' + pythonDirectoryJob;
+  for (const value of ['${{ matrix.path }}', '|', '{ path: python }', 'python/ingest\n        unknown: value', 'python/ingest\n        working-directory: other']) {
+    rejected({ ciSource: source.replace('python/ingest', value) }, /no successful source-backed/);
+  }
+  for (const directive of ['if: false', 'continue-on-error: true', 'needs: setup']) {
+    rejected({ ciSource: source.replace('    defaults:', `    ${directive}\n    defaults:`) }, /no successful source-backed/);
+  }
+  rejected({ ciSource: source.replace('        working-directory: python/ingest', '        shell: bash {0}') }, /no successful source-backed/);
+});
+
+test('step directory cannot borrow root package scripts or accept a dynamic path', () => {
+  rejected({ ciSource: ciSource.replace('- run: pnpm quality', '- run: pnpm quality\n        working-directory: python/ingest') }, /no successful source-backed/);
+  rejected({ ciSource: ciSource.replace('- run: pnpm quality', '- run: uv run pytest -q\n        working-directory: ${{ matrix.path }}') }, /no successful source-backed/);
+});
+
+
+test('an unrelated step directory does not disable a root package validator', () => {
+  const source = ciSource.replace('      - run: pnpm quality', '      - run: echo setup\n        working-directory: python/ingest\n      - run: pnpm quality');
+  const result = exercise({ ciSource: source });
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+});
+
+test('workflow defaults remain unknown rather than assuming root scripts', () => {
+  const source = ciSource.replace('jobs:', 'defaults:\n  run:\n    working-directory: python/ingest\njobs:');
+  rejected({ ciSource: source }, /no successful source-backed/);
+});


### PR DESCRIPTION
The deploy guard rejects a green workflow when an unrelated Python job declares a working directory: that directory disables root package-script recognition across the whole file. It also ignores an unconditional direct pytest job under a conventional directory default.

Scope directory eligibility to each job/step. Recognize only the literal `defaults.run.working-directory` mapping for direct pytest commands; never resolve a nonroot package script against the root package.json. Dynamic directories, workflow defaults, unknown mappings, conditional/error-tolerant jobs and shell masking remain unknown. Exact-head/all-push-run success rules are unchanged. This recognizes High Signal’s existing Python coverage job without interpreting its opaque Node or filtered pnpm wrappers.

Validation: three regression cases failed before the change; all 235 tooling tests now pass, including 33 deploy-guard tests. Tooling validator, public-manifest validation, Bash syntax and diff checks pass. Read-only extraction against High Signal’s actual CI selects its unconditional `uv run pytest ... --cov-fail-under=55` step. No provider operation or deployment ran. Main-checkout owner edits and catalog files remain untouched.

Refs #104.
