### PR TITLE
Fix deploy guard recognition of package-directory CI builds

### DIFF
--- a/tooling/scripts/fleet-deploy-guard.sh
+++ b/tooling/scripts/fleet-deploy-guard.sh
@@ -92,6 +92,7 @@ inspect_push_ci() {
   node - "$1" "$2" "$3" <<'NODE'
 const fs = require('node:fs');
 const path = require('node:path');
+const { execFileSync } = require('node:child_process');
 const [sha, runsInput, workflowsInput] = process.argv.slice(2);
 function fail(detail) { console.log(detail); process.exit(1); }
 try {
@@ -127,7 +128,7 @@ try {
   // This is deliberately a narrow source recognizer, not a YAML/shell interpreter.
   // Only literal run steps and simple unquoted commands qualify. Never execute
   // a workflow or package script to discover its meaning. Unknown wrappers,
-  // reusable actions and directory-dependent package scripts cannot prove CI.
+  // reusable actions and dynamic directories cannot prove CI.
   function runBlocks(source) {
     const lines = source.split(/\r?\n/);
     const blocks = [];
@@ -148,26 +149,38 @@ try {
     }
     return blocks;
   }
-  let scripts = {};
-  if (fs.existsSync('package.json')) scripts = JSON.parse(fs.readFileSync('package.json', 'utf8')).scripts || {};
-  function validates(command, allowScripts, seen = new Set(), pytestOnly = false) {
+  const checkout = fs.realpathSync(process.cwd());
+  function packageScripts(directory = '.') {
+    // Resolve only literal in-checkout manifests; never read a sibling project,
+    // a dynamic path or a manifest symlink escaping the checked source.
+    if (path.isAbsolute(directory) || directory.split('/').includes('..')) return {};
+    try {
+      const file = path.join(checkout, directory, 'package.json');
+      const real = fs.realpathSync(file);
+      if (!real.startsWith(checkout + path.sep) || !fs.lstatSync(file).isFile()) return {};
+      const relative = path.relative(checkout, file);
+      const source = execFileSync('git', ['show', `${sha}:${relative}`], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+      const scripts = JSON.parse(source).scripts;
+      return scripts && typeof scripts === 'object' && !Array.isArray(scripts) ? scripts : {};
+    } catch { return {}; }
+  }
+  function validates(command, scripts, seen = new Set(), pytestOnly = false) {
     // Reject quoting/comments rather than interpreting an echo containing a
     // convincing-looking command, interpolation, or a commented-out validator.
     if (/["'`#;|<>$\\]/.test(command) || /&/.test(command.replaceAll('&&', ''))) return false;
-    if (/[(){}]/.test(command) || /(?:^|&&|\n)\s*(?:if|then|else|elif|fi|for|while|until|do|done|case|esac|exit|return|exec|trap|set|source|eval|command|builtin|\.)(?:\s|$)/.test(command)) return false;
+    if (/[(){}]/.test(command) || /(?:^|&&|\n)\s*(?:if|then|else|elif|fi|for|while|until|do|done|case|esac|exit|return|exec|trap|set|source|eval|command|builtin|cd|pushd|popd|\.)(?:\s|$)/.test(command)) return false;
     return command.split(/&&|\n/).some(raw => {
       const line = raw.trim();
       if (/(?:^|\s)(?:--help|--version|-h|-V)(?:\s|$)/.test(line)) return false;
       if (/^(?:uv run )?(?:pytest(?:\s|$)|python(?:3)? -m pytest(?:\s|$))/.test(line)) return true;
-      if (pytestOnly) return false;
-      if (/^(?:cargo|swift|go) test(?:\s|$)/.test(line) ||
+      if (!pytestOnly && (/^(?:cargo|swift|go) test(?:\s|$)/.test(line) ||
           /^node --test(?:\s|$)/.test(line) ||
           /^(?:vitest|jest)(?:\s|$)/.test(line) ||
-          /^(?:astro|vite|next) build(?:\s|$)/.test(line)) return true;
+          /^(?:astro|vite|next) build(?:\s|$)/.test(line))) return true;
       const invocation = line.match(/^(?:pnpm|npm|yarn) (?:run )?([a-zA-Z0-9:_-]+)(?:\s|$)/);
-      if (!allowScripts || !invocation || seen.has(invocation[1])) return false;
+      if (!invocation || seen.has(invocation[1])) return false;
       const name = invocation[1];
-      return typeof scripts[name] === 'string' && validates(scripts[name], true, new Set([...seen, name]));
+      return typeof scripts[name] === 'string' && validates(scripts[name], scripts, new Set([...seen, name]));
     });
   }
   function unconditionalRunBlocks(source) {
@@ -200,9 +213,9 @@ try {
       // A dependency can implicitly skip a job even without an explicit if.
       if (body.some(line => /^    (?:if|continue-on-error|needs|strategy|uses)\s*:/.test(line))) continue;
       // Only this literal defaults mapping is understood. Directory-scoped
-      // jobs can prove direct pytest, never scripts from the root package.json.
+      // jobs resolve package scripts only from their own literal manifest.
       const defaults = body.flatMap((line, i) => /^    defaults\s*:/.test(line) ? [i] : []);
-      let jobDirectory = false;
+      let jobDirectory = null;
       if (defaults.length) {
         if (defaults.length !== 1) continue;
         const start = defaults[0];
@@ -212,7 +225,7 @@ try {
         if (mapping.length !== 3 || !/^    defaults:\s*$/.test(mapping[0]) ||
             !/^      run:\s*$/.test(mapping[1]) ||
             !/^        working-directory:\s*[A-Za-z0-9_./-]+\s*$/.test(mapping[2])) continue;
-        jobDirectory = true;
+        jobDirectory = mapping[2].split(':').slice(1).join(':').trim();
       }
       const starts = body.flatMap((line, i) => /^    steps:\s*(?:#.*)?$/.test(line) ? [i] : []);
       if (starts.length !== 1) continue;
@@ -229,9 +242,10 @@ try {
         const directories = block.filter(line => /^(?:      - |        )working-directory\s*:/.test(line));
         if (directories.length > 1 || directories.some(line =>
             !/^(?:      - |        )working-directory:\s*[A-Za-z0-9_./-]+\s*$/.test(line))) continue;
-        const directoryScoped = jobDirectory || directories.length === 1;
+        const directory = directories.length ? directories[0].split(':').slice(1).join(':').trim() : jobDirectory;
+        if (directory && (path.isAbsolute(directory) || directory.split('/').includes('..'))) continue;
         const commands = runBlocks(block.join('\n'));
-        if (commands.length === 1) eligible.push({ command: commands[0], directoryScoped });
+        if (commands.length === 1) eligible.push({ command: commands[0], directory });
       }
     }
     return eligible;
@@ -249,7 +263,7 @@ try {
     }
     const source = fs.readFileSync(path.resolve(file), 'utf8');
     if (unconditionalRunBlocks(source).some(block =>
-        validates(block.command, !block.directoryScoped, new Set(), block.directoryScoped))) validationCount++;
+        validates(block.command, packageScripts(block.directory ?? '.'), new Set(), block.directory !== null))) validationCount++;
   }
   if (!validationCount) fail('unknown: no successful source-backed build/test push workflow');
   console.log(`green for ${sha.slice(0, 8)}: ${latest.size} push workflows, ${validationCount} build/test definitions`);

--- a/tooling/skills/fleet-deploy-guard/SKILL.md
+++ b/tooling/skills/fleet-deploy-guard/SKILL.md
@@ -41,14 +41,14 @@ in the handoff).
 
 The gate reads all pages of GitHub run and workflow metadata, matches workflow
 IDs to their checked-in paths, and inspects literal `run` steps without
-executing them. Simple package-script calls are resolved from the owning root
-`package.json`; direct test/build commands are recognized independently of
+executing them. Simple package-script calls are resolved from the owning
+`package.json` at the exact checked Git revision; direct test/build commands are recognized independently of
 workflow display names. Node.js is required for this read-only inspection.
 
 Pending, failed, cancelled, skipped, missing/disabled, non-exact or malformed
 workflow evidence fails closed. The recognizer intentionally does not interpret
-arbitrary YAML/shell, quoted commands, reusable actions, or package scripts with
-workflow working-directory overrides. Unrecognized source is **unknown**, not
+arbitrary YAML/shell, quoted commands, reusable actions, or dynamic
+working-directory overrides. Unrecognized source is **unknown**, not
 green. This is a workflow-completion/source-definition gate, not proof that
 every conditionally skipped step actually executed. Review product-specific
 acceptance separately. The existing explicitly approved `--force` exception is
@@ -60,11 +60,14 @@ or beside an optional step may qualify. The source recognizer accepts only
 conventional block mappings: `jobs` at column 0, literal job IDs at 2, job fields
 at 4, step list items at 6 and step fields at 8. Dependency-gated jobs (`needs`),
 matrices, aliases/merge keys, quoted mapping keys, custom shells and unsupported
-layouts remain unknown. Directory-dependent package scripts remain unsupported.
-A conventional job `defaults.run.working-directory` containing one unquoted,
-literal path can qualify a direct `pytest`, `python -m pytest` or `uv run pytest`
-command. Its root package scripts are never inferred. Literal step directories
-use the same restriction. Directory scope stays within its job/step, so an
+layouts remain unknown. A conventional job `defaults.run.working-directory`
+containing one unquoted literal path can qualify direct `pytest`, `python -m
+pytest` or `uv run pytest`, or a simple package-script call resolved from that
+directory's tracked manifest. A literal step directory overrides its job default;
+neither can borrow scripts from a different package. Absolute paths, parent
+traversal, ignored manifests and symlinks escaping the checkout are rejected.
+Directory-changing shell commands are not interpreted. Directory scope stays
+within its job/step, so an
 unrelated Python job cannot disable root package-script evidence. Dynamic paths,
 unknown default mappings and workflow-level defaults remain unknown.
 Shell early exits, conditional programs, failure masking, pipelines, redirection,

--- a/tooling/test/fleet-deploy-guard.test.mjs
+++ b/tooling/test/fleet-deploy-guard.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import test from 'node:test';
@@ -25,8 +25,19 @@ export function exercise(options = {}) {
   try {
     writeFileSync(join(project, 'wrangler.json'), '{"name":"synthetic-target"}');
     writeFileSync(join(project, 'package.json'), JSON.stringify({ scripts: options.scripts || { quality: 'pnpm test', test: 'vitest run' } }));
+    for (const [directory, scripts] of Object.entries(options.packages || {})) {
+      mkdirSync(join(project, directory), { recursive: true });
+      writeFileSync(join(project, directory, 'package.json'), JSON.stringify({ scripts }));
+    }
+    if (options.externalPackage) {
+      const external = join(root, 'outside');
+      mkdirSync(external);
+      writeFileSync(join(external, 'package.json'), JSON.stringify({ scripts: { build: 'astro build' } }));
+      symlinkSync(external, join(project, 'website'));
+    }
     writeFileSync(join(project, ci.path), options.ciSource ?? ciSource);
     writeFileSync(join(project, docs.path), docsSource);
+    if (options.ignoredPackage) writeFileSync(join(project, '.gitignore'), 'website/package.json\n');
     git('init', '-b', 'main');
     git('add', '.');
     git('-c', 'user.name=Fixture', '-c', 'user.email=fixture@example.invalid', 'commit', '-m', 'synthetic fixture');
@@ -305,4 +316,47 @@ test('an unrelated step directory does not disable a root package validator', ()
 test('workflow defaults remain unknown rather than assuming root scripts', () => {
   const source = ciSource.replace('jobs:', 'defaults:\n  run:\n    working-directory: python/ingest\njobs:');
   rejected({ ciSource: source }, /no successful source-backed/);
+});
+
+
+const websiteDirectorySource = 'name: CI\non: [push]\njobs:\n' + pythonDirectoryJob
+  .replace('python/ingest', 'website')
+  .replace('uv run pytest -q --cov=example --cov-fail-under=55', 'pnpm run build');
+
+test('literal job package scripts resolve against that package, including required build chains', () => {
+  const result = exercise({ ciSource: websiteDirectorySource,
+    scripts: { build: 'echo root is not evidence' },
+    packages: { website: { build: 'pnpm run docs && astro build', docs: 'node merge-docs.mjs' } } });
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+});
+
+test('literal step directory overrides job directory without borrowing another manifest', () => {
+  const source = websiteDirectorySource.replace('      - run: pnpm run build', '      - run: pnpm run build\n        working-directory: packages/site');
+  const result = exercise({ ciSource: source, packages: {
+    website: { build: 'echo no validation' }, 'packages/site': { build: 'vite build' },
+  } });
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  rejected({ ciSource: source, packages: { website: { build: 'astro build' } } }, /no successful source-backed/);
+});
+
+test('scoped manifests cannot prove commands from root, another directory or an unsafe wrapper', () => {
+  for (const build of ['echo astro build', 'astro build || true', 'pnpm run build', 'cd ../other && astro build']) {
+    rejected({ ciSource: websiteDirectorySource, scripts: { build: 'astro build' },
+      packages: { website: { build } } }, /no successful source-backed/);
+  }
+  rejected({ ciSource: websiteDirectorySource, scripts: { build: 'astro build' } }, /no successful source-backed/);
+});
+
+test('absolute, parent and external symlink package paths stay unknown', () => {
+  for (const directory of ['/tmp/website', '../outside', 'website/../website']) {
+    rejected({ ciSource: websiteDirectorySource.replace('working-directory: website', `working-directory: ${directory}`),
+      packages: { website: { build: 'astro build' } } }, /no successful source-backed/);
+  }
+  rejected({ ciSource: websiteDirectorySource, externalPackage: true }, /no successful source-backed/);
+});
+
+
+test('ignored package manifests cannot supply exact-source build evidence', () => {
+  rejected({ ciSource: websiteDirectorySource, ignoredPackage: true,
+    packages: { website: { build: 'astro build' } } }, /no successful source-backed/);
 });


### PR DESCRIPTION
The deploy guard rejected successful CI when a build ran from a literal package directory, blocking the checked Pace website release. Resolve simple package-script calls from that directory’s tracked package.json at the exact checked revision, with step directories taking precedence over job defaults.

Keep dynamic directories, traversal, escaping symlinks, ignored manifests, opaque shell wrappers and failure masking unqualified. No deploy bypass is added.

Validation: 38 focused guard tests and all 240 tooling tests pass; tooling validator and shell syntax pass. Independent review found no blocking issue.
