### PR TITLE
Refresh four public retained-history dates

### DIFF
--- a/catalog/generated/public.json
+++ b/catalog/generated/public.json
@@ -45,7 +45,7 @@
       "changelogUrl": "https://codevetter.com/changelog",
       "roadmapUrl": "https://github.com/Codevetter/codevetter/issues",
       "firstCommitAt": "2025-11-30",
-      "latestCommitAt": "2026-09-07"
+      "latestCommitAt": "2026-09-09"
     },
     {
       "id": "posttrainllm",
@@ -128,7 +128,7 @@
       "changelogUrl": "https://live.significanthobbies.com/changelog",
       "roadmapUrl": "https://github.com/Significant-Hobbies/live/issues",
       "firstCommitAt": "2026-03-01",
-      "latestCommitAt": "2026-09-07"
+      "latestCommitAt": "2026-09-09"
     },
     {
       "id": "saas-maker",
@@ -171,7 +171,7 @@
       "changelogUrl": "https://sassmaker.com/changelog",
       "roadmapUrl": "https://github.com/sass-maker/saas-maker/issues",
       "firstCommitAt": "2026-02-26",
-      "latestCommitAt": "2026-09-07"
+      "latestCommitAt": "2026-09-09"
     },
     {
       "id": "gitstat",
@@ -583,7 +583,7 @@
       "changelogUrl": "https://learn.significanthobbies.com/changelog",
       "roadmapUrl": "https://github.com/Significant-Hobbies/swe-interview-prep/issues",
       "firstCommitAt": "2026-02-08",
-      "latestCommitAt": "2026-09-07"
+      "latestCommitAt": "2026-09-08"
     },
     {
       "id": "rolepatch",


### PR DESCRIPTION
Four public directory entries still displayed older retained-Git dates after their owning repositories advanced. Regenerate the checked-in projection from Site Health `208ff071`: CodeVetter, Live and SaaS Maker now show 2026-09-09; SWE Interview Prep shows 2026-09-08.

Only four `directory[].latestCommitAt` values change. Lifecycle, shareability, membership and all other public fields are identical. The canonical advisory is now 56/57 matches, retaining excluded Nomad as unavailable.

Validation: canonical projection equality, public-field validation and documentation checks passed; 12 focused public-products/directory/public-surface tests passed; the showcase built all 33 pages. Prepared in an isolated checkout with the frozen offline dependency cache; owner worktree changes are untouched. No deployment.
